### PR TITLE
Implement user-specified target definitions

### DIFF
--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -37,6 +37,8 @@
  */
 package io.cryostat;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -75,6 +77,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
         })
 public abstract class MainModule {
     public static final String RECORDINGS_PATH = "RECORDINGS_PATH";
+    public static final String CONF_DIR = "CONF_DIR";
 
     @Provides
     @Singleton
@@ -118,8 +121,21 @@ public abstract class MainModule {
     @Singleton
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath(Logger logger, Environment env) {
-        String ARCHIVE_PATH = env.getEnv("CRYOSTAT_ARCHIVE_PATH", "/flightrecordings");
-        logger.info("Local save path for flight recordings set as {}", ARCHIVE_PATH);
-        return Paths.get(ARCHIVE_PATH);
+        String archivePath = env.getEnv("CRYOSTAT_ARCHIVE_PATH", "/flightrecordings");
+        logger.info("Local save path for flight recordings set as {}", archivePath);
+        return Paths.get(archivePath);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CONF_DIR)
+    static Path provideConfigurationPath(Environment env) {
+        Path path = Paths.get(env.getEnv(CONF_DIR)).resolve("conf");
+        try {
+            Files.createDirectory(path);
+            return path;
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
@@ -62,8 +62,12 @@ public class ApiException extends HttpStatusException {
         this(statusCode, null, reason, null);
     }
 
+    ApiException(int statusCode, Throwable cause) {
+        this(statusCode, null, cause.getMessage(), cause);
+    }
+
     ApiException(int statusCode) {
-        this(statusCode, null);
+        this(statusCode, (String) null);
     }
 
     public String getApiStatus() {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
@@ -51,18 +51,22 @@ class RequestParameters {
     private final Map<String, String> pathParams;
     private final MultiMap queryParams;
     private final MultiMap headers;
+    private final MultiMap formAttributes;
     private final Set<FileUpload> fileUploads;
 
     RequestParameters(
             Map<String, String> pathParams,
             MultiMap queryParams,
             MultiMap headers,
+            MultiMap formAttributes,
             Set<FileUpload> fileUploads) {
         this.pathParams = new HashMap<>(pathParams);
         this.queryParams = MultiMap.caseInsensitiveMultiMap();
         this.queryParams.addAll(queryParams);
         this.headers = MultiMap.caseInsensitiveMultiMap();
         this.headers.addAll(headers);
+        this.formAttributes = MultiMap.caseInsensitiveMultiMap();
+        this.formAttributes.addAll(formAttributes);
         this.fileUploads = new HashSet<>(fileUploads);
     }
 
@@ -82,12 +86,17 @@ class RequestParameters {
             headers.addAll(ctx.request().headers());
         }
 
+        MultiMap formAttributes = MultiMap.caseInsensitiveMultiMap();
+        if (ctx != null && ctx.request() != null && ctx.request().formAttributes() != null) {
+            formAttributes.addAll(ctx.request().formAttributes());
+        }
+
         Set<FileUpload> fileUploads = new HashSet<>();
         if (ctx != null && ctx.fileUploads() != null) {
             fileUploads.addAll(ctx.fileUploads());
         }
 
-        return new RequestParameters(pathParams, queryParams, headers, fileUploads);
+        return new RequestParameters(pathParams, queryParams, headers, formAttributes, fileUploads);
     }
 
     Map<String, String> getPathParams() {
@@ -100,6 +109,10 @@ class RequestParameters {
 
     MultiMap getHeaders() {
         return this.headers;
+    }
+
+    MultiMap getFormAttributes() {
+        return this.formAttributes;
     }
 
     Set<FileUpload> getFileUploads() {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import javax.inject.Inject;
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.platform.internal.CustomTargetPlatformClient;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
+
+class TargetDeleteHandler extends AbstractV2RequestHandler<Void> {
+
+    private final CustomTargetPlatformClient customTargetPlatformClient;
+
+    @Inject
+    TargetDeleteHandler(
+            AuthManager auth, Gson gson, CustomTargetPlatformClient customTargetPlatformClient) {
+        super(auth, gson);
+        this.customTargetPlatformClient = customTargetPlatformClient;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.DELETE;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + "targets/:targetId";
+    }
+
+    @Override
+    public HttpMimeType mimeType() {
+        return HttpMimeType.JSON;
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
+    public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
+        try {
+            String targetId = params.getPathParams().get("targetId");
+            if (StringUtils.isBlank(targetId)) {
+                throw new ApiException(400, "Invalid targetId");
+            }
+            JMXServiceURL serviceUrl = new JMXServiceURL(targetId);
+            if (!customTargetPlatformClient.removeTarget(serviceUrl)) {
+                throw new ApiException(404);
+            }
+            return new IntermediateResponse<Void>().body(null);
+        } catch (MalformedURLException mue) {
+            throw new ApiException(400, "Invalid targetId", mue);
+        } catch (IOException ioe) {
+            throw new ApiException(500, "Internal Error", ioe);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
@@ -37,73 +37,47 @@
  */
 package io.cryostat.net.web.http.api.v2;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.function.Function;
+import javax.inject.Inject;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
+import io.cryostat.net.web.http.api.ApiVersion;
 
-import io.cryostat.net.security.CertificateValidator;
-import io.cryostat.net.web.http.RequestHandler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.Provides;
-import dagger.multibindings.IntoSet;
+class TargetsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
 
-@Module
-public abstract class HttpApiV2Module {
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetsPostHandler(TargetsPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetsPostBodyHandler(TargetsPostBodyHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetDeleteHandler(TargetDeleteHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetSnapshotPostHandler(TargetSnapshotPostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostHandler(CertificatePostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetRecordingOptionsListGetHandler(
-            TargetRecordingOptionsListGetHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetEventsSearchGetHandler(TargetEventsSearchGetHandler handler);
-
-    @Provides
-    @Singleton
-    @Named("OutputStreamFunction")
-    static Function<File, FileOutputStream> provideOutputStreamFunction() throws RuntimeException {
-        return (File file) -> {
-            try {
-                return new FileOutputStream(file);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
+    @Inject
+    TargetsPostBodyHandler(AuthManager auth) {
+        super(auth);
     }
 
-    @Provides
-    static CertificateValidator provideCertificateValidator() {
-        return new CertificateValidator();
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
     }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCertificatePostBodyHandler(CertificatePostBodyHandler handler);
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + TargetsPostHandler.PATH;
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        BODY_HANDLER.handle(ctx);
+    }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.internal.CustomTargetPlatformClient;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
+
+class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
+
+    static final String PATH = "targets";
+
+    private final PlatformClient platformClient;
+    private final CustomTargetPlatformClient customTargetPlatformClient;
+
+    @Inject
+    TargetsPostHandler(
+            AuthManager auth,
+            Gson gson,
+            PlatformClient platformClient,
+            CustomTargetPlatformClient customTargetPlatformClient) {
+        super(auth, gson);
+        this.platformClient = platformClient;
+        this.customTargetPlatformClient = customTargetPlatformClient;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + PATH;
+    }
+
+    @Override
+    public HttpMimeType mimeType() {
+        return HttpMimeType.JSON;
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
+    public IntermediateResponse<ServiceRef> handle(RequestParameters params) throws ApiException {
+        try {
+            MultiMap attrs = params.getFormAttributes();
+            String connectUrl = attrs.get("connectUrl");
+            if (StringUtils.isBlank(connectUrl)) {
+                throw new ApiException(400, "\"connectUrl\" form parameter must be provided");
+            }
+            JMXServiceURL jmxServiceURL = new JMXServiceURL(connectUrl);
+            if (platformClient.listDiscoverableServices().stream()
+                    .anyMatch(sr -> Objects.equals(jmxServiceURL, sr.getJMXServiceUrl()))) {
+                throw new ApiException(400, "Duplicate connectUrl");
+            }
+            ServiceRef serviceRef = new ServiceRef(jmxServiceURL, attrs.get("alias"));
+            boolean v = customTargetPlatformClient.addTarget(serviceRef);
+            if (!v) {
+                throw new ApiException(400, "Duplicate connectUrl");
+            }
+            return new IntermediateResponse<ServiceRef>().body(serviceRef);
+        } catch (MalformedURLException mue) {
+            throw new ApiException(400, "Invalid connectUrl", mue);
+        } catch (IOException ioe) {
+            throw new ApiException(500, "Internal Error", ioe);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -117,12 +117,16 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             if (StringUtils.isBlank(connectUrl)) {
                 throw new ApiException(400, "\"connectUrl\" form parameter must be provided");
             }
+            String alias = attrs.get("alias");
+            if (StringUtils.isBlank(alias)) {
+                throw new ApiException(400, "\"alias\" form parameter must be provided");
+            }
             JMXServiceURL jmxServiceURL = new JMXServiceURL(connectUrl);
             if (platformClient.listDiscoverableServices().stream()
                     .anyMatch(sr -> Objects.equals(jmxServiceURL, sr.getJMXServiceUrl()))) {
                 throw new ApiException(400, "Duplicate connectUrl");
             }
-            ServiceRef serviceRef = new ServiceRef(jmxServiceURL, attrs.get("alias"));
+            ServiceRef serviceRef = new ServiceRef(jmxServiceURL, alias);
             boolean v = customTargetPlatformClient.addTarget(serviceRef);
             if (!v) {
                 throw new ApiException(400, "Duplicate connectUrl");

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.platform.internal;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.inject.Named;
+import javax.management.remote.JMXServiceURL;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.platform.ServiceRef;
+
+public class CustomTargetPlatformClient extends AbstractPlatformClient {
+
+    static final String SAVEFILE_NAME = "custom_targets.json";
+
+    private final SortedSet<ServiceRef> targets;
+    private final Path saveFile;
+    private final FileSystem fs;
+    private final Gson gson;
+
+    public CustomTargetPlatformClient(
+            NotificationFactory notificationFactory,
+            @Named(MainModule.CONF_DIR) Path confDir,
+            FileSystem fs,
+            Gson gson) {
+        super(notificationFactory);
+        this.targets =
+                new TreeSet<>(
+                        (u1, u2) ->
+                                u1.getJMXServiceUrl()
+                                        .toString()
+                                        .compareTo(u2.getJMXServiceUrl().toString()));
+        this.saveFile = confDir.resolve(SAVEFILE_NAME);
+        this.fs = fs;
+        this.gson = gson;
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (fs.isRegularFile(saveFile) && fs.isReadable(saveFile)) {
+            try (Reader reader = fs.readFile(saveFile)) {
+                this.targets.addAll(
+                        gson.fromJson(reader, new TypeToken<List<ServiceRef>>() {}.getType()));
+            }
+        }
+    }
+
+    public boolean addTarget(ServiceRef serviceRef) throws IOException {
+        boolean v = targets.add(serviceRef);
+        if (v) {
+            fs.writeString(
+                    saveFile,
+                    gson.toJson(targets),
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.CREATE);
+            notifyAsyncTargetDiscovery(EventKind.FOUND, serviceRef);
+        }
+        return v;
+    }
+
+    public boolean removeTarget(ServiceRef serviceRef) throws IOException {
+        boolean v = targets.remove(serviceRef);
+        if (v) {
+            fs.writeString(
+                    saveFile,
+                    gson.toJson(targets),
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.CREATE);
+            notifyAsyncTargetDiscovery(EventKind.LOST, serviceRef);
+        }
+        return v;
+    }
+
+    public boolean removeTarget(JMXServiceURL connectUrl) throws IOException {
+        ServiceRef ref = null;
+        for (ServiceRef target : targets) {
+            if (Objects.equals(connectUrl, target.getJMXServiceUrl())) {
+                ref = target;
+                break;
+            }
+        }
+        if (ref != null) {
+            return removeTarget(ref);
+        }
+        return false;
+    }
+
+    @Override
+    public List<ServiceRef> listDiscoverableServices() {
+        return new ArrayList<>(targets);
+    }
+}

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -50,14 +50,14 @@ import java.util.TreeSet;
 import javax.inject.Named;
 import javax.management.remote.JMXServiceURL;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-
 import io.cryostat.MainModule;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.ServiceRef;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 public class CustomTargetPlatformClient extends AbstractPlatformClient {
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandlerTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.platform.internal.CustomTargetPlatformClient;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetDeleteHandlerTest {
+
+    TargetDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock CustomTargetPlatformClient customTargetPlatformClient;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetDeleteHandler(auth, gson, customTargetPlatformClient);
+    }
+
+    @Test
+    void shouldRequireAuthentication() {
+        Assertions.assertTrue(handler.requiresAuthentication());
+    }
+
+    @Test
+    void shouldBeV2API() {
+        MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+    }
+
+    @Test
+    void shouldHaveDELETEMethod() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+    }
+
+    @Test
+    void shouldHaveTargetsPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/targets/:targetId"));
+    }
+
+    @Test
+    void shouldHaveJsonMimeType() {
+        MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @Test
+    void shouldBeOrdered() {
+        Assertions.assertTrue(handler.isOrdered());
+    }
+
+    @Test
+    void testSuccessfulRequest() throws IOException {
+        Map<String, String> pathParams = new HashMap<>();
+        RequestParameters requestParameters = Mockito.mock(RequestParameters.class);
+        Mockito.when(requestParameters.getPathParams()).thenReturn(pathParams);
+        Mockito.when(customTargetPlatformClient.removeTarget(Mockito.any(JMXServiceURL.class)))
+                .thenReturn(true);
+
+        String targetId = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        pathParams.put("targetId", targetId);
+
+        IntermediateResponse<Void> response = handler.handle(requestParameters);
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+        ArgumentCaptor<JMXServiceURL> urlCaptor = ArgumentCaptor.forClass(JMXServiceURL.class);
+        Mockito.verify(customTargetPlatformClient).removeTarget(urlCaptor.capture());
+        JMXServiceURL captured = urlCaptor.getValue();
+        MatcherAssert.assertThat(captured, Matchers.equalTo(new JMXServiceURL(targetId)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"badUrl", "bad:123", "http://example.com/foo"})
+    void testRequestWithBadTarget(String targetId) throws IOException {
+        Map<String, String> pathParams = new HashMap<>();
+        pathParams.put("targetId", targetId);
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getPathParams()).thenReturn(pathParams);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
+    @Test
+    void testRequestWithNonexistentTarget() throws IOException {
+        Map<String, String> pathParams = new HashMap<>();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getPathParams()).thenReturn(pathParams);
+        String targetId = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        pathParams.put("targetId", targetId);
+        Mockito.when(customTargetPlatformClient.removeTarget(Mockito.any(JMXServiceURL.class)))
+                .thenReturn(false);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+    }
+
+    @Test
+    void testRequestWithIOException() throws IOException {
+        Map<String, String> pathParams = new HashMap<>();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getPathParams()).thenReturn(pathParams);
+        String targetId = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+
+        pathParams.put("targetId", targetId);
+
+        Mockito.when(customTargetPlatformClient.removeTarget(Mockito.any(JMXServiceURL.class)))
+                .thenThrow(IOException.class);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetEventsSearchGetHandlerTest.java
@@ -114,6 +114,7 @@ class TargetEventsSearchGetHandlerTest {
                         Map.of("targetId", "foo:9091", "query", "foo"),
                         MultiMap.caseInsensitiveMultiMap(),
                         MultiMap.caseInsensitiveMultiMap(),
+                        MultiMap.caseInsensitiveMultiMap(),
                         Set.of());
 
         IntermediateResponse<List<SerializableEventTypeInfo>> result = handler.handle(params);
@@ -178,6 +179,7 @@ class TargetEventsSearchGetHandlerTest {
         RequestParameters params =
                 new RequestParameters(
                         Map.of("targetId", "foo:9091", "query", "foo"),
+                        MultiMap.caseInsensitiveMultiMap(),
                         MultiMap.caseInsensitiveMultiMap(),
                         MultiMap.caseInsensitiveMultiMap(),
                         Set.of());

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -158,6 +158,20 @@ class TargetsPostHandlerTest {
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void testRequestWithBadAlias(String alias) throws IOException {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", alias);
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
     @Test
     void testRequestWithDuplicateTarget() throws IOException {
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
@@ -166,6 +180,7 @@ class TargetsPostHandlerTest {
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
 
         attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", "TestTarget");
 
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(false);
 
@@ -181,6 +196,7 @@ class TargetsPostHandlerTest {
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
 
         attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", "TestTarget");
 
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any()))
                 .thenThrow(IOException.class);

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.internal.CustomTargetPlatformClient;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetsPostHandlerTest {
+
+    TargetsPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock PlatformClient platformClient;
+    @Mock CustomTargetPlatformClient customTargetPlatformClient;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new TargetsPostHandler(auth, gson, platformClient, customTargetPlatformClient);
+    }
+
+    @Test
+    void shouldRequireAuthentication() {
+        Assertions.assertTrue(handler.requiresAuthentication());
+    }
+
+    @Test
+    void shouldBeV2API() {
+        MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+    }
+
+    @Test
+    void shouldHavePOSTMethod() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHaveTargetsPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/targets"));
+    }
+
+    @Test
+    void shouldHaveJsonMimeType() {
+        MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+    }
+
+    @Test
+    void shouldNotBeAsync() {
+        Assertions.assertFalse(handler.isAsync());
+    }
+
+    @Test
+    void shouldBeOrdered() {
+        Assertions.assertTrue(handler.isOrdered());
+    }
+
+    @Test
+    void testSuccessfulRequest() throws IOException {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters requestParameters = Mockito.mock(RequestParameters.class);
+        Mockito.when(requestParameters.getFormAttributes()).thenReturn(attrs);
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
+        Mockito.when(platformClient.listDiscoverableServices()).thenReturn(List.of());
+
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        String alias = "TestTarget";
+        attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", alias);
+
+        IntermediateResponse<ServiceRef> response = handler.handle(requestParameters);
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+        ArgumentCaptor<ServiceRef> refCaptor = ArgumentCaptor.forClass(ServiceRef.class);
+        Mockito.verify(customTargetPlatformClient).addTarget(refCaptor.capture());
+        ServiceRef captured = refCaptor.getValue();
+        MatcherAssert.assertThat(
+                captured.getJMXServiceUrl(), Matchers.equalTo(new JMXServiceURL(connectUrl)));
+        MatcherAssert.assertThat(captured.getAlias(), Matchers.equalTo(Optional.of(alias)));
+        MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(captured));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"badUrl", "bad:123", "http://example.com/foo"})
+    void testRequestWithBadTarget(String connectUrl) throws IOException {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+
+        attrs.set("connectUrl", connectUrl);
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
+    @Test
+    void testRequestWithDuplicateTarget() throws IOException {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+
+        attrs.set("connectUrl", connectUrl);
+
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(false);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+    }
+
+    @Test
+    void testRequestWithIOException() throws IOException {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+
+        attrs.set("connectUrl", connectUrl);
+
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any()))
+                .thenThrow(IOException.class);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+    }
+}

--- a/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.platform.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.messaging.notifications.Notification;
+import io.cryostat.messaging.notifications.Notification.MetaType;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.platform.ServiceRef;
+
+import com.google.gson.Gson;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomTargetPlatformClientTest {
+
+    CustomTargetPlatformClient client;
+    @Mock NotificationFactory notificationFactory;
+    @Mock Path confDir;
+    @Mock Path saveFile;
+    @Mock FileSystem fs;
+    @Mock Notification notification;
+    @Mock Notification.Builder notificationBuilder;
+    Gson gson = MainModule.provideGson(null);
+
+    static final ServiceRef SERVICE_REF;
+
+    static {
+        try {
+            SERVICE_REF =
+                    new ServiceRef(
+                            new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi"),
+                            "TestTarget");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        Mockito.when(confDir.resolve(Mockito.anyString())).thenReturn(saveFile);
+
+        Mockito.lenient().when(notificationFactory.createBuilder()).thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.meta(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(MetaType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(HttpMimeType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaCategory(Mockito.anyString()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.message(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
+
+        this.client = new CustomTargetPlatformClient(notificationFactory, confDir, fs, gson);
+    }
+
+    @Test
+    void shouldReadSaveFileIfPresent() throws IOException {
+        Mockito.verifyNoInteractions(fs);
+        Mockito.when(fs.isRegularFile(saveFile)).thenReturn(true);
+        Mockito.when(fs.isReadable(saveFile)).thenReturn(true);
+        BufferedReader reader = new BufferedReader(new StringReader("[]"));
+        Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
+
+        client.start();
+
+        Mockito.verify(fs).readFile(saveFile);
+        Mockito.verifyNoMoreInteractions(fs);
+    }
+
+    @Test
+    void shouldPopulateTargetsOnStartup() throws IOException {
+        Mockito.verifyNoInteractions(fs);
+        Mockito.when(fs.isRegularFile(saveFile)).thenReturn(true);
+        Mockito.when(fs.isReadable(saveFile)).thenReturn(true);
+
+        BufferedReader reader =
+                new BufferedReader(new StringReader(gson.toJson(List.of(SERVICE_REF))));
+        Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
+
+        client.start();
+        List<ServiceRef> result = client.listDiscoverableServices();
+        MatcherAssert.assertThat(result, Matchers.equalTo(List.of(SERVICE_REF)));
+    }
+
+    @Test
+    void shouldSkipReadSaveFileIfNotPresent() throws IOException {
+        Mockito.verifyNoInteractions(fs);
+
+        client.start();
+
+        Mockito.verify(fs).isRegularFile(saveFile);
+        Mockito.verifyNoMoreInteractions(fs);
+    }
+
+    @Test
+    void testAddNewTarget() throws IOException {
+        Assertions.assertTrue(client.addTarget(SERVICE_REF));
+
+        Mockito.verify(fs)
+                .writeString(
+                        saveFile,
+                        gson.toJson(List.of(SERVICE_REF)),
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.CREATE);
+        Mockito.verify(notificationFactory).createBuilder();
+        Mockito.verify(notificationBuilder).metaCategory("TargetJvmDiscovery");
+        ArgumentCaptor<Map<String, String>> messageCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(notificationBuilder).message(messageCaptor.capture());
+        Map<String, String> message = messageCaptor.getValue();
+        MatcherAssert.assertThat(
+                message,
+                Matchers.equalTo(
+                        Map.of(
+                                "event",
+                                Map.of("kind", EventKind.FOUND, "serviceRef", SERVICE_REF))));
+        Mockito.verify(notificationBuilder).build();
+        Mockito.verify(notification).send();
+    }
+
+    @Test
+    void testAddDuplicateTarget() throws IOException {
+        Mockito.when(fs.isRegularFile(saveFile)).thenReturn(true);
+        Mockito.when(fs.isReadable(saveFile)).thenReturn(true);
+
+        BufferedReader reader =
+                new BufferedReader(new StringReader(gson.toJson(List.of(SERVICE_REF))));
+        Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
+
+        client.start();
+        Assertions.assertFalse(client.addTarget(SERVICE_REF));
+
+        Mockito.verify(fs, Mockito.never())
+                .writeString(
+                        Mockito.any(), Mockito.anyString(), ArgumentMatchers.<OpenOption>any());
+        Mockito.verifyNoInteractions(notificationFactory);
+        Mockito.verifyNoInteractions(notificationBuilder);
+        Mockito.verifyNoInteractions(notification);
+    }
+
+    @Test
+    void testRemoveTarget() throws IOException {
+        Mockito.when(fs.isRegularFile(saveFile)).thenReturn(true);
+        Mockito.when(fs.isReadable(saveFile)).thenReturn(true);
+
+        BufferedReader reader =
+                new BufferedReader(new StringReader(gson.toJson(List.of(SERVICE_REF))));
+        Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
+
+        client.start();
+        Assertions.assertTrue(client.removeTarget(SERVICE_REF));
+
+        Mockito.verify(fs)
+                .writeString(
+                        saveFile,
+                        gson.toJson(List.of()),
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.CREATE);
+        Mockito.verify(notificationFactory).createBuilder();
+        Mockito.verify(notificationBuilder).metaCategory("TargetJvmDiscovery");
+        ArgumentCaptor<Map<String, String>> messageCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(notificationBuilder).message(messageCaptor.capture());
+        Map<String, String> message = messageCaptor.getValue();
+        MatcherAssert.assertThat(
+                message,
+                Matchers.equalTo(
+                        Map.of(
+                                "event",
+                                Map.of("kind", EventKind.LOST, "serviceRef", SERVICE_REF))));
+        Mockito.verify(notificationBuilder).build();
+        Mockito.verify(notification).send();
+    }
+
+    @Test
+    void testRemoveNonexistentTarget() throws IOException {
+        Assertions.assertFalse(client.removeTarget(SERVICE_REF));
+
+        Mockito.verify(fs, Mockito.never())
+                .writeString(
+                        Mockito.any(), Mockito.anyString(), ArgumentMatchers.<OpenOption>any());
+        Mockito.verifyNoInteractions(notificationFactory);
+        Mockito.verifyNoInteractions(notificationBuilder);
+        Mockito.verifyNoInteractions(notification);
+    }
+
+    @Test
+    void testRemoveTargetByUrl() throws IOException {
+        Mockito.when(fs.isRegularFile(saveFile)).thenReturn(true);
+        Mockito.when(fs.isReadable(saveFile)).thenReturn(true);
+
+        BufferedReader reader =
+                new BufferedReader(new StringReader(gson.toJson(List.of(SERVICE_REF))));
+        Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
+
+        client.start();
+        Assertions.assertTrue(client.removeTarget(SERVICE_REF.getJMXServiceUrl()));
+
+        Mockito.verify(fs)
+                .writeString(
+                        saveFile,
+                        gson.toJson(List.of()),
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.CREATE);
+        Mockito.verify(notificationFactory).createBuilder();
+        Mockito.verify(notificationBuilder).metaCategory("TargetJvmDiscovery");
+        ArgumentCaptor<Map<String, String>> messageCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(notificationBuilder).message(messageCaptor.capture());
+        Map<String, String> message = messageCaptor.getValue();
+        MatcherAssert.assertThat(
+                message,
+                Matchers.equalTo(
+                        Map.of(
+                                "event",
+                                Map.of("kind", EventKind.LOST, "serviceRef", SERVICE_REF))));
+        Mockito.verify(notificationBuilder).build();
+        Mockito.verify(notification).send();
+    }
+
+    @Test
+    void testRemoveNonexistentTargetByUrl() throws IOException {
+        Assertions.assertFalse(client.removeTarget(SERVICE_REF.getJMXServiceUrl()));
+
+        Mockito.verify(fs, Mockito.never())
+                .writeString(
+                        Mockito.any(), Mockito.anyString(), ArgumentMatchers.<OpenOption>any());
+        Mockito.verifyNoInteractions(notificationFactory);
+        Mockito.verifyNoInteractions(notificationBuilder);
+        Mockito.verifyNoInteractions(notification);
+    }
+}

--- a/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.platform.internal;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.List;
+
+import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.platform.ServiceRef;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MergingPlatformClientTest {
+
+    @Mock PlatformClient clientA;
+    @Mock PlatformClient clientB;
+    MergingPlatformClient mergingClient;
+
+    @BeforeEach
+    void setup() {
+        this.mergingClient = new MergingPlatformClient(clientA, clientB);
+    }
+
+    @Test
+    void testStart() throws IOException {
+        Mockito.verifyNoInteractions(clientA);
+        Mockito.verifyNoInteractions(clientB);
+
+        mergingClient.start();
+
+        Mockito.verify(clientA).start();
+        Mockito.verify(clientB).start();
+    }
+
+    @Test
+    void testMergedDiscoverableServices() throws MalformedURLException {
+        ServiceRef serviceA =
+                new ServiceRef(
+                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9098/jmxrmi"),
+                        "ServiceA");
+        ServiceRef serviceB =
+                new ServiceRef(
+                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi"),
+                        "ServiceB");
+
+        Mockito.when(clientA.listDiscoverableServices()).thenReturn(List.of(serviceA));
+        Mockito.when(clientB.listDiscoverableServices()).thenReturn(List.of(serviceB));
+
+        MatcherAssert.assertThat(
+                mergingClient.listDiscoverableServices(),
+                Matchers.equalTo(List.of(serviceA, serviceB)));
+
+        Mockito.verify(clientA).listDiscoverableServices();
+        Mockito.verify(clientB).listDiscoverableServices();
+    }
+}


### PR DESCRIPTION
Initial backend support for #468.

Perhaps there should also be some metadata added to `ServiceRef`s to mark their source, ex. platform detection vs manually added, but that is currently not implemented.

Here we have two new V2 API handlers, for `POST /api/v2/targets` and `DELETE /api/v2/targets/:targetId`.

The `POST` request checks if there are any existing targets with an identical service URL and fails if so. If not, then a new `ServiceRef` is created using the service URL and alias provided (by `POST` form attributes) and tracked by the new `CustomTargetPlatformClient`.

The `DELETE` request simply removes any `ServiceRef` from the `CustomTargetPlatformClient` which matches the specified `targetId` path parameter.

The `CustomTargetPlatformClient` simply maintains an internal sorted set of `ServiceRef`s with `add`/`remove` methods to mutate this state. It also persists the state to disk on each write operation, and loads this state from disk when `start()`ed. This allows the user's custom target definitions to survive service restarts (assuming the configuration directory is mounted somewhere that will survive a restart - this is not the case by default in `run.sh`/`smoketest.sh`).

Results from the `CustomTargetPlatformClient` are combined with the pre-existing platform-specific client by the new `MergingPlatformClient`, which is pretty self-explanatory.

Frontend support for this feature will come later.

To test, use websocat and curl or httpie. The following steps use httpie.

Start container.
`CRYOSTAT_IMAGE=quay.io/andrewazores/cryostat:custom-targets`

Connect to notification channel.
`$ websocat -kE wss://0.0.0.0:8181/api/v1/command`

Create a new custom target definition.
`$ http --verify=false -f POST https://0.0.0.0:8181/api/v2/targets connectUrl="service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi" alias="Fake"`

Observe that this target is `FOUND` in the notification channel stream.
Check that it is reflected in the API results - it should be listed first.
`$ http --verify=false https://0.0.0.0:8181/api/v1/targets`

Delete the custom target definition.
`$ http --verify=false DELETE https://0.0.0.0:8181/api/v2/targets/service%3Ajmx%3Armi%3A%2F%2F%2Fjndi%2Frmi%3A%2F%2Fcryostat%3A9099%2Fjmxrmi`

Again observe that the target is `LOST` in the notification channel stream.
Check that it is no longer reflected in the API result.
`$ http --verify=false https://0.0.0.0:8181/api/v1/targets`

The web-client UI already has support for the notification events emitted since they reuse the existing platform discovery notification category and type information, so the `POST`/`DELETE` effects can also be seen in the graphical target list.