### PR TITLE
[autorules] Rules deletion enhancements

### DIFF
--- a/rulestest.sh
+++ b/rulestest.sh
@@ -61,3 +61,9 @@ podman run \
     --env HTTP_PORT=8081 \
     --env JMX_PORT=9094 \
     --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
+
+sleep 5
+echo "Deleting rule definition"
+curl -k \
+    -X DELETE \
+    "$CRYOSTAT_HOST/api/v2/rules/Default_Rule"

--- a/rulestest.sh
+++ b/rulestest.sh
@@ -13,7 +13,7 @@ if [ -z "$CRYOSTAT_HOST" ]; then
     CRYOSTAT_HOST="https://0.0.0.0:8181"
 fi
 
-TARGET_CONTAINER=vertx-fib-demo-1
+TARGET_CONTAINER=vertx-fib-demo-2
 
 echo "Killing $TARGET_CONTAINER container"
 podman kill $TARGET_CONTAINER
@@ -58,6 +58,6 @@ echo "Restarting $TARGET_CONTAINER"
 podman run \
     --name $TARGET_CONTAINER \
     --pod cryostat \
-    --env JMX_PORT=9093 \
-    --env USE_AUTH=true \
-    --rm -d quay.io/andrewazores/vertx-fib-demo:0.6.0
+    --env HTTP_PORT=8081 \
+    --env JMX_PORT=9094 \
+    --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0

--- a/rulestest.sh
+++ b/rulestest.sh
@@ -21,6 +21,11 @@ podman kill $TARGET_CONTAINER
 demoAppServiceUrl="service:jmx:rmi:///jndi/rmi://cryostat:9094/jmxrmi"
 demoAppTargetId="$(echo -n $demoAppServiceUrl | jq -sRr @uri)"
 
+echo "Deleting nonexistent rule definition"
+curl -k \
+    -X DELETE \
+    "$CRYOSTAT_HOST/api/v2/rules/Default_Rule"
+
 sleep 2
 echo "POSTing $TARGET_CONTAINER credentials"
 curl -k \

--- a/rulestest.sh
+++ b/rulestest.sh
@@ -18,7 +18,7 @@ TARGET_CONTAINER=vertx-fib-demo-2
 echo "Killing $TARGET_CONTAINER container"
 podman kill $TARGET_CONTAINER
 
-demoAppServiceUrl="service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"
+demoAppServiceUrl="service:jmx:rmi:///jndi/rmi://cryostat:9094/jmxrmi"
 demoAppTargetId="$(echo -n $demoAppServiceUrl | jq -sRr @uri)"
 
 sleep 2

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandler.java
@@ -93,6 +93,9 @@ class RuleDeleteHandler extends AbstractV2RequestHandler<Void> {
     @Override
     public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
         String name = params.getPathParams().get(Rule.Attribute.NAME.getSerialKey());
+        if (!ruleRegistry.hasRuleByName(name)) {
+            throw new ApiException(404);
+        }
         try {
             ruleRegistry.deleteRule(name);
         } catch (IOException e) {

--- a/src/main/java/io/cryostat/rules/PeriodicArchiver.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiver.java
@@ -116,22 +116,34 @@ class PeriodicArchiver implements Runnable {
         // exposed by this refactored chunk, and this refactored chunk can also be consumed here
         // rather than firing HTTP requests to ourselves
 
-        URI path =
+        // URI path =
+        //         URI.create(
+        //                         archiveRequestPath
+        //                                 .replaceAll(
+        //                                         ":targetId",
+        //                                         URLEncodedUtils.formatSegments(
+        //
+        // serviceRef.getJMXServiceUrl().toString()))
+        //                                 .replaceAll(
+        //                                         ":recordingName",
+        //                                         URLEncodedUtils.formatSegments(
+        //                                                 rule.getRecordingName())))
+        //                 .normalize();
+
+        String path =
                 URI.create(
-                                archiveRequestPath
-                                        .replaceAll(
-                                                ":targetId",
-                                                URLEncodedUtils.formatSegments(
-                                                        serviceRef.getJMXServiceUrl().toString()))
-                                        .replaceAll(
-                                                ":recordingName",
-                                                URLEncodedUtils.formatSegments(
-                                                        rule.getRecordingName())))
-                        .normalize();
+                                String.format(
+                                        "/api/v1/targets/%s/recordings/%s",
+                                        URLEncodedUtils.formatSegments(
+                                                serviceRef.getJMXServiceUrl().toString()),
+                                        URLEncodedUtils.formatSegments(rule.getRecordingName())))
+                        .normalize()
+                        .toString();
+        this.logger.info("PATCH \"save\" {}", path);
 
         CompletableFuture<String> future = new CompletableFuture<>();
         this.webClient
-                .patch(path.toString())
+                .patch(path)
                 .putHeaders(headersFactory.apply(credentials))
                 .sendBuffer(
                         Buffer.buffer("save"),

--- a/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
@@ -41,8 +41,6 @@ import java.util.function.Function;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
-import io.cryostat.net.web.http.api.v1.RecordingDeleteHandler;
-import io.cryostat.net.web.http.api.v1.TargetRecordingPatchHandler;
 import io.cryostat.platform.ServiceRef;
 
 import io.vertx.core.MultiMap;
@@ -51,33 +49,18 @@ import io.vertx.ext.web.client.WebClient;
 class PeriodicArchiverFactory {
 
     private final WebClient webClient;
-    private final String archiveRequestPath;
-    private final String deleteRequestPath;
     private final Function<Credentials, MultiMap> headersFactory;
     private final Logger logger;
 
     PeriodicArchiverFactory(
-            WebClient webClient,
-            TargetRecordingPatchHandler archiveHandler,
-            RecordingDeleteHandler deleteHandler,
-            Function<Credentials, MultiMap> headersFactory,
-            Logger logger) {
+            WebClient webClient, Function<Credentials, MultiMap> headersFactory, Logger logger) {
         this.webClient = webClient;
-        this.archiveRequestPath = archiveHandler.path();
-        this.deleteRequestPath = deleteHandler.path();
         this.headersFactory = headersFactory;
         this.logger = logger;
     }
 
     PeriodicArchiver create(ServiceRef serviceRef, Credentials credentials, Rule rule) {
         return new PeriodicArchiver(
-                serviceRef,
-                credentials,
-                rule,
-                webClient,
-                archiveRequestPath,
-                deleteRequestPath,
-                headersFactory,
-                logger);
+                serviceRef, credentials, rule, webClient, headersFactory, logger);
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -80,7 +80,6 @@ public class RuleProcessor
     private final ScheduledExecutorService scheduler;
     private final CredentialsManager credentialsManager;
     private final WebClient webClient;
-    private final String postPath;
     private final PeriodicArchiverFactory periodicArchiverFactory;
     private final Function<Credentials, MultiMap> headersFactory;
     private final Logger logger;
@@ -93,7 +92,6 @@ public class RuleProcessor
             ScheduledExecutorService scheduler,
             CredentialsManager credentialsManager,
             WebClient webClient,
-            String postPath,
             PeriodicArchiverFactory periodicArchiverFactory,
             Function<Credentials, MultiMap> headersFactory,
             Logger logger) {
@@ -102,7 +100,6 @@ public class RuleProcessor
         this.scheduler = scheduler;
         this.credentialsManager = credentialsManager;
         this.webClient = webClient;
-        this.postPath = postPath;
         this.periodicArchiverFactory = periodicArchiverFactory;
         this.headersFactory = headersFactory;
         this.logger = logger;
@@ -231,9 +228,6 @@ public class RuleProcessor
         if (maxSizeBytes > 0) {
             form.attribute("maxSize", String.valueOf(maxSizeBytes));
         }
-        // String path =
-        //         postPath.replaceAll(
-        //                 ":targetId", URLEncodedUtils.formatSegments(serviceUrl.toString()));
         String path =
                 URI.create(
                                 String.format(
@@ -242,7 +236,7 @@ public class RuleProcessor
                         .normalize()
                         .toString();
 
-        this.logger.info("POST {}", path);
+        this.logger.trace("POST {}", path);
 
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         this.webClient

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -131,28 +131,17 @@ public class RuleRegistry {
 
     public void deleteRule(String name) throws IOException {
         this.rules.removeIf(r -> Objects.equals(r.getName(), name));
-        this.fs.listDirectoryChildren(rulesDir).stream()
-                .filter(s -> Objects.equals(s, name + ".json"))
-                .map(rulesDir::resolve)
-                .forEach(
-                        path -> {
-                            try {
-                                fs.deleteIfExists(path);
-                            } catch (IOException e) {
-                                logger.warn(e);
-                            }
-                        });
+        for (String child : this.fs.listDirectoryChildren(rulesDir)) {
+            if (!Objects.equals(child, name + ".json")) {
+                continue;
+            }
+            fs.deleteIfExists(rulesDir.resolve(child));
+        }
     }
 
     public void deleteRules(ServiceRef serviceRef) throws IOException {
-        getRules(serviceRef)
-                .forEach(
-                        rule -> {
-                            try {
-                                deleteRule(rule);
-                            } catch (IOException e) {
-                                logger.warn(e);
-                            }
-                        });
+        for (Rule rule : getRules(serviceRef)) {
+            deleteRule(rule);
+        }
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -49,10 +49,13 @@ import java.util.stream.Collectors;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.RuleRegistry.RuleEvent;
+import io.cryostat.util.events.AbstractEventEmitter;
+import io.cryostat.util.events.EventType;
 
 import com.google.gson.Gson;
 
-public class RuleRegistry {
+public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
 
     private final Path rulesDir;
     private final FileSystem fs;
@@ -101,6 +104,7 @@ public class RuleRegistry {
                 StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING);
         loadRules();
+        emit(RuleEvent.ADDED, rule);
         return rule;
     }
 
@@ -130,18 +134,31 @@ public class RuleRegistry {
     }
 
     public void deleteRule(String name) throws IOException {
-        this.rules.removeIf(r -> Objects.equals(r.getName(), name));
         for (String child : this.fs.listDirectoryChildren(rulesDir)) {
             if (!Objects.equals(child, name + ".json")) {
                 continue;
             }
             fs.deleteIfExists(rulesDir.resolve(child));
         }
+        this.rules.stream()
+                .filter(r -> Objects.equals(r.getName(), name))
+                .findFirst()
+                .ifPresent(
+                        rule -> {
+                            emit(RuleEvent.REMOVED, rule);
+                            this.rules.remove(rule);
+                        });
     }
 
     public void deleteRules(ServiceRef serviceRef) throws IOException {
         for (Rule rule : getRules(serviceRef)) {
             deleteRule(rule);
         }
+    }
+
+    enum RuleEvent implements EventType {
+        ADDED,
+        REMOVED,
+        ;
     }
 }

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -55,9 +55,6 @@ import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.NetworkConfiguration;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
-import io.cryostat.net.web.http.api.v1.RecordingDeleteHandler;
-import io.cryostat.net.web.http.api.v1.TargetRecordingPatchHandler;
-import io.cryostat.net.web.http.api.v1.TargetRecordingsPostHandler;
 import io.cryostat.platform.PlatformClient;
 
 import com.google.gson.Gson;
@@ -100,7 +97,6 @@ public abstract class RulesModule {
             RuleRegistry registry,
             CredentialsManager credentialsManager,
             @Named(RULES_WEB_CLIENT) WebClient webClient,
-            TargetRecordingsPostHandler postHandler,
             PeriodicArchiverFactory periodicArchiverFactory,
             @Named(RULES_HEADERS_FACTORY) Function<Credentials, MultiMap> headersFactory,
             Logger logger) {
@@ -110,7 +106,6 @@ public abstract class RulesModule {
                 Executors.newScheduledThreadPool(1),
                 credentialsManager,
                 webClient,
-                postHandler.path(),
                 periodicArchiverFactory,
                 headersFactory,
                 logger);
@@ -120,12 +115,9 @@ public abstract class RulesModule {
     @Singleton
     static PeriodicArchiverFactory providePeriodicArchivedFactory(
             @Named(RULES_WEB_CLIENT) WebClient webClient,
-            TargetRecordingPatchHandler archiveHandler,
-            RecordingDeleteHandler deleteHandler,
             @Named(RULES_HEADERS_FACTORY) Function<Credentials, MultiMap> headersFactory,
             Logger logger) {
-        return new PeriodicArchiverFactory(
-                webClient, archiveHandler, deleteHandler, headersFactory, logger);
+        return new PeriodicArchiverFactory(webClient, headersFactory, logger);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/util/events/AbstractEventEmitter.java
+++ b/src/main/java/io/cryostat/util/events/AbstractEventEmitter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.util.events;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class AbstractEventEmitter<T extends EventType, V> {
+    protected final Set<EventListener<T, V>> listeners = new HashSet<>();
+
+    public void addListener(EventListener<T, V> listener) {
+        this.listeners.add(listener);
+    }
+
+    protected void emit(T eventType, V payload) {
+        this.listeners.forEach(
+                listener -> {
+                    listener.onEvent(new Event<>(eventType, payload));
+                });
+    }
+}

--- a/src/main/java/io/cryostat/util/events/Event.java
+++ b/src/main/java/io/cryostat/util/events/Event.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.util.events;
+
+public class Event<T extends EventType, V> {
+
+    private final T eventType;
+    private final V payload;
+
+    public Event(T eventType, V payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+
+    public T getEventType() {
+        return eventType;
+    }
+
+    public V getPayload() {
+        return payload;
+    }
+}

--- a/src/main/java/io/cryostat/util/events/EventListener.java
+++ b/src/main/java/io/cryostat/util/events/EventListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.util.events;
+
+public interface EventListener<T extends EventType, V> {
+    void onEvent(Event<T, V> event);
+}

--- a/src/main/java/io/cryostat/util/events/EventType.java
+++ b/src/main/java/io/cryostat/util/events/EventType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.util.events;
+
+public interface EventType {}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.Map;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.rules.RuleRegistry;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RuleDeleteHandlerTest {
+
+    RuleDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock RuleRegistry registry;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new RuleDeleteHandler(auth, registry, gson, logger);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldRequireAuthentication() {
+            Assertions.assertTrue(handler.requiresAuthentication());
+        }
+
+        @Test
+        void shouldBeV2Handler() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+        }
+
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+        }
+
+        @Test
+        void shouldHaveExpectedApiPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/rules/:name"));
+        }
+
+        @Test
+        void shouldHavePlaintextMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.PLAINTEXT));
+        }
+
+        @Test
+        void shouldBeAsyncHandler() {
+            Assertions.assertTrue(handler.isAsync());
+        }
+
+        @Test
+        void shouldBeOrderedHandler() {
+            Assertions.assertTrue(handler.isOrdered());
+        }
+    }
+
+    @Nested
+    class Requests {
+        @Mock RequestParameters params;
+        final String testRuleName = "Test_Rule";
+
+        @Test
+        void shouldRespondOk() throws Exception {
+            Mockito.when(params.getPathParams()).thenReturn(Map.of("name", testRuleName));
+            Mockito.when(registry.hasRuleByName(testRuleName)).thenReturn(true);
+
+            IntermediateResponse<Void> response = handler.handle(params);
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+        }
+
+        @Test
+        void shouldRespondWith404ForNonexistentRule() throws Exception {
+            Mockito.when(params.getPathParams()).thenReturn(Map.of("name", testRuleName));
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleGetHandlerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.rules.Rule;
+import io.cryostat.rules.RuleRegistry;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RuleGetHandlerTest {
+
+    RuleGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock RuleRegistry registry;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new RuleGetHandler(auth, registry, gson, logger);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldRequireAuthentication() {
+            Assertions.assertTrue(handler.requiresAuthentication());
+        }
+
+        @Test
+        void shouldBeV2Handler() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+        }
+
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+        }
+
+        @Test
+        void shouldHaveExpectedApiPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/rules/:name"));
+        }
+
+        @Test
+        void shouldHavePlaintextMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+        }
+
+        @Test
+        void shouldBeAsyncHandler() {
+            Assertions.assertTrue(handler.isAsync());
+        }
+
+        @Test
+        void shouldBeOrderedHandler() {
+            Assertions.assertTrue(handler.isOrdered());
+        }
+    }
+
+    @Nested
+    class Requests {
+        @Mock RequestParameters params;
+        final Rule testRule =
+                new Rule.Builder()
+                        .name("Test Rule")
+                        .targetAlias("localhost:0")
+                        .eventSpecifier("template=Profiling")
+                        .build();
+
+        @Test
+        void shouldRespondWithRuleDefinition() throws Exception {
+            Mockito.when(params.getPathParams()).thenReturn(Map.of("name", testRule.getName()));
+            Mockito.when(registry.getRule(Mockito.anyString())).thenReturn(Optional.of(testRule));
+
+            IntermediateResponse<Rule> response = handler.handle(params);
+            MatcherAssert.assertThat(response.getBody(), Matchers.sameInstance(testRule));
+        }
+
+        @Test
+        void shouldRespondWith404ForNonexistentRule() throws Exception {
+            Mockito.when(params.getPathParams()).thenReturn(Map.of("name", testRule.getName()));
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesGetHandlerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.rules.Rule;
+import io.cryostat.rules.RuleRegistry;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RulesGetHandlerTest {
+
+    RulesGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock RuleRegistry registry;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new RulesGetHandler(auth, registry, gson, logger);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldRequireAuthentication() {
+            Assertions.assertTrue(handler.requiresAuthentication());
+        }
+
+        @Test
+        void shouldBeV2Handler() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+        }
+
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+        }
+
+        @Test
+        void shouldHaveExpectedApiPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2/rules"));
+        }
+
+        @Test
+        void shouldHavePlaintextMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+        }
+
+        @Test
+        void shouldBeAsyncHandler() {
+            Assertions.assertTrue(handler.isAsync());
+        }
+
+        @Test
+        void shouldBeOrderedHandler() {
+            Assertions.assertTrue(handler.isOrdered());
+        }
+    }
+
+    @Nested
+    class Requests {
+        @Mock RequestParameters params;
+        Set<Rule> testRules;
+
+        @BeforeEach
+        void setup() {
+            Rule ruleA =
+                    new Rule.Builder()
+                            .name("Rule A")
+                            .eventSpecifier("template=Profiling")
+                            .targetAlias("fooTarget")
+                            .build();
+
+            Rule ruleB =
+                    new Rule.Builder()
+                            .name("Rule B")
+                            .eventSpecifier("template=Continuous")
+                            .targetAlias("barTarget")
+                            .build();
+
+            testRules = Set.of(ruleA, ruleB);
+        }
+
+        @Test
+        void shouldRespondOk() throws Exception {
+            Mockito.when(registry.getRules()).thenReturn(testRules);
+
+            IntermediateResponse<Set<Rule>> response = handler.handle(params);
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(testRules));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -82,8 +82,6 @@ class PeriodicArchiverTest {
                     .archivalPeriodSeconds(67)
                     .build();
     @Mock WebClient webClient;
-    String archiveRequestPath = "/api/v1/targets/:targetId/recordings/:recordingName";
-    String deleteRequestPath = "/api/v1/recordings/:recordingName";
     @Mock MultiMap headers;
     @Mock Logger logger;
 
@@ -92,14 +90,7 @@ class PeriodicArchiverTest {
         this.serviceRef = new ServiceRef(new JMXServiceURL(jmxUrl), "com.example.App");
         this.archiver =
                 new PeriodicArchiver(
-                        serviceRef,
-                        credentials,
-                        rule,
-                        webClient,
-                        archiveRequestPath,
-                        deleteRequestPath,
-                        c -> headers,
-                        logger);
+                        serviceRef, credentials, rule, webClient, c -> headers, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -82,7 +82,6 @@ class RuleProcessorTest {
     @Mock ScheduledExecutorService scheduler;
     @Mock CredentialsManager credentialsManager;
     @Mock WebClient webClient;
-    String postPath = "/api/v1/targets/:targetId/recordings";
     @Mock PeriodicArchiverFactory periodicArchiverFactory;
     @Mock MultiMap headers;
     @Mock Logger logger;
@@ -96,7 +95,6 @@ class RuleProcessorTest {
                         scheduler,
                         credentialsManager,
                         webClient,
-                        postPath,
                         periodicArchiverFactory,
                         c -> headers,
                         logger);

--- a/src/test/java/io/cryostat/rules/RuleRegistryTest.java
+++ b/src/test/java/io/cryostat/rules/RuleRegistryTest.java
@@ -225,7 +225,7 @@ class RuleRegistryTest {
     void testDeleteRuleDoesNothingIfNoneAdded() throws Exception {
         registry.deleteRule(TEST_RULE.getName());
         Mockito.verifyNoInteractions(gson);
-        Mockito.verify(fs).listDirectoryChildren(rulesDir);
+        Mockito.verify(fs).listDirectoryChildren(Mockito.any());
         Mockito.verifyNoMoreInteractions(fs);
         Mockito.verifyNoInteractions(rulesDir);
     }
@@ -252,7 +252,7 @@ class RuleRegistryTest {
     }
 
     @Test
-    void testDeleteLogsFileDeletionException() throws Exception {
+    void testDeletePropagatesFileDeletionException() throws Exception {
         Path rulePath = Mockito.mock(Path.class);
         Mockito.when(rulesDir.resolve(Mockito.anyString())).thenReturn(rulePath);
         Mockito.when(fs.listDirectoryChildren(rulesDir)).thenReturn(List.of("test_rule.json"));
@@ -261,8 +261,6 @@ class RuleRegistryTest {
 
         registry.addRule(TEST_RULE);
 
-        registry.deleteRule(TEST_RULE.getName());
-
-        Mockito.verify(logger).warn(Mockito.any(IOException.class));
+        Assertions.assertThrows(IOException.class, () -> registry.deleteRule(TEST_RULE.getName()));
     }
 }


### PR DESCRIPTION
This addresses the following two items in the ongoing autorules PR #416:

> Deleting a non-existent rule, as well as an existing one, gives a 200. It would be helpful if non-existent-rule deletions gave a 404 instead, to indicate to the user that the given rule was not found and that no deletion has occurred. Or they could make a note of it in the result, if a 404 is inappropriate here.

`DELETE` on a rule now responds with either `200` or `404`.

> If a rule is already running, and the user would like to stop that rule (delete the active recording and stop the PeriodicArchiver), is there any way for them to do this besides killing the target container? Should deleting a rule maybe be able to do this? Or maybe this could be the job of a new PATCH STOP handler?

`DELETE`ing a rule definition which is "active", in the sense that it has been triggered and a PeriodicArchiver exists due to that rule definition, will now also stop and remove such archiver tasks. The in-memory active recording is left intact on the target since the user may still wish to see that - they can follow up with a `DELETE` or `PATCH stop` on the recording resource itself if they want it removed/stopped, since it's ambiguous which behaviour would be desired when deleting a rule.