### PR TITLE
API exception responses should contain more detail

### DIFF
--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -152,7 +152,7 @@ public class WebServer {
                                         ? exception.getPayload()
                                         : exception.getMessage();
 
-                        if(exception.getCause() != null) {
+                        if (exception.getCause() != null) {
                             payload += ": " + exception.getCause().getMessage();
                         }
 

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -74,6 +74,7 @@ import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 
@@ -152,8 +153,9 @@ public class WebServer {
                                         ? exception.getPayload()
                                         : exception.getMessage();
 
-                        if (exception.getCause() != null) {
-                            payload += ": " + exception.getCause().getMessage();
+                        if (ExceptionUtils.hasCause(exception, HttpStatusException.class)) {
+                            payload +=
+                                    " caused by " + ExceptionUtils.getRootCauseMessage(exception);
                         }
 
                         String accept = ctx.request().getHeader(HttpHeaders.ACCEPT);

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -152,6 +152,10 @@ public class WebServer {
                                         ? exception.getPayload()
                                         : exception.getMessage();
 
+                        if(exception.getCause() != null) {
+                            payload += ": " + exception.getCause().getMessage();
+                        }
+
                         String accept = ctx.request().getHeader(HttpHeaders.ACCEPT);
                         if (accept.contains(HttpMimeType.JSON.mime())
                                 && accept.indexOf(HttpMimeType.JSON.mime())


### PR DESCRIPTION
Resolves #435. Exceptions that get re-thrown as a `new HttpStatusException(500, e)` by a handler get caught and handled by `WebServer`. The `new HttpStatusException` does not contain an error message itself, but the `WebServer` can append the underlying exception message to the API exception responses with `e.getCause().getMessage()`:

![Screenshot from 2021-06-04 11-04-54](https://user-images.githubusercontent.com/84587295/120826964-f5e94000-c528-11eb-8d5a-54d3a345611e.png)

Slightly unrelated question: Why does JaCoCo show that the `WebServer` failure handler isn't covered by any unit tests? I found an integration test for `ClientUrl` that only tests for successful scenarios.