### PR TITLE
Loosen ServiceRef JMXServiceURL coupling

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
@@ -39,6 +39,7 @@ package io.cryostat.net.web.http.api.v1;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -58,6 +59,7 @@ import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.PlatformClient;
+import io.cryostat.util.URIUtil;
 
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
@@ -140,10 +142,12 @@ class TargetRecordingPatchSave {
                                 serviceRef -> {
                                     try {
                                         return serviceRef
-                                                        .getJMXServiceUrl()
-                                                        .equals(connection.getJMXURL())
+                                                        .getServiceUri()
+                                                        .equals(
+                                                                URIUtil.convert(
+                                                                        connection.getJMXURL()))
                                                 && serviceRef.getAlias().isPresent();
-                                    } catch (IOException ioe) {
+                                    } catch (URISyntaxException | IOException ioe) {
                                         return false;
                                     }
                                 })

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
@@ -38,15 +38,16 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.inject.Inject;
-import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.platform.internal.CustomTargetPlatformClient;
+import io.cryostat.util.URIUtil;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
@@ -105,13 +106,13 @@ class TargetDeleteHandler extends AbstractV2RequestHandler<Void> {
             if (StringUtils.isBlank(targetId)) {
                 throw new ApiException(400, "Invalid targetId");
             }
-            JMXServiceURL serviceUrl = new JMXServiceURL(targetId);
-            if (!customTargetPlatformClient.removeTarget(serviceUrl)) {
+            URI uri = URIUtil.createAbsolute(targetId);
+            if (!customTargetPlatformClient.removeTarget(uri)) {
                 throw new ApiException(404);
             }
             return new IntermediateResponse<Void>().body(null);
-        } catch (MalformedURLException mue) {
-            throw new ApiException(400, "Invalid targetId", mue);
+        } catch (URISyntaxException use) {
+            throw new ApiException(400, "Invalid targetId", use);
         } catch (IOException ioe) {
             throw new ApiException(500, "Internal Error", ioe);
         }

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -42,8 +42,6 @@ import java.util.Optional;
 
 import javax.management.remote.JMXServiceURL;
 
-import io.cryostat.core.net.JFRConnectionToolkit;
-
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -61,11 +59,6 @@ public class ServiceRef {
 
     public ServiceRef(JMXServiceURL jmxServiceUrl) throws MalformedURLException {
         this(jmxServiceUrl, null);
-    }
-
-    public ServiceRef(JFRConnectionToolkit toolkit, String host, int port, String alias)
-            throws MalformedURLException {
-        this(toolkit.createServiceURL(host, port), alias);
     }
 
     public JMXServiceURL getJMXServiceUrl() {

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -38,12 +38,7 @@
 package io.cryostat.platform;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Optional;
-
-import javax.management.remote.JMXServiceURL;
-
-import io.cryostat.util.URIUtil;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -58,10 +53,6 @@ public class ServiceRef {
     public ServiceRef(URI uri, String alias) {
         this.serviceUri = uri;
         this.alias = alias;
-    }
-
-    public ServiceRef(JMXServiceURL jmxServiceUrl, String alias) throws URISyntaxException {
-        this(URIUtil.convert(jmxServiceUrl), alias);
     }
 
     public URI getServiceUri() {

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -57,10 +57,6 @@ public class ServiceRef {
         this.alias = alias;
     }
 
-    public ServiceRef(JMXServiceURL jmxServiceUrl) throws MalformedURLException {
-        this(jmxServiceUrl, null);
-    }
-
     public JMXServiceURL getJMXServiceUrl() {
         return JMXServiceURL;
     }

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -39,6 +39,7 @@ package io.cryostat.platform.internal;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -48,7 +49,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import javax.inject.Named;
-import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
@@ -74,12 +74,7 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
             FileSystem fs,
             Gson gson) {
         super(notificationFactory);
-        this.targets =
-                new TreeSet<>(
-                        (u1, u2) ->
-                                u1.getJMXServiceUrl()
-                                        .toString()
-                                        .compareTo(u2.getJMXServiceUrl().toString()));
+        this.targets = new TreeSet<>((u1, u2) -> u1.getServiceUri().compareTo(u2.getServiceUri()));
         this.saveFile = confDir.resolve(SAVEFILE_NAME);
         this.fs = fs;
         this.gson = gson;
@@ -121,10 +116,10 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
         return v;
     }
 
-    public boolean removeTarget(JMXServiceURL connectUrl) throws IOException {
+    public boolean removeTarget(URI connectUrl) throws IOException {
         ServiceRef ref = null;
         for (ServiceRef target : targets) {
-            if (Objects.equals(connectUrl, target.getJMXServiceUrl())) {
+            if (Objects.equals(connectUrl, target.getServiceUri())) {
                 ref = target;
                 break;
             }

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -39,6 +39,7 @@ package io.cryostat.platform.internal;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -77,7 +78,7 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
                             evt.getJvmDescriptor().getJmxServiceUrl(),
                             evt.getJvmDescriptor().getMainClass());
             notifyAsyncTargetDiscovery(evt.getEventKind(), serviceRef);
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | URISyntaxException e) {
             logger.warn(e);
         }
     }
@@ -89,7 +90,7 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
                         u -> {
                             try {
                                 return new ServiceRef(u.getJmxServiceUrl(), u.getMainClass());
-                            } catch (MalformedURLException e) {
+                            } catch (MalformedURLException | URISyntaxException e) {
                                 logger.warn(e);
                                 return null;
                             }

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -49,6 +49,7 @@ import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<JvmDiscoveryEvent> {
 
@@ -75,7 +76,7 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
         try {
             ServiceRef serviceRef =
                     new ServiceRef(
-                            evt.getJvmDescriptor().getJmxServiceUrl(),
+                            URIUtil.convert(evt.getJvmDescriptor().getJmxServiceUrl()),
                             evt.getJvmDescriptor().getMainClass());
             notifyAsyncTargetDiscovery(evt.getEventKind(), serviceRef);
         } catch (MalformedURLException | URISyntaxException e) {
@@ -89,7 +90,8 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
                 .map(
                         u -> {
                             try {
-                                return new ServiceRef(u.getJmxServiceUrl(), u.getMainClass());
+                                return new ServiceRef(
+                                        URIUtil.convert(u.getJmxServiceUrl()), u.getMainClass());
                             } catch (MalformedURLException | URISyntaxException e) {
                                 logger.warn(e);
                                 return null;

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -49,6 +49,7 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import dagger.Lazy;
 import io.fabric8.kubernetes.api.model.EndpointPort;
@@ -174,9 +175,11 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
                         addr -> {
                             try {
                                 return new ServiceRef(
-                                        connectionToolkit
-                                                .get()
-                                                .createServiceURL(addr.getIp(), port.getPort()),
+                                        URIUtil.convert(
+                                                connectionToolkit
+                                                        .get()
+                                                        .createServiceURL(
+                                                                addr.getIp(), port.getPort())),
                                         addr.getTargetRef().getName());
                             } catch (Exception e) {
                                 logger.warn(e);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -174,9 +174,9 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
                         addr -> {
                             try {
                                 return new ServiceRef(
-                                        connectionToolkit.get(),
-                                        addr.getIp(),
-                                        port.getPort(),
+                                        connectionToolkit
+                                                .get()
+                                                .createServiceURL(addr.getIp(), port.getPort()),
                                         addr.getTargetRef().getName());
                             } catch (Exception e) {
                                 logger.warn(e);

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -87,7 +87,8 @@ class KubeEnvPlatformClient implements PlatformClient {
         String alias = matcher.group(1).toLowerCase();
         int port = Integer.parseInt(matcher.group(2));
         try {
-            return new ServiceRef(connectionToolkit.get(), entry.getValue(), port, alias);
+            return new ServiceRef(
+                    connectionToolkit.get().createServiceURL(entry.getValue(), port), alias);
         } catch (Exception e) {
             logger.warn(e);
             return null;

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -50,6 +50,7 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import dagger.Lazy;
 
@@ -88,7 +89,9 @@ class KubeEnvPlatformClient implements PlatformClient {
         int port = Integer.parseInt(matcher.group(2));
         try {
             return new ServiceRef(
-                    connectionToolkit.get().createServiceURL(entry.getValue(), port), alias);
+                    URIUtil.convert(
+                            connectionToolkit.get().createServiceURL(entry.getValue(), port)),
+                    alias);
         } catch (Exception e) {
             logger.warn(e);
             return null;

--- a/src/main/java/io/cryostat/util/RelativeURIException.java
+++ b/src/main/java/io/cryostat/util/RelativeURIException.java
@@ -35,55 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.platform;
+package io.cryostat.util;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Optional;
 
-import javax.management.remote.JMXServiceURL;
-
-import io.cryostat.util.URIUtil;
-
-import com.google.gson.annotations.SerializedName;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
-public class ServiceRef {
-
-    private final @SerializedName("connectUrl") URI serviceUri;
-    private final String alias;
-
-    public ServiceRef(URI uri, String alias) {
-        this.serviceUri = uri;
-        this.alias = alias;
-    }
-
-    public ServiceRef(JMXServiceURL jmxServiceUrl, String alias) throws URISyntaxException {
-        this(URIUtil.convert(jmxServiceUrl), alias);
-    }
-
-    public URI getServiceUri() {
-        return serviceUri;
-    }
-
-    public Optional<String> getAlias() {
-        return Optional.ofNullable(alias);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+@SuppressWarnings("serial")
+public class RelativeURIException extends URISyntaxException {
+    public RelativeURIException(URI u) {
+        super(u.toString(), "Not a valid absolute URI");
     }
 }

--- a/src/main/java/io/cryostat/util/URIUtil.java
+++ b/src/main/java/io/cryostat/util/URIUtil.java
@@ -35,69 +35,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.platform.internal;
+package io.cryostat.util;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 
 import javax.management.remote.JMXServiceURL;
 
-import io.cryostat.platform.PlatformClient;
-import io.cryostat.platform.ServiceRef;
+public class URIUtil {
+    private URIUtil() {}
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-class MergingPlatformClientTest {
-
-    @Mock PlatformClient clientA;
-    @Mock PlatformClient clientB;
-    MergingPlatformClient mergingClient;
-
-    @BeforeEach
-    void setup() {
-        this.mergingClient = new MergingPlatformClient(clientA, clientB);
+    public static URI createAbsolute(String uri) throws URISyntaxException, RelativeURIException {
+        URI u = new URI(uri);
+        if (!u.isAbsolute()) {
+            throw new RelativeURIException(u);
+        }
+        return u;
     }
 
-    @Test
-    void testStart() throws IOException {
-        Mockito.verifyNoInteractions(clientA);
-        Mockito.verifyNoInteractions(clientB);
-
-        mergingClient.start();
-
-        Mockito.verify(clientA).start();
-        Mockito.verify(clientB).start();
-    }
-
-    @Test
-    void testMergedDiscoverableServices() throws MalformedURLException, URISyntaxException {
-        ServiceRef serviceA =
-                new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9098/jmxrmi"),
-                        "ServiceA");
-        ServiceRef serviceB =
-                new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi"),
-                        "ServiceB");
-
-        Mockito.when(clientA.listDiscoverableServices()).thenReturn(List.of(serviceA));
-        Mockito.when(clientB.listDiscoverableServices()).thenReturn(List.of(serviceB));
-
-        MatcherAssert.assertThat(
-                mergingClient.listDiscoverableServices(),
-                Matchers.equalTo(List.of(serviceA, serviceB)));
-
-        Mockito.verify(clientA).listDiscoverableServices();
-        Mockito.verify(clientB).listDiscoverableServices();
+    public static URI convert(JMXServiceURL serviceUrl) throws URISyntaxException {
+        return new URI(serviceUrl.toString());
     }
 }

--- a/src/test/java/io/cryostat/net/web/WebServerTest.java
+++ b/src/test/java/io/cryostat/net/web/WebServerTest.java
@@ -69,7 +69,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -154,10 +153,10 @@ class WebServerTest {
     void shouldProvideDownloadUrl(String recordingName) throws URISyntaxException, IOException {
         when(netConf.getWebServerHost()).thenReturn("example.com");
         when(netConf.getExternalWebServerPort()).thenReturn(8181);
-        JMXServiceURL mockJmxUrl = Mockito.mock(JMXServiceURL.class);
-        when(mockJmxUrl.toString())
-                .thenReturn("service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
-        when(connection.getJMXURL()).thenReturn(mockJmxUrl);
+        JMXServiceURL jmxUrl =
+                new JMXServiceURL(
+                        "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
+        when(connection.getJMXURL()).thenReturn(jmxUrl);
 
         MatcherAssert.assertThat(
                 exporter.getDownloadURL(connection, recordingName),
@@ -174,10 +173,10 @@ class WebServerTest {
         when(httpServer.isSsl()).thenReturn(true);
         when(netConf.getWebServerHost()).thenReturn("example.com");
         when(netConf.getExternalWebServerPort()).thenReturn(8181);
-        JMXServiceURL mockJmxUrl = Mockito.mock(JMXServiceURL.class);
-        when(mockJmxUrl.toString())
-                .thenReturn("service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
-        when(connection.getJMXURL()).thenReturn(mockJmxUrl);
+        JMXServiceURL jmxUrl =
+                new JMXServiceURL(
+                        "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
+        when(connection.getJMXURL()).thenReturn(jmxUrl);
 
         MatcherAssert.assertThat(
                 exporter.getDownloadURL(connection, recordingName),
@@ -192,10 +191,10 @@ class WebServerTest {
     void shouldProvideReportUrl(String recordingName) throws URISyntaxException, IOException {
         when(netConf.getWebServerHost()).thenReturn("example.com");
         when(netConf.getExternalWebServerPort()).thenReturn(8181);
-        JMXServiceURL mockJmxUrl = Mockito.mock(JMXServiceURL.class);
-        when(mockJmxUrl.toString())
-                .thenReturn("service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
-        when(connection.getJMXURL()).thenReturn(mockJmxUrl);
+        JMXServiceURL jmxUrl =
+                new JMXServiceURL(
+                        "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
+        when(connection.getJMXURL()).thenReturn(jmxUrl);
 
         MatcherAssert.assertThat(
                 exporter.getReportURL(connection, recordingName),
@@ -226,10 +225,10 @@ class WebServerTest {
         when(httpServer.isSsl()).thenReturn(true);
         when(netConf.getWebServerHost()).thenReturn("example.com");
         when(netConf.getExternalWebServerPort()).thenReturn(8181);
-        JMXServiceURL mockJmxUrl = Mockito.mock(JMXServiceURL.class);
-        when(mockJmxUrl.toString())
-                .thenReturn("service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
-        when(connection.getJMXURL()).thenReturn(mockJmxUrl);
+        JMXServiceURL jmxUrl =
+                new JMXServiceURL(
+                        "service:jmx:rmi://localhost:9091/jndi/rmi://fooHost:9091/jmxrmi");
+        when(connection.getJMXURL()).thenReturn(jmxUrl);
 
         MatcherAssert.assertThat(
                 exporter.getReportURL(connection, recordingName),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
@@ -61,6 +61,7 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
@@ -175,15 +176,21 @@ class TargetRecordingPatchSaveTest {
 
         ServiceRef serviceRef1 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")),
                         "some.Alias.1");
         ServiceRef serviceRef2 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")),
                         "some.Alias.2");
         ServiceRef serviceRef3 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi")),
                         "some.Alias.3");
 
         Mockito.when(platformClient.listDiscoverableServices())
@@ -246,15 +253,21 @@ class TargetRecordingPatchSaveTest {
 
         ServiceRef serviceRef1 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")),
                         "some.Alias.1");
         ServiceRef serviceRef2 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")),
                         null);
         ServiceRef serviceRef3 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi")),
                         "some.Alias.3");
 
         Mockito.when(platformClient.listDiscoverableServices())
@@ -305,11 +318,15 @@ class TargetRecordingPatchSaveTest {
 
         ServiceRef serviceRef1 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")),
                         "some.Alias.1");
         ServiceRef serviceRef3 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi")),
                         "some.Alias.3");
 
         Mockito.when(platformClient.listDiscoverableServices())
@@ -362,15 +379,21 @@ class TargetRecordingPatchSaveTest {
 
         ServiceRef serviceRef1 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")),
                         "some.Alias.1");
         ServiceRef serviceRef2 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")),
                         "some.Alias.2");
         ServiceRef serviceRef3 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi")),
                         "some.Alias.3");
 
         Mockito.when(platformClient.listDiscoverableServices())
@@ -420,15 +443,21 @@ class TargetRecordingPatchSaveTest {
 
         ServiceRef serviceRef1 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")),
                         "some.Alias.1");
         ServiceRef serviceRef2 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")),
                         "some.Alias.2");
         ServiceRef serviceRef3 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi")),
                         "some.Alias.3");
 
         Mockito.when(platformClient.listDiscoverableServices())

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
@@ -250,7 +250,8 @@ class TargetRecordingPatchSaveTest {
                         "some.Alias.1");
         ServiceRef serviceRef2 =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"));
+                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi"),
+                        null);
         ServiceRef serviceRef3 =
                 new ServiceRef(
                         new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi"),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
@@ -107,7 +107,7 @@ class TargetsGetHandlerTest {
                                         String.format("/jndi/rmi://%s:%s/jmxrmi", host, port));
                             }
                         });
-        ServiceRef target = new ServiceRef(connectionToolkit, "foo", 1, "foo");
+        ServiceRef target = new ServiceRef(connectionToolkit.createServiceURL("foo", 1), "foo");
 
         List<ServiceRef> targets = Collections.singletonList(target);
         Mockito.when(platformClient.listDiscoverableServices()).thenReturn(targets);

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
@@ -48,6 +48,7 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.net.AuthManager;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -107,7 +108,9 @@ class TargetsGetHandlerTest {
                                         String.format("/jndi/rmi://%s:%s/jmxrmi", host, port));
                             }
                         });
-        ServiceRef target = new ServiceRef(connectionToolkit.createServiceURL("foo", 1), "foo");
+        ServiceRef target =
+                new ServiceRef(
+                        URIUtil.convert(connectionToolkit.createServiceURL("foo", 1)), "foo");
 
         List<ServiceRef> targets = Collections.singletonList(target);
         Mockito.when(platformClient.listDiscoverableServices()).thenReturn(targets);

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -38,10 +38,9 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-
-import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
@@ -121,7 +120,7 @@ class TargetsPostHandlerTest {
     }
 
     @Test
-    void testSuccessfulRequest() throws IOException {
+    void testSuccessfulRequest() throws Exception {
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
         RequestParameters requestParameters = Mockito.mock(RequestParameters.class);
         Mockito.when(requestParameters.getFormAttributes()).thenReturn(attrs);
@@ -139,8 +138,7 @@ class TargetsPostHandlerTest {
         ArgumentCaptor<ServiceRef> refCaptor = ArgumentCaptor.forClass(ServiceRef.class);
         Mockito.verify(customTargetPlatformClient).addTarget(refCaptor.capture());
         ServiceRef captured = refCaptor.getValue();
-        MatcherAssert.assertThat(
-                captured.getJMXServiceUrl(), Matchers.equalTo(new JMXServiceURL(connectUrl)));
+        MatcherAssert.assertThat(captured.getServiceUri(), Matchers.equalTo(new URI(connectUrl)));
         MatcherAssert.assertThat(captured.getAlias(), Matchers.equalTo(Optional.of(alias)));
         MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(captured));
     }

--- a/src/test/java/io/cryostat/platform/internal/AbstractPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/AbstractPlatformClientTest.java
@@ -87,7 +87,8 @@ class AbstractPlatformClientTest {
     void shouldEmitNotification() throws Exception {
         Mockito.verifyNoInteractions(notificationFactory);
 
-        JMXServiceURL serviceUrl = Mockito.mock(JMXServiceURL.class);
+        JMXServiceURL serviceUrl =
+                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
         String alias = "com.example.Foo";
         ServiceRef serviceRef = new ServiceRef(serviceUrl, alias);
         EventKind kind = EventKind.FOUND;

--- a/src/test/java/io/cryostat/platform/internal/AbstractPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/AbstractPlatformClientTest.java
@@ -38,6 +38,7 @@
 package io.cryostat.platform.internal;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,8 +89,9 @@ class AbstractPlatformClientTest {
     void shouldEmitNotification() throws Exception {
         Mockito.verifyNoInteractions(notificationFactory);
 
-        JMXServiceURL serviceUrl =
-                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
+        URI serviceUrl =
+                URIUtil.convert(
+                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"));
         String alias = "com.example.Foo";
         ServiceRef serviceRef = new ServiceRef(serviceUrl, alias);
         EventKind kind = EventKind.FOUND;

--- a/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
@@ -259,7 +259,7 @@ class CustomTargetPlatformClientTest {
         Mockito.when(fs.readFile(saveFile)).thenReturn(reader);
 
         client.start();
-        Assertions.assertTrue(client.removeTarget(SERVICE_REF.getJMXServiceUrl()));
+        Assertions.assertTrue(client.removeTarget(SERVICE_REF.getServiceUri()));
 
         Mockito.verify(fs)
                 .writeString(
@@ -284,7 +284,7 @@ class CustomTargetPlatformClientTest {
 
     @Test
     void testRemoveNonexistentTargetByUrl() throws IOException {
-        Assertions.assertFalse(client.removeTarget(SERVICE_REF.getJMXServiceUrl()));
+        Assertions.assertFalse(client.removeTarget(SERVICE_REF.getServiceUri()));
 
         Mockito.verify(fs, Mockito.never())
                 .writeString(

--- a/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
@@ -56,6 +56,7 @@ import io.cryostat.messaging.notifications.Notification.MetaType;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import com.google.gson.Gson;
 import org.hamcrest.MatcherAssert;
@@ -88,7 +89,9 @@ class CustomTargetPlatformClientTest {
         try {
             SERVICE_REF =
                     new ServiceRef(
-                            new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi"),
+                            URIUtil.convert(
+                                    new JMXServiceURL(
+                                            "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi")),
                             "TestTarget");
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -97,7 +97,8 @@ class DefaultPlatformClientTest {
     @Test
     void testDiscoverableServiceMapping() throws Exception {
         DiscoveredJvmDescriptor desc1 = mock(DiscoveredJvmDescriptor.class);
-        JMXServiceURL url1 = mock(JMXServiceURL.class);
+        JMXServiceURL url1 =
+                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
         when(desc1.getMainClass()).thenReturn("com.example.Main");
         when(desc1.getJmxServiceUrl()).thenReturn(url1);
 
@@ -105,9 +106,10 @@ class DefaultPlatformClientTest {
         when(desc2.getJmxServiceUrl()).thenThrow(MalformedURLException.class);
 
         DiscoveredJvmDescriptor desc3 = mock(DiscoveredJvmDescriptor.class);
-        JMXServiceURL url3 = mock(JMXServiceURL.class);
+        JMXServiceURL url2 =
+                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi");
         when(desc3.getMainClass()).thenReturn("io.cryostat.Cryostat");
-        when(desc3.getJmxServiceUrl()).thenReturn(url3);
+        when(desc3.getJmxServiceUrl()).thenReturn(url2);
 
         when(discoveryClient.getDiscoveredJvmDescriptors())
                 .thenReturn(List.of(desc1, desc2, desc3));
@@ -122,7 +124,7 @@ class DefaultPlatformClientTest {
 
     @Test
     void testAcceptDiscoveryEvent() throws Exception {
-        JMXServiceURL url = mock(JMXServiceURL.class);
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
         String mainClass = "com.example.Main";
         DiscoveredJvmDescriptor desc = mock(DiscoveredJvmDescriptor.class);
         when(desc.getMainClass()).thenReturn(mainClass);
@@ -147,11 +149,7 @@ class DefaultPlatformClientTest {
 
         verifyNoInteractions(notificationFactory);
 
-        try {
-            client.accept(evt);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        client.accept(evt);
 
         verifyNoInteractions(discoveryClient);
 

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -60,6 +60,7 @@ import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,8 +117,10 @@ class DefaultPlatformClientTest {
 
         List<ServiceRef> results = client.listDiscoverableServices();
 
-        ServiceRef exp1 = new ServiceRef(desc1.getJmxServiceUrl(), desc1.getMainClass());
-        ServiceRef exp2 = new ServiceRef(desc3.getJmxServiceUrl(), desc3.getMainClass());
+        ServiceRef exp1 =
+                new ServiceRef(URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
+        ServiceRef exp2 =
+                new ServiceRef(URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
 
         assertThat(results, equalTo(List.of(exp1, exp2)));
     }
@@ -163,7 +166,7 @@ class DefaultPlatformClientTest {
                                         "kind",
                                         EventKind.FOUND,
                                         "serviceRef",
-                                        new ServiceRef(url, mainClass))));
+                                        new ServiceRef(URIUtil.convert(url), mainClass))));
         verify(builder).build();
         verify(notification).send();
     }

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -51,6 +51,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import io.fabric8.kubernetes.api.model.EndpointAddress;
 import io.fabric8.kubernetes.api.model.EndpointPort;
@@ -193,15 +194,21 @@ class KubeApiPlatformClientTest {
         List<ServiceRef> result = platformClient.listDiscoverableServices();
         ServiceRef serv1 =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address2.getIp(), port2.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address2.getIp(), port2.getPort())),
                         address2.getTargetRef().getName());
         ServiceRef serv2 =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address3.getIp(), port2.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address3.getIp(), port2.getPort())),
                         address3.getTargetRef().getName());
         ServiceRef serv3 =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address4.getIp(), port3.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address4.getIp(), port3.getPort())),
                         address4.getTargetRef().getName());
 
         MatcherAssert.assertThat(result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3)));
@@ -279,7 +286,9 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(1)).createBuilder();
@@ -345,7 +354,9 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(1)).createBuilder();
@@ -410,7 +421,9 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
+                        URIUtil.convert(
+                                connectionToolkit.createServiceURL(
+                                        address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(2)).createBuilder();

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -193,21 +193,15 @@ class KubeApiPlatformClientTest {
         List<ServiceRef> result = platformClient.listDiscoverableServices();
         ServiceRef serv1 =
                 new ServiceRef(
-                        connectionToolkit,
-                        address2.getIp(),
-                        port2.getPort(),
+                        connectionToolkit.createServiceURL(address2.getIp(), port2.getPort()),
                         address2.getTargetRef().getName());
         ServiceRef serv2 =
                 new ServiceRef(
-                        connectionToolkit,
-                        address3.getIp(),
-                        port2.getPort(),
+                        connectionToolkit.createServiceURL(address3.getIp(), port2.getPort()),
                         address3.getTargetRef().getName());
         ServiceRef serv3 =
                 new ServiceRef(
-                        connectionToolkit,
-                        address4.getIp(),
-                        port3.getPort(),
+                        connectionToolkit.createServiceURL(address4.getIp(), port3.getPort()),
                         address4.getTargetRef().getName());
 
         MatcherAssert.assertThat(result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3)));
@@ -285,9 +279,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit,
-                        address.getIp(),
-                        port.getPort(),
+                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(1)).createBuilder();
@@ -353,9 +345,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit,
-                        address.getIp(),
-                        port.getPort(),
+                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(1)).createBuilder();
@@ -420,9 +410,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serviceRef =
                 new ServiceRef(
-                        connectionToolkit,
-                        address.getIp(),
-                        port.getPort(),
+                        connectionToolkit.createServiceURL(address.getIp(), port.getPort()),
                         address.getTargetRef().getName());
 
         Mockito.verify(notificationFactory, Mockito.times(2)).createBuilder();

--- a/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,7 @@ class KubeEnvPlatformClientTest {
         }
 
         @Test
-        void shouldDiscoverServicesByEnv() throws MalformedURLException {
+        void shouldDiscoverServicesByEnv() throws MalformedURLException, URISyntaxException {
             when(env.getEnv())
                     .thenReturn(
                             Map.of(

--- a/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
@@ -52,6 +52,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -121,9 +122,13 @@ class KubeEnvPlatformClientTest {
                             });
 
             ServiceRef serv1 =
-                    new ServiceRef(connectionToolkit.createServiceURL("127.0.0.1", 1234), "foo");
+                    new ServiceRef(
+                            URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.1", 1234)),
+                            "foo");
             ServiceRef serv2 =
-                    new ServiceRef(connectionToolkit.createServiceURL("1.2.3.4", 9999), "bar");
+                    new ServiceRef(
+                            URIUtil.convert(connectionToolkit.createServiceURL("1.2.3.4", 9999)),
+                            "bar");
 
             List<ServiceRef> services = client.listDiscoverableServices();
 

--- a/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
@@ -46,6 +46,7 @@ import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.util.URIUtil;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -83,11 +84,15 @@ class MergingPlatformClientTest {
     void testMergedDiscoverableServices() throws MalformedURLException, URISyntaxException {
         ServiceRef serviceA =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9098/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9098/jmxrmi")),
                         "ServiceA");
         ServiceRef serviceB =
                 new ServiceRef(
-                        new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi"),
+                        URIUtil.convert(
+                                new JMXServiceURL(
+                                        "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi")),
                         "ServiceB");
 
         Mockito.when(clientA.listDiscoverableServices()).thenReturn(List.of(serviceA));


### PR DESCRIPTION
Related to #520 #495 #280 #281

Use (absolute) URIs in most ServiceRef API touch-points rather than JMXServiceURLs to reduce coupling and ease future explorations for non-JMX connections. JMXServiceURLs are still required in other places, namely the TargetConnectionManager only knows how to deal with JMXServiceURLs.