### PR TITLE
483 View in Grafana not working with smoketest.sh

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -15,24 +15,27 @@ function runCryostat() {
 function runDemoApps() {
     podman run \
         --name vertx-fib-demo-1 \
+        --env HTTP_PORT=8081 \
         --env JMX_PORT=9093 \
         --pod cryostat \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.6.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
 
     podman run \
         --name vertx-fib-demo-2 \
+        --env HTTP_PORT=8081 \
         --env JMX_PORT=9094 \
         --env USE_AUTH=true \
         --pod cryostat \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.6.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
 
     podman run \
         --name vertx-fib-demo-3 \
+        --env HTTP_PORT=8081 \
         --env JMX_PORT=9095 \
         --env USE_SSL=true \
         --env USE_AUTH=true \
         --pod cryostat \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.6.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
 
     podman run \
         --name quarkus-test \


### PR DESCRIPTION
Fixes #483, where both the JFR datasource and the fibonacci demos attempted to bind to port 8080. Resolved by setting the fibonacci demos to listen at port 8081.

Question: I tried to update my branch with ```git pull upstream main``` and now the PR includes the changes made in commit ```43713a3``` as part of my PR. How do I fix that?