### PR TITLE
Add WebSocket Message Emitted Event

### DIFF
--- a/src/main/extras/app/Cryostat.xml
+++ b/src/main/extras/app/Cryostat.xml
@@ -14,6 +14,14 @@
     true
   </setting>
  </event>
+ <event name="io.cyostat.net.web.MessagingServer.WsMessageEmitted">
+  <setting name="enabled">
+    true
+  </setting>
+  <setting name="threshold">
+    0 ms
+  </setting>
+ </event>
  <event name="jdk.ThreadAllocationStatistics">
   <setting name="enabled">
    true

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -166,14 +166,8 @@ public class MessagingServer implements AutoCloseable {
     public void writeMessage(WsMessage message) {
         String json = gson.toJson(message);
         logger.info("Outgoing WS message: {}", json);
-
         synchronized (connections) {
-            connections
-                    .keySet()
-                    .forEach(
-                            c -> {
-                                c.writeMessage(json);
-                            });
+            connections.keySet().forEach(c -> c.writeMessage(json));
         }
     }
 

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -200,7 +200,7 @@ public class MessagingServer implements AutoCloseable {
             this.message = message;
         }
 
-        public void SetConnection(WsClient connection) {
+        public void setConnection(WsClient connection) {
             this.connection = connection;
         }
     }

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -181,7 +181,9 @@ public class MessagingServer implements AutoCloseable {
                                 evt.begin();
                                 c.writeMessage(json);
                                 evt.end();
-                                evt.commit();
+                                if (evt.shouldCommit()) {
+                                    evt.commit();
+                                }
                             });
         }
     }

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -187,7 +187,7 @@ public class MessagingServer implements AutoCloseable {
     }
 
     @Name("io.cryostat.messaging.MessagingServer.WsMessageEmitted")
-    @Label("WsMessageEmitted")
+    @Label("WebSocket Message Emitted")
     @Category("Cryostat")
     @SuppressFBWarnings(
             value = "URF_UNREAD_FIELD",

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -171,7 +171,7 @@ public class MessagingServer implements AutoCloseable {
     public void writeMessage(WsMessage message) {
         String json = gson.toJson(message);
         logger.info("Outgoing WS message: {}", json);
-        WsMessageEmitted evt = new WsMessageEmitted(message);
+        WsMessageEmitted evt = new WsMessageEmitted(json);
 
         synchronized (connections) {
             connections
@@ -194,10 +194,10 @@ public class MessagingServer implements AutoCloseable {
             justification = "Event fields are recorded with JFR instead of accessed directly")
     public static class WsMessageEmitted extends Event {
         WsClient connection;
-        WsMessage message;
+        String json;
 
-        public WsMessageEmitted(WsMessage message) {
-            this.message = message;
+        public WsMessageEmitted(String json) {
+            this.json = json;
         }
 
         public void setConnection(WsClient connection) {

--- a/src/main/java/io/cryostat/messaging/MessagingServer.java
+++ b/src/main/java/io/cryostat/messaging/MessagingServer.java
@@ -59,11 +59,6 @@ import io.cryostat.net.HttpServer;
 import io.cryostat.net.web.http.HttpMimeType;
 
 import com.google.gson.Gson;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Label;
-import jdk.jfr.Name;
 
 public class MessagingServer implements AutoCloseable {
 
@@ -171,39 +166,14 @@ public class MessagingServer implements AutoCloseable {
     public void writeMessage(WsMessage message) {
         String json = gson.toJson(message);
         logger.info("Outgoing WS message: {}", json);
-        WsMessageEmitted evt = new WsMessageEmitted(json);
 
         synchronized (connections) {
             connections
                     .keySet()
                     .forEach(
                             c -> {
-                                evt.begin();
                                 c.writeMessage(json);
-                                evt.end();
-                                if (evt.shouldCommit()) {
-                                    evt.commit();
-                                }
                             });
-        }
-    }
-
-    @Name("io.cryostat.messaging.MessagingServer.WsMessageEmitted")
-    @Label("WebSocket Message Emitted")
-    @Category("Cryostat")
-    @SuppressFBWarnings(
-            value = "URF_UNREAD_FIELD",
-            justification = "Event fields are recorded with JFR instead of accessed directly")
-    public static class WsMessageEmitted extends Event {
-        WsClient connection;
-        String json;
-
-        public WsMessageEmitted(String json) {
-            this.json = json;
-        }
-
-        public void setConnection(WsClient connection) {
-            this.connection = connection;
         }
     }
 


### PR DESCRIPTION
Related #461 

What do you think about the level of detail needed for recording WebSocket events? I decided to include the outgoing json to record more information rather than less:

![Screenshot from 2021-06-09 14-53-17](https://user-images.githubusercontent.com/84587295/121412445-b8beec80-c932-11eb-9e29-0c08361283d9.png)

Also, when is it generally appropriate to add a threshold setting for events? I added a threshold setting in this case because WebSocket messages that take a long time to send may indicate a problem.