### PR TITLE
Add Wildfly demo app

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -38,6 +38,11 @@ function runDemoApps() {
         --name quarkus-test \
         --pod cryostat \
         --rm -d quay.io/andrewazores/quarkus-test:0.0.2
+
+    podman run \
+        --name wildfly \
+        --pod cryostat \
+        --rm -d quay.io/andrewazores/wildfly-demo:v0.0.1
 }
 
 function runJfrDatasource() {


### PR DESCRIPTION
This simply adds a Wildfly server as an additional demo app in the smoketest environment. It is configured with credentials (see upstream at https://github.com/andrewazores/wildfly-demo), but is not discoverable (not JDP enabled, see #468) and currently any connection attempts will fail due to #469 anyway.