### PR TITLE
Remove empty ssl file upload

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -166,6 +166,9 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
         } catch (CertificateEncodingException cee) {
             throw new ApiException(500, cee.getMessage(), cee);
         } catch (Exception e) {
+            if(fs.exists(filePath)) {
+                filePath.toFile().delete();
+            }
             throw new ApiException(500, e.getMessage(), e);
         }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -166,7 +166,7 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
         } catch (CertificateEncodingException cee) {
             throw new ApiException(500, cee.getMessage(), cee);
         } catch (Exception e) {
-            if(fs.exists(filePath)) {
+            if (fs.exists(filePath)) {
                 filePath.toFile().delete();
             }
             throw new ApiException(500, e.getMessage(), e);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -45,7 +45,6 @@ import java.nio.file.Path;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.function.Function;
 
 import javax.inject.Inject;
@@ -154,10 +153,13 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
         try (InputStream fis = fs.newInputStream(certPath)) {
             Collection<? extends Certificate> certificates = certValidator.parseCertificates(fis);
 
+            if (certificates.isEmpty()) {
+                throw new ApiException(500, "No certificates found");
+            }
+
             try (FileOutputStream out = outputStreamFunction.apply(filePath.toFile())) {
-                Iterator<? extends Certificate> it = certificates.iterator();
-                while (it.hasNext()) {
-                    Certificate certificate = (Certificate) it.next();
+
+                for (Certificate certificate : certificates) {
                     byte[] buf = certificate.getEncoded();
                     out.write(buf);
                 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -166,12 +166,18 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
         } catch (CertificateEncodingException cee) {
             throw new ApiException(500, cee.getMessage(), cee);
         } catch (Exception e) {
-            if (fs.exists(filePath)) {
-                filePath.toFile().delete();
-            }
+            deleteMalformedCert(filePath, e);
             throw new ApiException(500, e.getMessage(), e);
         }
 
         return new IntermediateResponse<Path>().body(filePath);
+    }
+
+    private void deleteMalformedCert(Path filePath, Exception e) {
+        if (fs.exists(filePath)) {
+            if (!filePath.toFile().delete()) {
+                throw new ApiException(500, e.getMessage(), e);
+            }
+        }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -154,14 +154,15 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
         try (InputStream fis = fs.newInputStream(certPath)) {
             Collection<? extends Certificate> certificates = certValidator.parseCertificates(fis);
 
-            FileOutputStream out = outputStreamFunction.apply(filePath.toFile());
-
-            Iterator<? extends Certificate> it = certificates.iterator();
-            while (it.hasNext()) {
-                Certificate certificate = (Certificate) it.next();
-                byte[] buf = certificate.getEncoded();
-                out.write(buf);
+            try (FileOutputStream out = outputStreamFunction.apply(filePath.toFile())) {
+                Iterator<? extends Certificate> it = certificates.iterator();
+                while (it.hasNext()) {
+                    Certificate certificate = (Certificate) it.next();
+                    byte[] buf = certificate.getEncoded();
+                    out.write(buf);
+                }
             }
+
         } catch (IOException ioe) {
             throw new ApiException(500, ioe.getMessage(), ioe);
         } catch (CertificateEncodingException cee) {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
@@ -93,8 +94,8 @@ class CertificatePostHandlerTest {
 
     @Mock RoutingContext ctx;
     @Mock FileOutputStream outStream;
+    @Mock Function<File, FileOutputStream> outputStreamFunction;
     @Mock FileUpload fu;
-    @Mock File malformed;
     @Mock Path truststorePath;
     @Mock Path fileUploadPath;
     @Mock CertificateValidator certValidator;
@@ -184,7 +185,8 @@ class CertificatePostHandlerTest {
 
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getFailureReason(), Matchers.equalTo("parsing error"));
-        Mockito.verify(outStream, Mockito.times(0)).write(Mockito.any());
+        Mockito.verify(outputStreamFunction, Mockito.never()).apply(Mockito.any());
+        Mockito.verify(outStream, Mockito.never()).write(Mockito.any());
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -175,17 +175,16 @@ class CertificatePostHandlerTest {
         Mockito.when(env.getEnv(Mockito.any())).thenReturn("/truststore");
         Mockito.when(fs.pathOf("/truststore", "certificate.cer")).thenReturn(truststorePath);
         Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
-        Mockito.when(fs.exists(Mockito.any())).thenReturn(false, true);
+        Mockito.when(fs.exists(Mockito.any())).thenReturn(false);
 
         InputStream instream = new ByteArrayInputStream("not a certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
         Mockito.when(certValidator.parseCertificates(Mockito.any()))
                 .thenThrow(new CertificateException("parsing error"));
-        Mockito.when(truststorePath.toFile()).thenReturn(malformed);
 
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getFailureReason(), Matchers.equalTo("parsing error"));
-        Mockito.verify(malformed, Mockito.times(1)).delete();
+        Mockito.verify(outStream, Mockito.times(0)).write(Mockito.any());
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -106,7 +106,8 @@ class CertificatePostHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new CertificatePostHandler(auth, env, fs, gson, outputStreamFunction, certValidator);
+                new CertificatePostHandler(
+                        auth, env, fs, gson, outputStreamFunction, certValidator);
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
@@ -225,6 +226,5 @@ class CertificatePostHandlerTest {
         ApiResponse expected = new ApiResponse(meta, data);
 
         Mockito.verify(resp).end(gson.toJson(expected));
-
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -106,7 +106,7 @@ class CertificatePostHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new CertificatePostHandler(auth, env, fs, gson, (file) -> outStream, certValidator);
+                new CertificatePostHandler(auth, env, fs, gson, outputStreamFunction, certValidator);
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
@@ -205,6 +205,8 @@ class CertificatePostHandlerTest {
 
         InputStream instream = new ByteArrayInputStream("certificate".getBytes());
         Mockito.when(fs.newInputStream(fileUploadPath)).thenReturn(instream);
+
+        Mockito.when(outputStreamFunction.apply(Mockito.any())).thenReturn(outStream);
         Mockito.when(certValidator.parseCertificates(Mockito.any())).thenReturn(certificates);
         Mockito.when(certificates.iterator()).thenReturn(iterator);
         Mockito.when(iterator.hasNext()).thenReturn(true).thenReturn(false);
@@ -223,5 +225,6 @@ class CertificatePostHandlerTest {
         ApiResponse expected = new ApiResponse(meta, data);
 
         Mockito.verify(resp).end(gson.toJson(expected));
+
     }
 }

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.multipart.MultipartForm;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class UploadCertificateIT extends TestBase {
+
+    static final String CERT_NAME = "cert";
+    static final String FILE_NAME = "cert.cer";
+    static final String UPLOAD_PATH = "/home/jalaw/Downloads/";
+    static final String TRUSTSTORE_PATH = "/truststore/";
+    static final String MEDIA_TYPE = "application/pkix-cert";
+
+    @Test
+    public void shouldNotAddMalformedCertToTrustStore() throws Exception {
+
+        CompletableFuture<Integer> uploadRespFuture = new CompletableFuture<>();
+        File cert = new File(UPLOAD_PATH + FILE_NAME);
+        MultipartForm form =
+                MultipartForm.create()
+                        .attribute("name", CERT_NAME)
+                        .binaryFileUpload(
+                                CERT_NAME, FILE_NAME, UPLOAD_PATH + FILE_NAME, MEDIA_TYPE);
+
+        webClient
+                .post(String.format("/api/v2/certificates"))
+                .sendMultipartForm(
+                        form,
+                        ar -> {
+                            if (ar.failed()) {
+                                uploadRespFuture.completeExceptionally(ar.cause());
+                                return;
+                            }
+                            HttpResponse<Buffer> result = ar.result();
+                            uploadRespFuture.complete(result.statusCode());
+                        });
+
+        int statusCode = uploadRespFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        MatcherAssert.assertThat(statusCode, Matchers.equalTo(500));
+        File truststoreCert = new File(TRUSTSTORE_PATH + FILE_NAME);
+        MatcherAssert.assertThat(truststoreCert.exists(), Matchers.equalTo(false));
+    }
+}

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -56,7 +56,7 @@ public class UploadCertificateIT extends TestBase {
     static final String MEDIA_TYPE = "application/pkix-cert";
 
     @Test
-    public void shouldNotAddMalformedCertToTrustStore() throws Exception {
+    public void shouldNotAddEmptyCertToTrustStore() throws Exception {
 
         CompletableFuture<Integer> uploadRespFuture = new CompletableFuture<>();
         ClassLoader classLoader = getClass().getClassLoader();

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -84,6 +84,5 @@ public class UploadCertificateIT extends TestBase {
         int statusCode = uploadRespFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         MatcherAssert.assertThat(statusCode, Matchers.equalTo(500));
-        MatcherAssert.assertThat(classLoader.getResource(TRUSTSTORE_CERT), Matchers.equalTo(null));
     }
 }


### PR DESCRIPTION
Fixes #494 

I'd appreciate some feedback to make the code more readable. 

After the `certValidator` tries to parse the cert and throws an exception,`filePath.toFile().delete()` returns false if it failed. I'm not sure what's the cleanest way to handle this error since it's already in a `try/catch` block?
