### PR TITLE
[autorules] Mention all missing form fields on credentials POST

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -41,14 +41,16 @@ import java.io.IOException;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
-
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 
 class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
@@ -107,12 +109,12 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
         String username = params.getFormAttributes().get("username");
         String password = params.getFormAttributes().get("password");
 
-        if (username == null || password == null) {
+        if (StringUtils.isAnyBlank(username, password)) {
             StringBuilder sb = new StringBuilder();
-            if (username == null) {
+            if (StringUtils.isBlank(username)) {
                 sb.append("\"username\" is required.");
             }
-            if (password == null) {
+            if (StringUtils.isBlank(password)) {
                 sb.append(" \"password\" is required.");
             }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -41,17 +41,16 @@ import java.io.IOException;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang3.StringUtils;
-
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
 
 class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -110,10 +110,10 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
         if (username == null || password == null) {
             StringBuilder sb = new StringBuilder();
             if (username == null) {
-                sb.append("username is required.");
+                sb.append("\"username\" is required.");
             }
             if (password == null) {
-                sb.append(" password is required.");
+                sb.append(" \"password\" is required.");
             }
 
             throw new ApiException(400, sb.toString().trim());

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -38,7 +38,6 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -105,17 +104,19 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
     @Override
     public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
         String targetId = params.getPathParams().get("targetId");
-        String username;
-        String password;
-        try {
-            username =
-                    Objects.requireNonNull(
-                            params.getFormAttributes().get("username"), "Username is required");
-            password =
-                    Objects.requireNonNull(
-                            params.getFormAttributes().get("password"), "Password is required");
-        } catch (NullPointerException npe) {
-            throw new ApiException(400, npe.getMessage(), npe);
+        String username = params.getFormAttributes().get("username");
+        String password = params.getFormAttributes().get("password");
+
+        if (username == null || password == null) {
+            StringBuilder sb = new StringBuilder();
+            if (username == null) {
+                sb.append("username is required.");
+            }
+            if (password == null) {
+                sb.append(" password is required.");
+            }
+
+            throw new ApiException(400, sb.toString().trim());
         }
 
         try {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.util.Map;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetCredentialsPostHandlerTest {
+
+    AbstractV2RequestHandler<Void> handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetCredentialsPostHandler(auth, credentialsManager, gson, logger);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+        }
+
+        @Test
+        void shouldBeAPIV2() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/v2/targets/:targetId/credentials"));
+        }
+
+        @Test
+        void shouldReturnPlaintextMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.PLAINTEXT));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldRespond400WhenUsernameOmitted() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("password", "abc123");
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("username is required."));
+        }
+
+        @Test
+        void shouldRespond400WhenPasswordOmitted() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("username", "adminuser");
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("password is required."));
+        }
+
+        @Test
+        void shouldRespond400WhenFormEmpty() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(),
+                    Matchers.equalTo("username is required. password is required."));
+        }
+
+        @Test
+        void shouldDelegateToCredentialsManager() throws Exception {
+            String targetId = "fooTarget";
+            String username = "adminuser";
+            String password = "abc123";
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("username", username);
+            form.set("password", password);
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            IntermediateResponse<Void> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(response.getBody(), Matchers.nullValue());
+            Mockito.verify(credentialsManager)
+                    .addCredentials(targetId, new Credentials(username, password));
+        }
+
+        @Test
+        void shouldWrapIOExceptions() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("username", "adminuser");
+            form.set("password", "abc123");
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            Mockito.when(credentialsManager.addCredentials(Mockito.anyString(), Mockito.any()))
+                    .thenThrow(IOException.class);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -40,8 +40,17 @@ package io.cryostat.net.web.http.api.v2;
 import java.io.IOException;
 import java.util.Map;
 
-import com.google.gson.Gson;
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -54,16 +63,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.cryostat.MainModule;
-import io.cryostat.configuration.CredentialsManager;
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.Credentials;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.web.http.HttpMimeType;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
 class TargetCredentialsPostHandlerTest {
@@ -130,12 +129,7 @@ class TargetCredentialsPostHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings={
-            "",
-            " ",
-            "\t",
-            "\n"
-        })
+        @ValueSource(strings = {"", " ", "\t", "\n"})
         void shouldRespond400WhenUsernameBlank() throws Exception {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
 
@@ -168,12 +162,7 @@ class TargetCredentialsPostHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings={
-            "",
-            " ",
-            "\t",
-            "\n"
-        })
+        @ValueSource(strings = {"", " ", "\t", "\n"})
         void shouldRespond400WhenPasswordBlank() throws Exception {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -130,10 +130,11 @@ class TargetCredentialsPostHandlerTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void shouldRespond400WhenUsernameBlank() throws Exception {
+        void shouldRespond400WhenUsernameBlank(String username) throws Exception {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
 
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("username", username);
             form.set("password", "abc123");
             Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
 
@@ -163,11 +164,12 @@ class TargetCredentialsPostHandlerTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"", " ", "\t", "\n"})
-        void shouldRespond400WhenPasswordBlank() throws Exception {
+        void shouldRespond400WhenPasswordBlank(String password) throws Exception {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
 
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
             form.set("username", "adminuser");
+            form.set("password", password);
             Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
 
             ApiException ex =

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -123,7 +123,7 @@ class TargetCredentialsPostHandlerTest {
                             ApiException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
             MatcherAssert.assertThat(
-                    ex.getFailureReason(), Matchers.equalTo("username is required."));
+                    ex.getFailureReason(), Matchers.equalTo("\"username\" is required."));
         }
 
         @Test
@@ -139,7 +139,7 @@ class TargetCredentialsPostHandlerTest {
                             ApiException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
             MatcherAssert.assertThat(
-                    ex.getFailureReason(), Matchers.equalTo("password is required."));
+                    ex.getFailureReason(), Matchers.equalTo("\"password\" is required."));
         }
 
         @Test
@@ -155,7 +155,7 @@ class TargetCredentialsPostHandlerTest {
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
             MatcherAssert.assertThat(
                     ex.getFailureReason(),
-                    Matchers.equalTo("username is required. password is required."));
+                    Matchers.equalTo("\"username\" is required. \"password\" is required."));
         }
 
         @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -40,17 +40,8 @@ package io.cryostat.net.web.http.api.v2;
 import java.io.IOException;
 import java.util.Map;
 
-import io.cryostat.MainModule;
-import io.cryostat.configuration.CredentialsManager;
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.Credentials;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.web.http.HttpMimeType;
-import io.cryostat.net.web.http.api.ApiVersion;
-
 import com.google.gson.Gson;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpMethod;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -58,9 +49,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
 class TargetCredentialsPostHandlerTest {
@@ -126,8 +129,52 @@ class TargetCredentialsPostHandlerTest {
                     ex.getFailureReason(), Matchers.equalTo("\"username\" is required."));
         }
 
+        @ParameterizedTest
+        @ValueSource(strings={
+            "",
+            " ",
+            "\t",
+            "\n"
+        })
+        void shouldRespond400WhenUsernameBlank() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("password", "abc123");
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("\"username\" is required."));
+        }
+
         @Test
         void shouldRespond400WhenPasswordOmitted() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("username", "adminuser");
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(
+                    ex.getFailureReason(), Matchers.equalTo("\"password\" is required."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings={
+            "",
+            " ",
+            "\t",
+            "\n"
+        })
+        void shouldRespond400WhenPasswordBlank() throws Exception {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", "fooTarget"));
 
             MultiMap form = MultiMap.caseInsensitiveMultiMap();


### PR DESCRIPTION
This addresses the following deficiency in the auto-rules draft PR #416:

`POST /api/v2/targets/:targetId/credentials`

> When both the username and password are missing, the error message only says that the username is missing. It would be better if both missing parameters were mentioned.