### PR TITLE
Query POM for core version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,15 @@ jobs:
   build-deps:
     runs-on: ubuntu-latest
     steps:
+    - id: get-core-version
+      # Query POM for core version and save as output parameter
+      run: |
+        CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
+        echo "::set-output name=core-version::$CORE_VERSION"
     - uses: actions/checkout@v2
       with:
         repository: cryostatio/cryostat-core
-        ref: v2.2.3 # FIXME this needs to be synced with pom.xml core version
+        ref: ${{ steps.get-core-version.outputs.core-version }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       # Query POM for core version and save as output parameter
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
-        echo "::set-output name=core-version::$CORE_VERSION"
+        echo "::set-output name=core-version::v$CORE_VERSION"
     outputs:
       core-version: ${{ steps.query-pom.outputs.core-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,18 +7,26 @@ on:
     branches: [ main ]
 
 jobs:
-  build-deps:
+  get-core-version:
     runs-on: ubuntu-latest
     steps:
-    - id: get-core-version
+    - uses: actions/checkout@v2
+    - id: query-pom
       # Query POM for core version and save as output parameter
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
         echo "::set-output name=core-version::$CORE_VERSION"
+    outputs:
+      core-version: ${{ steps.query-pom.outputs.core-version }}
+
+  build-deps:
+    runs-on: ubuntu-latest
+    needs: [get-core-version]
+    steps:
     - uses: actions/checkout@v2
       with:
         repository: cryostatio/cryostat-core
-        ref: ${{ steps.get-core-version.outputs.core-version }}
+        ref: ${{ needs.get-core-version.outputs.core-version }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore


### PR DESCRIPTION
This adds a CI job to query the cryostat-core version from the pom file, instead of relying on a hardcoded value.