### PR TITLE
Fix previously hidden unit test failures

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
@@ -108,7 +108,7 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
         MultiMap attrs = ctx.request().formAttributes();
         if (attrs.contains("toDisk")) {
             Matcher m = bool.matcher(attrs.get("toDisk"));
-            if (!m.find()) throw new HttpStatusException(400, "Invalid options");
+            if (!m.matches()) throw new HttpStatusException(400, "Invalid options");
         }
         Arrays.asList("maxAge", "maxSize")
                 .forEach(

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -177,7 +177,7 @@ class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                                 if (attrs.contains("toDisk")) {
                                     Pattern bool = Pattern.compile("true|false");
                                     Matcher m = bool.matcher(attrs.get("toDisk"));
-                                    if (!m.find())
+                                    if (!m.matches())
                                         throw new HttpStatusException(400, "Invalid options");
                                     builder = builder.toDisk(Boolean.valueOf(attrs.get("toDisk")));
                                 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
@@ -168,12 +168,10 @@ class TargetRecordingOptionsPatchHandlerTest {
 
     private static Stream<Map<String, String>> getRequestMaps() {
         return Stream.of(
-                Map.of("toDisk", null),
                 Map.of("toDisk", ""),
                 Map.of("toDisk", "5"),
                 Map.of("toDisk", "T"),
                 Map.of("toDisk", "false1"),
-                Map.of("maxAge", null),
                 Map.of("maxAge", ""),
                 Map.of("maxAge", "true"),
                 Map.of("maxAge", "1e3"),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -323,13 +323,20 @@ class TargetRecordingsPostHandlerTest {
                                                 arg0.getArgument(1))
                                         .execute(connection));
         Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordings()).thenReturn(Arrays.asList(existingRecording));
+        RecordingOptionsBuilder recordingOptionsBuilder =
+                Mockito.mock(RecordingOptionsBuilder.class);
+        Mockito.when(recordingOptionsBuilderFactory.create(Mockito.any()))
+                .thenReturn(recordingOptionsBuilder);
+        Mockito.when(recordingOptionsBuilder.name(Mockito.any()))
+                .thenReturn(recordingOptionsBuilder);
 
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:9091");
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         attrs.addAll(requestValues);
-        attrs.add("recordingName", "someRecording");
+        attrs.add("recordingName", "testRecording");
         attrs.add("events", "foo.Bar:enabled=true");
         Mockito.when(req.formAttributes()).thenReturn(attrs);
 
@@ -340,16 +347,13 @@ class TargetRecordingsPostHandlerTest {
 
     private static Stream<Map<String, String>> getRequestMaps() {
         return Stream.of(
-                Map.of("duration", null),
                 Map.of("duration", ""),
                 Map.of("duration", "t"),
                 Map.of("duration", "90s"),
-                Map.of("toDisk", null),
                 Map.of("toDisk", ""),
                 Map.of("toDisk", "5"),
                 Map.of("toDisk", "T"),
                 Map.of("toDisk", "false1"),
-                Map.of("maxAge", null),
                 Map.of("maxAge", ""),
                 Map.of("maxAge", "true"),
                 Map.of("maxAge", "1e3"),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -323,7 +323,9 @@ class TargetRecordingsPostHandlerTest {
                                                 arg0.getArgument(1))
                                         .execute(connection));
         Mockito.when(connection.getService()).thenReturn(service);
-        Mockito.when(service.getAvailableRecordings()).thenReturn(Arrays.asList(existingRecording));
+        Mockito.when(service.getAvailableRecordings())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Arrays.asList(existingRecording));
         RecordingOptionsBuilder recordingOptionsBuilder =
                 Mockito.mock(RecordingOptionsBuilder.class);
         Mockito.when(recordingOptionsBuilderFactory.create(Mockito.any()))
@@ -336,7 +338,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         attrs.addAll(requestValues);
-        attrs.add("recordingName", "testRecording");
+        attrs.add("recordingName", "someRecording");
         attrs.add("events", "foo.Bar:enabled=true");
         Mockito.when(req.formAttributes()).thenReturn(attrs);
 


### PR DESCRIPTION
Resolve failures in invalid recording options testing that were previously hidden due to errors in Surefire/Failsafe test runner plugins. These errors have already been resolved by @andrewazores in #503.  

Fixes #502 