### PR TITLE
Bump version to 1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat</artifactId>
-<version>1.0.0</version>
+<version>1.1.0-SNAPSHOT</version>
 <packaging>jar</packaging>
 <name>cryostat</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
After the 1.0.0 release, we should bump the version on the v1 branch for any 1.1 development. I've branched a v1.0 branch prior to this for any bugfixes for potential 1.0.x releases.