### PR TITLE
[autorules] Cancel periodic archivers on failure

### DIFF
--- a/src/main/java/io/cryostat/rules/PeriodicArchiver.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiver.java
@@ -46,17 +46,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.http.client.utils.URLEncodedUtils;
-
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.util.HttpStatusCodeIdentifier;
+
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 class PeriodicArchiver implements Runnable {
 

--- a/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
@@ -39,10 +39,11 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.platform.ServiceRef;
-
 import io.vertx.core.MultiMap;
 import io.vertx.ext.web.client.WebClient;
 
@@ -59,8 +60,9 @@ class PeriodicArchiverFactory {
         this.logger = logger;
     }
 
-    PeriodicArchiver create(ServiceRef serviceRef, Credentials credentials, Rule rule) {
+    PeriodicArchiver create(ServiceRef serviceRef, Credentials credentials, Rule rule,
+            Function<Pair<ServiceRef, Rule>, Void> failureNotifier) {
         return new PeriodicArchiver(
-                serviceRef, credentials, rule, webClient, headersFactory, logger);
+                serviceRef, credentials, rule, webClient, headersFactory, failureNotifier, logger);
     }
 }

--- a/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
@@ -39,13 +39,13 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.platform.ServiceRef;
+
 import io.vertx.core.MultiMap;
 import io.vertx.ext.web.client.WebClient;
+import org.apache.commons.lang3.tuple.Pair;
 
 class PeriodicArchiverFactory {
 
@@ -60,7 +60,10 @@ class PeriodicArchiverFactory {
         this.logger = logger;
     }
 
-    PeriodicArchiver create(ServiceRef serviceRef, Credentials credentials, Rule rule,
+    PeriodicArchiver create(
+            ServiceRef serviceRef,
+            Credentials credentials,
+            Rule rule,
             Function<Pair<ServiceRef, Rule>, Void> failureNotifier) {
         return new PeriodicArchiver(
                 serviceRef, credentials, rule, webClient, headersFactory, failureNotifier, logger);

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -199,7 +199,9 @@ public class RuleProcessor
                                     Pair.of(tde.getServiceRef(), rule),
                                     scheduler.scheduleAtFixedRate(
                                             periodicArchiverFactory.create(
-                                                    tde.getServiceRef(), credentials, rule,
+                                                    tde.getServiceRef(),
+                                                    credentials,
+                                                    rule,
                                                     this::archivalFailureHandler),
                                             rule.getArchivalPeriodSeconds(),
                                             rule.getArchivalPeriodSeconds(),
@@ -208,8 +210,7 @@ public class RuleProcessor
     }
 
     private Void archivalFailureHandler(Pair<ServiceRef, Rule> id) {
-        Iterator<Map.Entry<Pair<ServiceRef, Rule>, Future<?>>> it =
-            tasks.entrySet().iterator();
+        Iterator<Map.Entry<Pair<ServiceRef, Rule>, Future<?>>> it = tasks.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Pair<ServiceRef, Rule>, Future<?>> entry = it.next();
             if (!Objects.equals(entry.getKey(), id)) {

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -210,17 +210,9 @@ public class RuleProcessor
     }
 
     private Void archivalFailureHandler(Pair<ServiceRef, Rule> id) {
-        Iterator<Map.Entry<Pair<ServiceRef, Rule>, Future<?>>> it = tasks.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<Pair<ServiceRef, Rule>, Future<?>> entry = it.next();
-            if (!Objects.equals(entry.getKey(), id)) {
-                continue;
-            }
-            Future<?> task = entry.getValue();
-            if (task != null) {
-                task.cancel(true);
-            }
-            it.remove();
+        Future<?> task = tasks.get(id);
+        if (task != null) {
+            task.cancel(true);
         }
         return null;
     }

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -90,7 +90,7 @@ class PeriodicArchiverTest {
         this.serviceRef = new ServiceRef(new JMXServiceURL(jmxUrl), "com.example.App");
         this.archiver =
                 new PeriodicArchiver(
-                        serviceRef, credentials, rule, webClient, c -> headers, logger);
+                        serviceRef, credentials, rule, webClient, c -> headers, p -> null, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -41,6 +41,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.management.remote.JMXServiceURL;
 
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
+import io.cryostat.platform.ServiceRef;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -53,17 +64,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.Credentials;
-import io.cryostat.platform.ServiceRef;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
 
 @ExtendWith(MockitoExtension.class)
 class PeriodicArchiverTest {
@@ -94,8 +94,16 @@ class PeriodicArchiverTest {
         this.failureCounter = new AtomicInteger();
         this.archiver =
                 new PeriodicArchiver(
-                        serviceRef, credentials, rule, webClient, c -> headers, p ->
-                        { failureCounter.incrementAndGet(); return null; }, logger);
+                        serviceRef,
+                        credentials,
+                        rule,
+                        webClient,
+                        c -> headers,
+                        p -> {
+                            failureCounter.incrementAndGet();
+                            return null;
+                        },
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -167,21 +167,9 @@ class PeriodicArchiverTest {
                 .sendBuffer(Mockito.any(), Mockito.any());
 
         MatcherAssert.assertThat(failureCounter.intValue(), Matchers.equalTo(0));
+
         archiver.run();
 
-        ArgumentCaptor<Buffer> patchActionCaptor = ArgumentCaptor.forClass(Buffer.class);
-        Mockito.verify(request).sendBuffer(patchActionCaptor.capture(), Mockito.any());
-        Buffer patchAction = patchActionCaptor.getValue();
-        MatcherAssert.assertThat(patchAction.toString(), Matchers.equalTo("save"));
-
-        ArgumentCaptor<MultiMap> headersCaptor = ArgumentCaptor.forClass(MultiMap.class);
-        Mockito.verify(request).putHeaders(headersCaptor.capture());
-        MultiMap capturedHeaders = headersCaptor.getValue();
-        MatcherAssert.assertThat(capturedHeaders, Matchers.sameInstance(headers));
-
-        Mockito.verify(webClient)
-                .patch(
-                        "/api/v1/targets/service:jmx:rmi:%2F%2Flocalhost:9091%2Fjndi%2Frmi:%2F%2FfooHost:9091%2Fjmxrmi/recordings/auto_Test_Rule");
         MatcherAssert.assertThat(failureCounter.intValue(), Matchers.equalTo(1));
     }
 

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -163,8 +163,9 @@ class RuleProcessorTest {
         Mockito.when(registry.getRules(serviceRef)).thenReturn(Set.of(rule));
 
         PeriodicArchiver periodicArchiver = Mockito.mock(PeriodicArchiver.class);
-        Mockito.when(periodicArchiverFactory.create(Mockito.any(), Mockito.any(), Mockito.any(),
-                    Mockito.any()))
+        Mockito.when(
+                        periodicArchiverFactory.create(
+                                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(periodicArchiver);
 
         processor.accept(tde);

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -40,7 +40,9 @@ package io.cryostat.rules;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import javax.management.remote.JMXServiceURL;
 
@@ -61,6 +63,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.multipart.MultipartForm;
 import io.vertx.ext.web.multipart.impl.FormDataPartImpl;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -194,5 +197,80 @@ class RuleProcessorTest {
         MatcherAssert.assertThat(capturedHeaders, Matchers.sameInstance(headers));
 
         Mockito.verify(scheduler).scheduleAtFixedRate(periodicArchiver, 67, 67, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testTaskCancellationOnFailure() throws Exception {
+        HttpRequest<Buffer> request = Mockito.mock(HttpRequest.class);
+        HttpResponse<Buffer> response = Mockito.mock(HttpResponse.class);
+        Mockito.when(response.statusCode()).thenReturn(200);
+
+        Mockito.when(webClient.post(Mockito.any())).thenReturn(request);
+        Mockito.when(request.putHeaders(Mockito.any())).thenReturn(request);
+        Mockito.doAnswer(
+                        new Answer<Void>() {
+                            @Override
+                            public Void answer(InvocationOnMock invocation) throws Throwable {
+                                AsyncResult res = Mockito.mock(AsyncResult.class);
+                                Mockito.when(res.failed()).thenReturn(false);
+                                Mockito.when(res.result()).thenReturn(response);
+                                ((Handler<AsyncResult>) invocation.getArgument(1)).handle(res);
+                                return null;
+                            }
+                        })
+                .when(request)
+                .sendMultipartForm(Mockito.any(), Mockito.any());
+
+        String jmxUrl = "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi";
+        ServiceRef serviceRef = new ServiceRef(new JMXServiceURL(jmxUrl), "com.example.App");
+
+        Credentials credentials = new Credentials("foouser", "barpassword");
+        Mockito.when(credentialsManager.getCredentials(jmxUrl)).thenReturn(credentials);
+
+        TargetDiscoveryEvent tde = new TargetDiscoveryEvent(EventKind.FOUND, serviceRef);
+
+        Rule rule =
+                new Rule.Builder()
+                        .name("Test Rule")
+                        .description("Automated unit test rule")
+                        .targetAlias("com.example.App")
+                        .eventSpecifier("template=Continuous")
+                        .maxAgeSeconds(30)
+                        .maxSizeBytes(1234)
+                        .preservedArchives(5)
+                        .archivalPeriodSeconds(67)
+                        .build();
+
+        Mockito.when(registry.getRules(serviceRef)).thenReturn(Set.of(rule));
+
+        PeriodicArchiver periodicArchiver = Mockito.mock(PeriodicArchiver.class);
+        Mockito.when(
+                        periodicArchiverFactory.create(
+                                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(periodicArchiver);
+
+        ScheduledFuture task = Mockito.mock(ScheduledFuture.class);
+        Mockito.when(
+                        scheduler.scheduleAtFixedRate(
+                                Mockito.any(Runnable.class),
+                                Mockito.anyLong(),
+                                Mockito.anyLong(),
+                                Mockito.any(TimeUnit.class)))
+                .thenReturn(task);
+
+        processor.accept(tde);
+
+        Mockito.verify(scheduler).scheduleAtFixedRate(periodicArchiver, 67, 67, TimeUnit.SECONDS);
+
+        ArgumentCaptor<Function<Pair<ServiceRef, Rule>, Void>> functionCaptor =
+                ArgumentCaptor.forClass(Function.class);
+        Mockito.verify(periodicArchiverFactory)
+                .create(Mockito.any(), Mockito.any(), Mockito.any(), functionCaptor.capture());
+        Function<Pair<ServiceRef, Rule>, Void> failureFunction = functionCaptor.getValue();
+        Mockito.verify(task, Mockito.never()).cancel(Mockito.anyBoolean());
+
+        failureFunction.apply(Pair.of(serviceRef, rule));
+
+        Mockito.verify(task).cancel(true);
     }
 }

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -163,7 +163,8 @@ class RuleProcessorTest {
         Mockito.when(registry.getRules(serviceRef)).thenReturn(Set.of(rule));
 
         PeriodicArchiver periodicArchiver = Mockito.mock(PeriodicArchiver.class);
-        Mockito.when(periodicArchiverFactory.create(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(periodicArchiverFactory.create(Mockito.any(), Mockito.any(), Mockito.any(),
+                    Mockito.any()))
                 .thenReturn(periodicArchiver);
 
         processor.accept(tde);


### PR DESCRIPTION
Addresses the following deficiency from the original #416 review:

`General`
> Deleting the recording created by an automatic rule causes an exception whenever the archiver tries to archive the recording (expectedly). I imagine there's no good way to protect that recording from being deleting, but maybe there is a way to stop the archiver if the recording does get deleted? It does seem unlikely that a user would accidentally delete the automatic recording, though.

This PR adds a callback failure handler function from the archivers back "up" to the RuleProcessor, which the archivers use to notify the processor if archival attempts fail. This can be due to IOExceptions on writing the archives, or because the source `auto_foo` recording has been deleted elsewhere, or any other reason. This can also extend to the case where the user has deleted the stored credentials in the target in another upcoming PR.

Currently the archivers simply notify the processor that a failure occurred, but they do not provide information about the specific failure cause. The processor always cancels the scheduled task corresponding to a failing archiver on the first failure as well. It may make sense in the future to enhance this so that the archivers provide failure causes to the processor, which can be more intelligent about the cancellation behaviour - ex. cancel after X number of failures occur (reset after a success?), re-schedule after cancellation for certain types of failure, etc.