### PR TITLE
Remove event specifier string syntax 

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -86,23 +86,19 @@ formatted as a JSON response.
 
 * #### `start`
     ###### usage
-    `start targetId foo jdk.SocketRead:enabled=true,jdk.PhysicalMemory:period=10ms`
+    `start targetId foo template=Foo`
     ###### synopsis
     Starts a continuous recording in the target JVM with the given name
-    (`foo`), which will record events as configured in the events string.
+    (`foo`), which will record events as configured in the event template.
 
     The targetID is a `hostname:port` or `service:rmi:jmx://` JMX Service URL
     specifying the location of the remote target JVM to connect to.
 
-    The syntax of an individual event string is `eventID:option=value`.
-    The syntax of the overall events string is `event1,event2,event3`, for
-    N >= 1 events.
+    The event template (`template=Foo`) allows preset configurations of events 
+    and options to be enabled.
 
-    The event string may also be provided in the form `template=Foo`. This
-    format allows preset configurations of events and options to be enabled.
-
-    The eventID is the fully qualified event name. For information about the
-    events and options available, see `list-event-types` or `search-events`.
+    For information about the events and options available, see `list-event-types` 
+    or `search-events`.
     ###### see also
     * [`list-event-types`](#list-event-types)
     * [`search-events`](#search-events)
@@ -119,11 +115,11 @@ formatted as a JSON response.
 
 * #### `dump`
     ###### usage
-    `dump targetId foo 30 jdk.SocketRead:enabled=true`
+    `dump targetId foo 30 template=Foo`
     ###### synopsis
     Starts a recording in the specified target JVM with the given name (`foo`),
     with a fixed duration of the given number of seconds (`30`), and recording
-    events as configured in the events string.
+    events as configured in the event template.
     ###### see also
     [`start`](#start)
 
@@ -198,7 +194,6 @@ formatted as a JSON response.
     ###### synopsis
     Searches for event types that can be produced by the specified target JVM
     where the event name, category, label, etc. matches the given query (`foo`).
-    This is useful for preparing event options strings.
     ###### see also
     * [`start`](#start)
     * [`dump`](#dump)
@@ -210,7 +205,6 @@ formatted as a JSON response.
     `list-event-types targetId`
     ###### synopsis
     Lists event types that can be produced by the specified target JVM.
-    This is useful for preparing event options strings.
     ###### see also
     * [`start`](#start)
     * [`dump`](#dump)

--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -851,10 +851,8 @@
     `recordingName` - The name of the recording to create.
     Should use percent-encoding.
 
-    `events` - The events configuration for the recording.
-    This can be a comma-seperated list of events, with each event having the
-    form `$EVENT_ID:$OPTION=$VALUE`; or it can be a template, using the form
-    `template=$TEMPLATE`.
+    `events` - The events configuration for the recording, as an
+    event template using the form `template=$TEMPLATE`.
 
     **The request may include the following fields:**
 
@@ -1250,7 +1248,6 @@ The handler-specific descriptions below describe how each handler populates the
     ###### synopsis
     Returns a list of event types that can be produced by a target JVM,
     where the event name, category, label, etc. matches the given query.
-    This is useful for preparing event options strings.
 
     ###### request
     `GET /api/v2/targets/:targetId/eventsSearch/:query`

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -253,7 +253,6 @@ class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
     protected IConstrainedMap<EventOptionID> enableEvents(JFRConnection connection, String events)
             throws Exception {
-        
         Matcher m = TEMPLATE_PATTERN.matcher(events);
         m.find();
         String templateName = m.group(1);

--- a/src/test/java/io/cryostat/commands/internal/AbstractRecordingCommandTest.java
+++ b/src/test/java/io/cryostat/commands/internal/AbstractRecordingCommandTest.java
@@ -100,44 +100,22 @@ class AbstractRecordingCommandTest extends TestBase {
                 "jdk:bar:baz",
                 "jdk.Event",
                 "Event",
+                "template=",
             })
-    void shouldNotValidateInvalidEventString(String events) {
+    void shouldNotValidateInvalidEventTemplate(String events) {
         assertFalse(command.validateEvents(events));
     }
 
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "foo.Event:prop=val",
-                "foo.Event:prop=val,bar.Event:thing=1",
-                "foo.class$Inner:prop=val",
                 "template=ALL",
                 "template=Foo",
                 "template=Continuous,type=TARGET",
                 "template=Foo,type=CUSTOM",
             })
-    void shouldValidateValidEventString(String events) {
+    void shouldValidateValidEventTemplate(String events) {
         assertTrue(command.validateEvents(events));
-    }
-
-    @Test
-    void shouldBuildSelectedEventMap() throws Exception {
-        verifyNoInteractions(eventOptionsBuilderFactory);
-
-        EventOptionsBuilder builder = mock(EventOptionsBuilder.class);
-        when(eventOptionsBuilderFactory.create(Mockito.any())).thenReturn(builder);
-
-        command.enableEvents(
-                connection,
-                "foo.Bar$Inner:prop=some,bar.Baz$Inner2:key=val,jdk.CPULoad:enabled=true");
-
-        verify(builder).addEvent("foo.Bar$Inner", "prop", "some");
-        verify(builder).addEvent("bar.Baz$Inner2", "key", "val");
-        verify(builder).addEvent("jdk.CPULoad", "enabled", "true");
-        verify(builder).build();
-
-        verifyNoMoreInteractions(builder);
-        verifyNoMoreInteractions(eventOptionsBuilderFactory);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -60,6 +61,8 @@ import io.cryostat.commands.internal.EventOptionsBuilder;
 import io.cryostat.commands.internal.RecordingOptionsBuilderFactory;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.templates.TemplateService;
+import io.cryostat.core.templates.TemplateType;
 import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
@@ -105,6 +108,7 @@ class TargetRecordingsPostHandlerTest {
 
     @Mock JFRConnection connection;
     @Mock IFlightRecorderService service;
+    @Mock TemplateService templateService;
     @Mock RoutingContext ctx;
     @Mock HttpServerRequest req;
     @Mock HttpServerResponse resp;
@@ -172,10 +176,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(recordingOptionsBuilder.maxSize(Mockito.anyLong()))
                 .thenReturn(recordingOptionsBuilder);
         Mockito.when(recordingOptionsBuilder.build()).thenReturn(recordingOptions);
-        EventOptionsBuilder builder = Mockito.mock(EventOptionsBuilder.class);
-        Mockito.when(eventOptionsBuilderFactory.create(Mockito.any())).thenReturn(builder);
         IConstrainedMap<EventOptionID> events = Mockito.mock(IConstrainedMap.class);
-        Mockito.when(builder.build()).thenReturn(events);
 
         Mockito.when(
                         webServer.getDownloadURL(
@@ -196,11 +197,14 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(req.formAttributes()).thenReturn(attrs);
         attrs.add("recordingName", "someRecording");
-        attrs.add("events", "foo.Bar:enabled=true");
+        attrs.add("events", "template=Foo");
         attrs.add("duration", "10");
         attrs.add("toDisk", "true");
         attrs.add("maxAge", "50");
         attrs.add("maxSize", "64");
+        Mockito.when(connection.getTemplateService()).thenReturn(templateService);
+        Mockito.when(templateService.getEvents("Foo", TemplateType.CUSTOM))
+                .thenReturn(Optional.of(events));
         Mockito.when(ctx.response()).thenReturn(resp);
 
         handler.handle(ctx);
@@ -212,11 +216,6 @@ class TargetRecordingsPostHandlerTest {
                 .end(
                         "{\"downloadUrl\":\"example-download-url\",\"reportUrl\":\"example-report-url\",\"id\":1,\"name\":\"someRecording\",\"state\":\"STOPPED\",\"startTime\":0,\"duration\":0,\"continuous\":false,\"toDisk\":false,\"maxSize\":0,\"maxAge\":0}");
 
-        ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Long> durationCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<Boolean> toDiskCaptor = ArgumentCaptor.forClass(Boolean.class);
-        ArgumentCaptor<Long> maxAgeCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<Long> maxSizeCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<IConstrainedMap<String>> recordingOptionsCaptor =
                 ArgumentCaptor.forClass(IConstrainedMap.class);
         ArgumentCaptor<IConstrainedMap<EventOptionID>> eventsCaptor =
@@ -234,16 +233,9 @@ class TargetRecordingsPostHandlerTest {
 
         MatcherAssert.assertThat(actualEvents, Matchers.sameInstance(events));
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
-        ArgumentCaptor<String> eventCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> optionCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(builder)
-                .addEvent(eventCaptor.capture(), optionCaptor.capture(), valueCaptor.capture());
-        Mockito.verify(builder).build();
 
-        MatcherAssert.assertThat(eventCaptor.getValue(), Matchers.equalTo("foo.Bar"));
-        MatcherAssert.assertThat(optionCaptor.getValue(), Matchers.equalTo("enabled"));
-        MatcherAssert.assertThat(valueCaptor.getValue(), Matchers.equalTo("true"));
+        Mockito.verify(connection).getTemplateService();
+        Mockito.verify(templateService).getEvents("Foo", TemplateType.CUSTOM);
 
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingCreated");
@@ -275,7 +267,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(req.formAttributes()).thenReturn(attrs);
         attrs.add("recordingName", "someRecording");
-        attrs.add("events", "foo.Bar:enabled=true");
+        attrs.add("events", "template=Foo");
 
         HttpStatusException ex =
                 Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -330,7 +322,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         attrs.addAll(requestValues);
         attrs.add("recordingName", "someRecording");
-        attrs.add("events", "foo.Bar:enabled=true");
+        attrs.add("events", "template=Foo");
         Mockito.when(req.formAttributes()).thenReturn(attrs);
 
         HttpStatusException ex =


### PR DESCRIPTION
Remove all event specifier string syntax. Eliminates user confusion and encourages use of event templates which are a better alternative because of the reasons stated in #480. 