### PR TITLE
Run integration tests in CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,7 @@ jobs:
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: git submodule init
     - run: git submodule update
-    # FIXME integration tests require Podman, CI runner uses Docker. Ideally this should all just be "clean verify"
-    - run: mvn -B -U clean compile test spotbugs:check spotless:check
+    - run: mvn -B -U clean verify
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save


### PR DESCRIPTION
Podman is now available in the Linux-based Github runners: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md