### PR TITLE
[autorules] Credentials deletion enhancements

### DIFF
--- a/rulestest.sh
+++ b/rulestest.sh
@@ -42,7 +42,7 @@ curl -k \
     -F targetAlias="es.andrewazor.demo.Main" \
     -F description="This is a test rule" \
     -F eventSpecifier="template=Continuous,type=TARGET" \
-    -F archivalPeriodSeconds="60" \
+    -F archivalPeriodSeconds="5" \
     -F preservedArchives="3" \
     "$CRYOSTAT_HOST/api/v2/rules"
 
@@ -67,3 +67,9 @@ podman run \
     --env JMX_PORT=9094 \
     --env USE_AUTH=true \
     --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
+
+sleep 15
+echo "Deleting credentials"
+curl -k \
+    -X DELETE \
+    "$CRYOSTAT_HOST/api/v2/targets/$demoAppTargetId/credentials"

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -114,9 +114,10 @@ public class CredentialsManager {
         return replaced;
     }
 
-    public void removeCredentials(String targetId) throws IOException {
-        this.credentialsMap.remove(targetId);
+    public boolean removeCredentials(String targetId) throws IOException {
+        Credentials deleted = this.credentialsMap.remove(targetId);
         fs.deleteIfExists(getPersistedPath(targetId));
+        return deleted != null;
     }
 
     public Credentials getCredentials(String targetId) {

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.core.sys.FileSystem;
+import io.cryostat.platform.ServiceRef;
 
 import com.google.gson.Gson;
 
@@ -122,6 +123,10 @@ public class CredentialsManager {
 
     public Credentials getCredentials(String targetId) {
         return this.credentialsMap.get(targetId);
+    }
+
+    public Credentials getCredentials(ServiceRef serviceRef) {
+        return getCredentials(serviceRef.getJMXServiceUrl().toString());
     }
 
     private Path getPersistedPath(String targetId) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
@@ -101,11 +101,11 @@ class TargetCredentialsDeleteHandler extends AbstractV2RequestHandler<Void> {
     public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
         String targetId = params.getPathParams().get("targetId");
         try {
-            this.credentialsManager.removeCredentials(targetId);
+            boolean status = this.credentialsManager.removeCredentials(targetId);
+            return new IntermediateResponse<Void>().statusCode(status ? 200 : 404);
         } catch (IOException e) {
             throw new ApiException(
                     500, "IOException occurred while clearing persisted credentials", e);
         }
-        return new IntermediateResponse<Void>().body(null);
     }
 }

--- a/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
@@ -39,6 +39,7 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.platform.ServiceRef;
@@ -62,10 +63,16 @@ class PeriodicArchiverFactory {
 
     PeriodicArchiver create(
             ServiceRef serviceRef,
-            Credentials credentials,
+            CredentialsManager credentialsManager,
             Rule rule,
             Function<Pair<ServiceRef, Rule>, Void> failureNotifier) {
         return new PeriodicArchiver(
-                serviceRef, credentials, rule, webClient, headersFactory, failureNotifier, logger);
+                serviceRef,
+                credentialsManager,
+                rule,
+                webClient,
+                headersFactory,
+                failureNotifier,
+                logger);
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -200,7 +200,7 @@ public class RuleProcessor
                                     scheduler.scheduleAtFixedRate(
                                             periodicArchiverFactory.create(
                                                     tde.getServiceRef(),
-                                                    credentials,
+                                                    credentialsManager,
                                                     rule,
                                                     this::archivalFailureHandler),
                                             rule.getArchivalPeriodSeconds(),

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandlerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.io.IOException;
+import java.util.Map;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetCredentialsDeleteHandlerTest {
+
+    AbstractV2RequestHandler<Void> handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new TargetCredentialsDeleteHandler(auth, credentialsManager, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+
+        @Test
+        void shouldRequireAuthentication() {
+            Assertions.assertTrue(handler.requiresAuthentication());
+        }
+
+        @Test
+        void shouldBeV2API() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2));
+        }
+
+        @Test
+        void shouldHaveDELETEMethod() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+        }
+
+        @Test
+        void shouldHaveTargetsPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/v2/targets/:targetId/credentials"));
+        }
+
+        @Test
+        void shouldHaveJsonMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.PLAINTEXT));
+        }
+
+        @Test
+        void shouldNotBeAsync() {
+            Assertions.assertFalse(handler.isAsync());
+        }
+
+        @Test
+        void shouldBeOrdered() {
+            Assertions.assertTrue(handler.isOrdered());
+        }
+    }
+
+    @Nested
+    class RequestExecutions {
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldRespond200OnSuccess() throws Exception {
+            String targetId = "fooTarget";
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+            Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
+                    .thenReturn(true);
+
+            IntermediateResponse<Void> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            Mockito.verify(credentialsManager).removeCredentials(targetId);
+        }
+
+        @Test
+        void shouldRespond404OnFailure() throws Exception {
+            String targetId = "fooTarget";
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+            Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
+                    .thenReturn(false);
+
+            IntermediateResponse<Void> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(404));
+            Mockito.verify(credentialsManager).removeCredentials(targetId);
+        }
+
+        @Test
+        void shouldWrapIOExceptions() throws Exception {
+            String targetId = "fooTarget";
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+            Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
+                    .thenThrow(IOException.class);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
+            MatcherAssert.assertThat(ex.getCause(), Matchers.instanceOf(IOException.class));
+            Mockito.verify(credentialsManager).removeCredentials(targetId);
+        }
+    }
+}

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -41,8 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.management.remote.JMXServiceURL;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.Credentials;
 import io.cryostat.platform.ServiceRef;
 
 import io.vertx.core.AsyncResult;
@@ -71,7 +71,7 @@ class PeriodicArchiverTest {
     PeriodicArchiver archiver;
     String jmxUrl = "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi";
     ServiceRef serviceRef;
-    Credentials credentials = new Credentials("foouser", "barpassword");
+    @Mock CredentialsManager credentialsManager;
     Rule rule =
             new Rule.Builder()
                     .name("Test Rule")
@@ -95,7 +95,7 @@ class PeriodicArchiverTest {
         this.archiver =
                 new PeriodicArchiver(
                         serviceRef,
-                        credentials,
+                        credentialsManager,
                         rule,
                         webClient,
                         c -> headers,
@@ -140,6 +140,8 @@ class PeriodicArchiverTest {
         Mockito.verify(request).putHeaders(headersCaptor.capture());
         MultiMap capturedHeaders = headersCaptor.getValue();
         MatcherAssert.assertThat(capturedHeaders, Matchers.sameInstance(headers));
+
+        Mockito.verify(credentialsManager).getCredentials(serviceRef);
 
         Mockito.verify(webClient)
                 .patch(

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -65,6 +65,10 @@ class AutoRulesIT extends TestBase {
     static final List<String> CONTAINERS = new ArrayList<>();
     static final Map<String, String> NULL_RESULT = new HashMap<>();
 
+    final String jmxServiceUrl =
+            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
+    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+
     static {
         NULL_RESULT.put("result", null);
     }
@@ -193,13 +197,7 @@ class AutoRulesIT extends TestBase {
         form.add("username", "admin");
         form.add("password", "adminpass123");
         webClient
-                .post(
-                        String.format(
-                                "/api/v2/targets/%s/credentials",
-                                String.format(
-                                                "service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi",
-                                                Podman.POD_NAME)
-                                        .replaceAll("/", "%2F")))
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
                 .sendForm(
                         form,
                         ar -> {
@@ -293,7 +291,7 @@ class AutoRulesIT extends TestBase {
     void testCredentialsCanBeDeleted() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
-                .delete(String.format("/api/v2/targets/%s/credentials", Podman.POD_NAME + ":9093"))
+                .delete(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
                 .send(
                         ar -> {
                             if (assertRequestStatus(ar, response)) {


### PR DESCRIPTION
This addresses the following review deficiencies from #416 :

`DELETE /api/v2/targets/:targetId/credentials`

> Maybe the response could specify if credentials were found and deleted, or if there were no credentials to be deleted? Not super important, but might be helpful.

~~(TODO):~~
> When a rule for a target is running, and I delete the credentials for that target, the archiver is still able to archive recordings, despite the fact that JMX auth is required for this, and the saved JMX auth credentials have been deleted. I see that this is because in the code, the credentials are given to the PeriodicArchiver in the constructor and saved to the object, not retreived from the CredentialsManager each time it is used. This is more efficient, but I'm wondering if it makes sense from the user's point of view. If they deleted some credentials, would they expect for CJFR to not have a copy of those credentials stored anywhere, anymore? Or at least not be able to use it?