### PR TITLE
Additional fields for ServiceRefs

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -128,6 +128,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                     throw new ApiException(400, "Duplicate connectUrl");
                 }
             }
+            // TODO form should allow client to populate various ServiceRef.AnnotationKey properties
             ServiceRef serviceRef = new ServiceRef(uri, alias);
             boolean v = customTargetPlatformClient.addTarget(serviceRef);
             if (!v) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -40,6 +40,8 @@ package io.cryostat.net.web.http.api.v2;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -49,6 +51,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.platform.internal.CustomTargetPlatformClient;
 import io.cryostat.util.URIUtil;
 
@@ -128,8 +131,18 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                     throw new ApiException(400, "Duplicate connectUrl");
                 }
             }
-            // TODO form should allow client to populate various ServiceRef.AnnotationKey properties
+            Map<AnnotationKey, String> cryostatAnnotations = new HashMap<>();
             ServiceRef serviceRef = new ServiceRef(uri, alias);
+            for (AnnotationKey ak : AnnotationKey.values()) {
+                // TODO is there a good way to determine this prefix from the structure of the
+                // ServiceRef's serialized form?
+                String formKey = "annotations.cryostat." + ak.name();
+                if (attrs.contains(formKey)) {
+                    cryostatAnnotations.put(ak, attrs.get(formKey));
+                }
+            }
+            serviceRef.setCryostatAnnotations(cryostatAnnotations);
+
             boolean v = customTargetPlatformClient.addTarget(serviceRef);
             if (!v) {
                 throw new ApiException(400, "Duplicate connectUrl");

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.google.gson.annotations.SerializedName;
@@ -182,36 +181,15 @@ public class ServiceRef {
     }
 
     public enum AnnotationKey {
-        HOST("host"),
-        PORT("port"),
-        JAVA_MAIN("javaMain"),
-        PID("pid"),
-        START_TIME("startTime"),
-        NAMESPACE("namespace"),
-        SERVICE_NAME("serviceName"),
-        CONTAINER_NAME("containerName"),
-        POD_NAME("podName"),
+        HOST,
+        PORT,
+        JAVA_MAIN,
+        PID,
+        START_TIME,
+        NAMESPACE,
+        SERVICE_NAME,
+        CONTAINER_NAME,
+        POD_NAME,
         ;
-
-        public static final String PREFIX = "target.cryostat.io";
-
-        private final String key;
-
-        AnnotationKey(String key) {
-            this.key = String.format("%s/%s", PREFIX, key);
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public AnnotationKey fromString(String s) {
-            for (AnnotationKey ak : values()) {
-                if (Objects.equals(ak.getKey(), s)) {
-                    return ak;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -73,16 +73,18 @@ public class ServiceRef {
         this.labels.putAll(labels);
     }
 
+    public Map<String, String> getLabels() {
+        return Collections.unmodifiableMap(labels);
+    }
+
     public void setPlatformAnnotations(Map<String, String> annotations) {
-        this.annotations.setPlatformAnnotations(annotations);
+        this.annotations.platform.clear();
+        this.annotations.platform.putAll(annotations);
     }
 
     public void setCryostatAnnotations(Map<AnnotationKey, String> annotations) {
-        this.annotations.setCryostatAnnotations(annotations);
-    }
-
-    public Map<String, String> getLabels() {
-        return Collections.unmodifiableMap(labels);
+        this.annotations.cryostat.clear();
+        this.annotations.cryostat.putAll(annotations);
     }
 
     public Annotations getAnnotations() {
@@ -124,29 +126,9 @@ public class ServiceRef {
         return ToStringBuilder.reflectionToString(this);
     }
 
-    public static class Annotations {
-        private final @SerializedName("platform") Map<String, String> platformAnnotations =
-                new HashMap<>();
-        private final @SerializedName("cryostat") Map<AnnotationKey, String> cryostatAnnotations =
-                new HashMap<>();
-
-        public Map<String, String> getPlatformAnnotations() {
-            return new HashMap<>(platformAnnotations);
-        }
-
-        public void setPlatformAnnotations(Map<String, String> platformAnnotations) {
-            this.platformAnnotations.clear();
-            this.platformAnnotations.putAll(platformAnnotations);
-        }
-
-        public Map<AnnotationKey, String> getCryostatAnnotations() {
-            return new HashMap<>(cryostatAnnotations);
-        }
-
-        public void setCryostatAnnotations(Map<AnnotationKey, String> cryostatAnnotations) {
-            this.cryostatAnnotations.clear();
-            this.cryostatAnnotations.putAll(cryostatAnnotations);
-        }
+    private static class Annotations {
+        private final Map<String, String> platform = new HashMap<>();
+        private final Map<AnnotationKey, String> cryostat = new HashMap<>();
 
         @Override
         public boolean equals(Object other) {
@@ -161,17 +143,14 @@ public class ServiceRef {
             }
             Annotations o = (Annotations) other;
             return new EqualsBuilder()
-                    .append(platformAnnotations, o.platformAnnotations)
-                    .append(cryostatAnnotations, o.cryostatAnnotations)
+                    .append(platform, o.platform)
+                    .append(cryostat, o.cryostat)
                     .build();
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(platformAnnotations)
-                    .append(cryostatAnnotations)
-                    .toHashCode();
+            return new HashCodeBuilder().append(platform).append(cryostat).toHashCode();
         }
 
         @Override

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -140,7 +140,7 @@ public class ServiceRef {
     public enum AnnotationKey {
         HOST("host"),
         PORT("port"),
-        MAIN_CLASS("mainClass"),
+        JAVA_MAIN("javaMain"),
         PID("pid"),
         START_TIME("startTime"),
         NAMESPACE("namespace"),

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -82,13 +82,17 @@ public class ServiceRef {
         this.annotations.platform.putAll(annotations);
     }
 
+    public Map<String, String> getPlatformAnnotations() {
+        return new HashMap<>(annotations.platform);
+    }
+
     public void setCryostatAnnotations(Map<AnnotationKey, String> annotations) {
         this.annotations.cryostat.clear();
         this.annotations.cryostat.putAll(annotations);
     }
 
-    public Annotations getAnnotations() {
-        return annotations;
+    public Map<AnnotationKey, String> getCryostatAnnotations() {
+        return new HashMap<>(annotations.cryostat);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -39,6 +39,7 @@ package io.cryostat.platform;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -132,7 +133,7 @@ public class ServiceRef {
 
     private static class Annotations {
         private final Map<String, String> platform = new HashMap<>();
-        private final Map<AnnotationKey, String> cryostat = new HashMap<>();
+        private final Map<AnnotationKey, String> cryostat = new EnumMap<>(AnnotationKey.class);
 
         @Override
         public boolean equals(Object other) {

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -42,6 +42,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -100,11 +101,12 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
             throws MalformedURLException, URISyntaxException {
         JMXServiceURL serviceUrl = desc.getJmxServiceUrl();
         ServiceRef serviceRef = new ServiceRef(URIUtil.convert(serviceUrl), desc.getMainClass());
-        serviceRef.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc.getMainClass());
-
         URI rmiTarget = URIUtil.getRmiTarget(serviceUrl);
-        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, rmiTarget.getHost());
-        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(rmiTarget.getPort()));
+        serviceRef.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.JAVA_MAIN, desc.getMainClass(),
+                        AnnotationKey.HOST, rmiTarget.getHost(),
+                        AnnotationKey.PORT, Integer.toString(rmiTarget.getPort())));
         return serviceRef;
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -100,7 +100,7 @@ class DefaultPlatformClient extends AbstractPlatformClient implements Consumer<J
             throws MalformedURLException, URISyntaxException {
         JMXServiceURL serviceUrl = desc.getJmxServiceUrl();
         ServiceRef serviceRef = new ServiceRef(URIUtil.convert(serviceUrl), desc.getMainClass());
-        serviceRef.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, desc.getMainClass());
+        serviceRef.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc.getMainClass());
 
         URI rmiTarget = URIUtil.getRmiTarget(serviceUrl);
         serviceRef.addCryostatAnnotation(AnnotationKey.HOST, rmiTarget.getHost());

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -48,6 +48,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.util.URIUtil;
 
 import dagger.Lazy;
@@ -171,13 +172,24 @@ class KubeApiPlatformClient extends AbstractPlatformClient {
                 .map(
                         addr -> {
                             try {
-                                return new ServiceRef(
-                                        URIUtil.convert(
-                                                connectionToolkit
-                                                        .get()
-                                                        .createServiceURL(
-                                                                addr.getIp(), port.getPort())),
-                                        addr.getTargetRef().getName());
+                                ServiceRef serviceRef =
+                                        new ServiceRef(
+                                                URIUtil.convert(
+                                                        connectionToolkit
+                                                                .get()
+                                                                .createServiceURL(
+                                                                        addr.getIp(),
+                                                                        port.getPort())),
+                                                addr.getTargetRef().getName());
+                                serviceRef.addCryostatAnnotation(AnnotationKey.HOST, addr.getIp());
+                                serviceRef.addCryostatAnnotation(
+                                        AnnotationKey.PORT, Integer.toString(port.getPort()));
+                                serviceRef.addCryostatAnnotation(
+                                        AnnotationKey.NAMESPACE,
+                                        addr.getTargetRef().getNamespace());
+                                serviceRef.addCryostatAnnotation(
+                                        AnnotationKey.SERVICE_NAME, addr.getTargetRef().getName());
+                                return serviceRef;
                             } catch (Exception e) {
                                 logger.warn(e);
                                 return null;

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -181,14 +182,15 @@ class KubeApiPlatformClient extends AbstractPlatformClient {
                                                                         addr.getIp(),
                                                                         port.getPort())),
                                                 addr.getTargetRef().getName());
-                                serviceRef.addCryostatAnnotation(AnnotationKey.HOST, addr.getIp());
-                                serviceRef.addCryostatAnnotation(
-                                        AnnotationKey.PORT, Integer.toString(port.getPort()));
-                                serviceRef.addCryostatAnnotation(
-                                        AnnotationKey.NAMESPACE,
-                                        addr.getTargetRef().getNamespace());
-                                serviceRef.addCryostatAnnotation(
-                                        AnnotationKey.SERVICE_NAME, addr.getTargetRef().getName());
+                                serviceRef.setCryostatAnnotations(
+                                        Map.of(
+                                                AnnotationKey.HOST, addr.getIp(),
+                                                AnnotationKey.PORT,
+                                                        Integer.toString(port.getPort()),
+                                                AnnotationKey.NAMESPACE,
+                                                        addr.getTargetRef().getNamespace(),
+                                                AnnotationKey.SERVICE_NAME,
+                                                        addr.getTargetRef().getName()));
                                 return serviceRef;
                             } catch (Exception e) {
                                 logger.warn(e);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -189,7 +189,7 @@ class KubeApiPlatformClient extends AbstractPlatformClient {
                                                         Integer.toString(port.getPort()),
                                                 AnnotationKey.NAMESPACE,
                                                         addr.getTargetRef().getNamespace(),
-                                                AnnotationKey.SERVICE_NAME,
+                                                AnnotationKey.POD_NAME,
                                                         addr.getTargetRef().getName()));
                                 return serviceRef;
                             } catch (Exception e) {

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -117,14 +118,18 @@ class DefaultPlatformClientTest {
 
         ServiceRef exp1 =
                 new ServiceRef(URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
-        exp1.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc1.getMainClass());
-        exp1.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
-        exp1.addCryostatAnnotation(AnnotationKey.PORT, "9091");
+        exp1.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.JAVA_MAIN, desc1.getMainClass(),
+                        AnnotationKey.HOST, "cryostat",
+                        AnnotationKey.PORT, "9091"));
         ServiceRef exp2 =
                 new ServiceRef(URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
-        exp2.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc3.getMainClass());
-        exp2.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
-        exp2.addCryostatAnnotation(AnnotationKey.PORT, "9092");
+        exp2.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.JAVA_MAIN, desc3.getMainClass(),
+                        AnnotationKey.HOST, "cryostat",
+                        AnnotationKey.PORT, "9092"));
 
         assertThat(results, equalTo(List.of(exp1, exp2)));
     }
@@ -150,9 +155,11 @@ class DefaultPlatformClientTest {
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         ServiceRef serviceRef = new ServiceRef(URIUtil.convert(url), javaMain);
-        serviceRef.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "com.example.Main");
-        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
-        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9091");
+        serviceRef.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.JAVA_MAIN, "com.example.Main",
+                        AnnotationKey.HOST, "cryostat",
+                        AnnotationKey.PORT, "9091"));
         MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));
     }
 }

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -56,8 +56,8 @@ import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
 import io.cryostat.platform.ServiceRef;
-import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
+import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.util.URIUtil;
 
 import org.hamcrest.MatcherAssert;
@@ -149,8 +149,10 @@ class DefaultPlatformClientTest {
 
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        MatcherAssert.assertThat(
-                event.getServiceRef(),
-                Matchers.equalTo(new ServiceRef(URIUtil.convert(url), javaMain)));
+        ServiceRef serviceRef = new ServiceRef(URIUtil.convert(url), javaMain);
+        serviceRef.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "com.example.Main");
+        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
+        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9091");
+        MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));
     }
 }

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -117,12 +117,12 @@ class DefaultPlatformClientTest {
 
         ServiceRef exp1 =
                 new ServiceRef(URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
-        exp1.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, desc1.getMainClass());
+        exp1.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc1.getMainClass());
         exp1.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
         exp1.addCryostatAnnotation(AnnotationKey.PORT, "9091");
         ServiceRef exp2 =
                 new ServiceRef(URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
-        exp2.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, desc3.getMainClass());
+        exp2.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, desc3.getMainClass());
         exp2.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
         exp2.addCryostatAnnotation(AnnotationKey.PORT, "9092");
 
@@ -132,9 +132,9 @@ class DefaultPlatformClientTest {
     @Test
     void testAcceptDiscoveryEvent() throws Exception {
         JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
-        String mainClass = "com.example.Main";
+        String javaMain = "com.example.Main";
         DiscoveredJvmDescriptor desc = mock(DiscoveredJvmDescriptor.class);
-        when(desc.getMainClass()).thenReturn(mainClass);
+        when(desc.getMainClass()).thenReturn(javaMain);
         when(desc.getJmxServiceUrl()).thenReturn(url);
         JvmDiscoveryEvent evt = mock(JvmDiscoveryEvent.class);
         when(evt.getEventKind()).thenReturn(EventKind.FOUND);
@@ -151,6 +151,6 @@ class DefaultPlatformClientTest {
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         MatcherAssert.assertThat(
                 event.getServiceRef(),
-                Matchers.equalTo(new ServiceRef(URIUtil.convert(url), mainClass)));
+                Matchers.equalTo(new ServiceRef(URIUtil.convert(url), javaMain)));
     }
 }

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -57,6 +57,7 @@ import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.TargetDiscoveryEvent;
+import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.util.URIUtil;
 
 import org.hamcrest.MatcherAssert;
@@ -116,8 +117,14 @@ class DefaultPlatformClientTest {
 
         ServiceRef exp1 =
                 new ServiceRef(URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
+        exp1.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, desc1.getMainClass());
+        exp1.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
+        exp1.addCryostatAnnotation(AnnotationKey.PORT, "9091");
         ServiceRef exp2 =
                 new ServiceRef(URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
+        exp2.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, desc3.getMainClass());
+        exp2.addCryostatAnnotation(AnnotationKey.HOST, "cryostat");
+        exp2.addCryostatAnnotation(AnnotationKey.PORT, "9092");
 
         assertThat(results, equalTo(List.of(exp1, exp2)));
     }
@@ -139,6 +146,7 @@ class DefaultPlatformClientTest {
         client.accept(evt);
 
         verifyNoInteractions(discoveryClient);
+
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -40,6 +40,7 @@ package io.cryostat.platform.internal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -201,33 +202,36 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address2.getIp(), port2.getPort())),
                         address2.getTargetRef().getName());
-        serv1.addCryostatAnnotation(AnnotationKey.HOST, address2.getIp());
-        serv1.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port2.getPort()));
-        serv1.addCryostatAnnotation(
-                AnnotationKey.NAMESPACE, address2.getTargetRef().getNamespace());
-        serv1.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address2.getTargetRef().getName());
+        serv1.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.HOST, address2.getIp(),
+                        AnnotationKey.PORT, Integer.toString(port2.getPort()),
+                        AnnotationKey.NAMESPACE, address2.getTargetRef().getNamespace(),
+                        AnnotationKey.SERVICE_NAME, address2.getTargetRef().getName()));
         ServiceRef serv2 =
                 new ServiceRef(
                         URIUtil.convert(
                                 connectionToolkit.createServiceURL(
                                         address3.getIp(), port2.getPort())),
                         address3.getTargetRef().getName());
-        serv2.addCryostatAnnotation(AnnotationKey.HOST, address3.getIp());
-        serv2.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port2.getPort()));
-        serv2.addCryostatAnnotation(
-                AnnotationKey.NAMESPACE, address3.getTargetRef().getNamespace());
-        serv2.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address3.getTargetRef().getName());
+        serv2.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.HOST, address3.getIp(),
+                        AnnotationKey.PORT, Integer.toString(port2.getPort()),
+                        AnnotationKey.NAMESPACE, address3.getTargetRef().getNamespace(),
+                        AnnotationKey.SERVICE_NAME, address3.getTargetRef().getName()));
         ServiceRef serv3 =
                 new ServiceRef(
                         URIUtil.convert(
                                 connectionToolkit.createServiceURL(
                                         address4.getIp(), port3.getPort())),
                         address4.getTargetRef().getName());
-        serv3.addCryostatAnnotation(AnnotationKey.HOST, address4.getIp());
-        serv3.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port3.getPort()));
-        serv3.addCryostatAnnotation(
-                AnnotationKey.NAMESPACE, address4.getTargetRef().getNamespace());
-        serv3.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address4.getTargetRef().getName());
+        serv3.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.HOST, address4.getIp(),
+                        AnnotationKey.PORT, Integer.toString(port3.getPort()),
+                        AnnotationKey.NAMESPACE, address4.getTargetRef().getNamespace(),
+                        AnnotationKey.SERVICE_NAME, address4.getTargetRef().getName()));
 
         MatcherAssert.assertThat(result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3)));
     }
@@ -305,10 +309,12 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
-        serviceRef.addCryostatAnnotation(AnnotationKey.NAMESPACE, "myproject");
-        serviceRef.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, "targetA");
-        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9999");
-        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "127.0.0.1");
+        serviceRef.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.NAMESPACE, "myproject",
+                        AnnotationKey.SERVICE_NAME, "targetA",
+                        AnnotationKey.PORT, "9999",
+                        AnnotationKey.HOST, "127.0.0.1"));
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));
@@ -369,10 +375,12 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
-        serviceRef.addCryostatAnnotation(AnnotationKey.NAMESPACE, "myproject");
-        serviceRef.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, "targetA");
-        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9999");
-        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "127.0.0.1");
+        serviceRef.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.NAMESPACE, "myproject",
+                        AnnotationKey.SERVICE_NAME, "targetA",
+                        AnnotationKey.PORT, "9999",
+                        AnnotationKey.HOST, "127.0.0.1"));
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.LOST));
         MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));
@@ -433,12 +441,12 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
-        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, address.getIp());
-        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port.getPort()));
-        serviceRef.addCryostatAnnotation(
-                AnnotationKey.NAMESPACE, address.getTargetRef().getNamespace());
-        serviceRef.addCryostatAnnotation(
-                AnnotationKey.SERVICE_NAME, address.getTargetRef().getName());
+        serviceRef.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.HOST, address.getIp(),
+                        AnnotationKey.PORT, Integer.toString(port.getPort()),
+                        AnnotationKey.NAMESPACE, address.getTargetRef().getNamespace(),
+                        AnnotationKey.SERVICE_NAME, address.getTargetRef().getName()));
 
         ArgumentCaptor<TargetDiscoveryEvent> eventCaptor =
                 ArgumentCaptor.forClass(TargetDiscoveryEvent.class);

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -52,6 +52,7 @@ import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.TargetDiscoveryEvent;
+import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.util.URIUtil;
 
 import io.fabric8.kubernetes.api.model.EndpointAddress;
@@ -131,10 +132,13 @@ class KubeApiPlatformClientTest {
         // Mockito.when(objRef1.getName()).thenReturn("targetA");
         ObjectReference objRef2 = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef2.getName()).thenReturn("targetB");
+        Mockito.when(objRef2.getNamespace()).thenReturn("myproject");
         ObjectReference objRef3 = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef3.getName()).thenReturn("targetC");
+        Mockito.when(objRef3.getNamespace()).thenReturn("myproject");
         ObjectReference objRef4 = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef4.getName()).thenReturn("targetD");
+        Mockito.when(objRef4.getNamespace()).thenReturn("myproject");
 
         EndpointAddress address1 = Mockito.mock(EndpointAddress.class);
         // Mockito.when(address1.getIp()).thenReturn("127.0.0.1");
@@ -197,18 +201,33 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address2.getIp(), port2.getPort())),
                         address2.getTargetRef().getName());
+        serv1.addCryostatAnnotation(AnnotationKey.HOST, address2.getIp());
+        serv1.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port2.getPort()));
+        serv1.addCryostatAnnotation(
+                AnnotationKey.NAMESPACE, address2.getTargetRef().getNamespace());
+        serv1.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address2.getTargetRef().getName());
         ServiceRef serv2 =
                 new ServiceRef(
                         URIUtil.convert(
                                 connectionToolkit.createServiceURL(
                                         address3.getIp(), port2.getPort())),
                         address3.getTargetRef().getName());
+        serv2.addCryostatAnnotation(AnnotationKey.HOST, address3.getIp());
+        serv2.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port2.getPort()));
+        serv2.addCryostatAnnotation(
+                AnnotationKey.NAMESPACE, address3.getTargetRef().getNamespace());
+        serv2.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address3.getTargetRef().getName());
         ServiceRef serv3 =
                 new ServiceRef(
                         URIUtil.convert(
                                 connectionToolkit.createServiceURL(
                                         address4.getIp(), port3.getPort())),
                         address4.getTargetRef().getName());
+        serv3.addCryostatAnnotation(AnnotationKey.HOST, address4.getIp());
+        serv3.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port3.getPort()));
+        serv3.addCryostatAnnotation(
+                AnnotationKey.NAMESPACE, address4.getTargetRef().getNamespace());
+        serv3.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, address4.getTargetRef().getName());
 
         MatcherAssert.assertThat(result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3)));
     }
@@ -254,6 +273,7 @@ class KubeApiPlatformClientTest {
 
         ObjectReference objRef = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef.getName()).thenReturn("targetA");
+        Mockito.when(objRef.getNamespace()).thenReturn("myproject");
         EndpointAddress address = Mockito.mock(EndpointAddress.class);
         Mockito.when(address.getIp()).thenReturn("127.0.0.1");
         Mockito.when(address.getTargetRef()).thenReturn(objRef);
@@ -298,7 +318,7 @@ class KubeApiPlatformClientTest {
 
         Mockito.when(connectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
                 .thenAnswer(
-                        new Answer<>() {
+                        new Answer<JMXServiceURL>() {
                             @Override
                             public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
                                 String host = args.getArgument(0);
@@ -313,6 +333,7 @@ class KubeApiPlatformClientTest {
 
         ObjectReference objRef = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef.getName()).thenReturn("targetA");
+        Mockito.when(objRef.getNamespace()).thenReturn("myproject");
         EndpointAddress address = Mockito.mock(EndpointAddress.class);
         Mockito.when(address.getIp()).thenReturn("127.0.0.1");
         Mockito.when(address.getTargetRef()).thenReturn(objRef);
@@ -372,6 +393,7 @@ class KubeApiPlatformClientTest {
 
         ObjectReference objRef = Mockito.mock(ObjectReference.class);
         Mockito.when(objRef.getName()).thenReturn("targetA");
+        Mockito.when(objRef.getNamespace()).thenReturn("myproject");
         EndpointAddress address = Mockito.mock(EndpointAddress.class);
         Mockito.when(address.getIp()).thenReturn("127.0.0.1");
         Mockito.when(address.getTargetRef()).thenReturn(objRef);
@@ -403,6 +425,12 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
+        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, address.getIp());
+        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(port.getPort()));
+        serviceRef.addCryostatAnnotation(
+                AnnotationKey.NAMESPACE, address.getTargetRef().getNamespace());
+        serviceRef.addCryostatAnnotation(
+                AnnotationKey.SERVICE_NAME, address.getTargetRef().getName());
 
         ArgumentCaptor<TargetDiscoveryEvent> eventCaptor =
                 ArgumentCaptor.forClass(TargetDiscoveryEvent.class);

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -51,8 +51,8 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.ServiceRef;
-import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
+import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.util.URIUtil;
 
 import io.fabric8.kubernetes.api.model.EndpointAddress;
@@ -305,6 +305,10 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
+        serviceRef.addCryostatAnnotation(AnnotationKey.NAMESPACE, "myproject");
+        serviceRef.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, "targetA");
+        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9999");
+        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "127.0.0.1");
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));
@@ -365,6 +369,10 @@ class KubeApiPlatformClientTest {
                                 connectionToolkit.createServiceURL(
                                         address.getIp(), port.getPort())),
                         address.getTargetRef().getName());
+        serviceRef.addCryostatAnnotation(AnnotationKey.NAMESPACE, "myproject");
+        serviceRef.addCryostatAnnotation(AnnotationKey.SERVICE_NAME, "targetA");
+        serviceRef.addCryostatAnnotation(AnnotationKey.PORT, "9999");
+        serviceRef.addCryostatAnnotation(AnnotationKey.HOST, "127.0.0.1");
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.LOST));
         MatcherAssert.assertThat(event.getServiceRef(), Matchers.equalTo(serviceRef));

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -207,7 +207,7 @@ class KubeApiPlatformClientTest {
                         AnnotationKey.HOST, address2.getIp(),
                         AnnotationKey.PORT, Integer.toString(port2.getPort()),
                         AnnotationKey.NAMESPACE, address2.getTargetRef().getNamespace(),
-                        AnnotationKey.SERVICE_NAME, address2.getTargetRef().getName()));
+                        AnnotationKey.POD_NAME, address2.getTargetRef().getName()));
         ServiceRef serv2 =
                 new ServiceRef(
                         URIUtil.convert(
@@ -219,7 +219,7 @@ class KubeApiPlatformClientTest {
                         AnnotationKey.HOST, address3.getIp(),
                         AnnotationKey.PORT, Integer.toString(port2.getPort()),
                         AnnotationKey.NAMESPACE, address3.getTargetRef().getNamespace(),
-                        AnnotationKey.SERVICE_NAME, address3.getTargetRef().getName()));
+                        AnnotationKey.POD_NAME, address3.getTargetRef().getName()));
         ServiceRef serv3 =
                 new ServiceRef(
                         URIUtil.convert(
@@ -231,7 +231,7 @@ class KubeApiPlatformClientTest {
                         AnnotationKey.HOST, address4.getIp(),
                         AnnotationKey.PORT, Integer.toString(port3.getPort()),
                         AnnotationKey.NAMESPACE, address4.getTargetRef().getNamespace(),
-                        AnnotationKey.SERVICE_NAME, address4.getTargetRef().getName()));
+                        AnnotationKey.POD_NAME, address4.getTargetRef().getName()));
 
         MatcherAssert.assertThat(result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3)));
     }
@@ -312,7 +312,7 @@ class KubeApiPlatformClientTest {
         serviceRef.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.NAMESPACE, "myproject",
-                        AnnotationKey.SERVICE_NAME, "targetA",
+                        AnnotationKey.POD_NAME, "targetA",
                         AnnotationKey.PORT, "9999",
                         AnnotationKey.HOST, "127.0.0.1"));
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
@@ -378,7 +378,7 @@ class KubeApiPlatformClientTest {
         serviceRef.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.NAMESPACE, "myproject",
-                        AnnotationKey.SERVICE_NAME, "targetA",
+                        AnnotationKey.POD_NAME, "targetA",
                         AnnotationKey.PORT, "9999",
                         AnnotationKey.HOST, "127.0.0.1"));
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
@@ -446,7 +446,7 @@ class KubeApiPlatformClientTest {
                         AnnotationKey.HOST, address.getIp(),
                         AnnotationKey.PORT, Integer.toString(port.getPort()),
                         AnnotationKey.NAMESPACE, address.getTargetRef().getNamespace(),
-                        AnnotationKey.SERVICE_NAME, address.getTargetRef().getName()));
+                        AnnotationKey.POD_NAME, address.getTargetRef().getName()));
 
         ArgumentCaptor<TargetDiscoveryEvent> eventCaptor =
                 ArgumentCaptor.forClass(TargetDiscoveryEvent.class);

--- a/src/test/java/io/cryostat/util/URIUtilTest.java
+++ b/src/test/java/io/cryostat/util/URIUtilTest.java
@@ -38,31 +38,21 @@
 package io.cryostat.util;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import javax.management.remote.JMXServiceURL;
 
-public class URIUtil {
-    private URIUtil() {}
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
-    public static URI createAbsolute(String uri) throws URISyntaxException, RelativeURIException {
-        URI u = new URI(uri);
-        if (!u.isAbsolute()) {
-            throw new RelativeURIException(u);
-        }
-        return u;
-    }
+class URIUtilTest {
 
-    public static URI convert(JMXServiceURL serviceUrl) throws URISyntaxException {
-        return new URI(serviceUrl.toString());
-    }
-
-    public static URI getRmiTarget(JMXServiceURL serviceUrl) throws URISyntaxException {
-        String rmiPart = "/jndi/rmi://";
-        String pathPart = serviceUrl.getURLPath();
-        if (!pathPart.startsWith(rmiPart)) {
-            throw new IllegalArgumentException(serviceUrl.getURLPath());
-        }
-        return new URI(pathPart.substring("/jndi/".length(), pathPart.length()));
+    @Test
+    void testGetRmiTarget() throws Exception {
+        String serviceUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi";
+        URI converted = URIUtil.getRmiTarget(new JMXServiceURL(serviceUrl));
+        MatcherAssert.assertThat(converted.getHost(), Matchers.equalTo("cryostat"));
+        MatcherAssert.assertThat(converted.getPort(), Matchers.equalTo(9091));
+        MatcherAssert.assertThat(converted.getPath(), Matchers.equalTo("/jmxrmi"));
     }
 }

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -134,9 +134,11 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
                                         "service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi",
                                         Podman.POD_NAME)),
                         "io.cryostat.Cryostat");
-        cryostat.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "io.cryostat.Cryostat");
-        cryostat.addCryostatAnnotation(AnnotationKey.HOST, Podman.POD_NAME);
-        cryostat.addCryostatAnnotation(AnnotationKey.PORT, "9091");
+        cryostat.setCryostatAnnotations(
+                Map.of(
+                        AnnotationKey.JAVA_MAIN, "io.cryostat.Cryostat",
+                        AnnotationKey.HOST, Podman.POD_NAME,
+                        AnnotationKey.PORT, "9091"));
         expected.add(cryostat);
         for (int i = 0; i < NUM_EXT_CONTAINERS; i++) {
             ServiceRef ext =
@@ -146,9 +148,14 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
                                             "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
                                             Podman.POD_NAME, 9093 + i)),
                             "es.andrewazor.demo.Main");
-            ext.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "es.andrewazor.demo.Main");
-            ext.addCryostatAnnotation(AnnotationKey.HOST, Podman.POD_NAME);
-            ext.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(9093 + i));
+            ext.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.JAVA_MAIN,
+                            "es.andrewazor.demo.Main",
+                            AnnotationKey.HOST,
+                            Podman.POD_NAME,
+                            AnnotationKey.PORT,
+                            Integer.toString(9093 + i)));
             expected.add(ext);
         }
         MatcherAssert.assertThat(actual, Matchers.equalTo(expected));

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -48,9 +48,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.ServiceRef.AnnotationKey;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.ExternalTargetsTest;
+import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -59,16 +68,6 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.platform.ServiceRef;
-import io.cryostat.platform.ServiceRef.AnnotationKey;
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.ExternalTargetsTest;
-import itest.util.Podman;
 
 @TestMethodOrder(OrderAnnotation.class)
 class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -109,7 +109,7 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
     @Test
     @Order(1)
     void testOtherContainersFound() throws Exception {
-        //FIXME don't use ServiceRefs or Gson (de)serialization in these tests. This should be
+        // FIXME don't use ServiceRefs or Gson (de)serialization in these tests. This should be
         // as independent as possible from Cryostat internal implementation details.
         CompletableFuture<Set<ServiceRef>> resp = new CompletableFuture<>();
         webClient
@@ -135,7 +135,7 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
                                         "service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi",
                                         Podman.POD_NAME)),
                         "io.cryostat.Cryostat");
-        cryostat.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, "io.cryostat.Cryostat");
+        cryostat.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "io.cryostat.Cryostat");
         cryostat.addCryostatAnnotation(AnnotationKey.HOST, Podman.POD_NAME);
         cryostat.addCryostatAnnotation(AnnotationKey.PORT, "9091");
         expected.add(cryostat);
@@ -147,7 +147,7 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
                                             "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
                                             Podman.POD_NAME, 9093 + i)),
                             "es.andrewazor.demo.Main");
-            ext.addCryostatAnnotation(AnnotationKey.MAIN_CLASS, "es.andrewazor.demo.Main");
+            ext.addCryostatAnnotation(AnnotationKey.JAVA_MAIN, "es.andrewazor.demo.Main");
             ext.addCryostatAnnotation(AnnotationKey.HOST, Podman.POD_NAME);
             ext.addCryostatAnnotation(AnnotationKey.PORT, Integer.toString(9093 + i));
             expected.add(ext);


### PR DESCRIPTION
Rebased on top of #538

Fixes #280

Related to #495

Sample output from `http :8181/api/v1/targets | jq`:
```json
[
  {
    "connectUrl": "service:jmx:rmi:///jndi/rmi://cryostat:9096/jmxrmi",
    "alias": "/deployments/quarkus-run.jar",
    "labels": {},
    "annotations": {
      "platform": {},
      "cryostat": {
        "HOST": "cryostat",
        "PORT": "9096",
        "JAVA_MAIN": "/deployments/quarkus-run.jar"
      }
    }
  },
  {
    "connectUrl": "service:jmx:rmi:///jndi/rmi://cryostat:9095/jmxrmi",
    "alias": "es.andrewazor.demo.Main",
    "labels": {},
    "annotations": {
      "platform": {},
      "cryostat": {
        "HOST": "cryostat",
        "PORT": "9095",
        "JAVA_MAIN": "es.andrewazor.demo.Main"
      }
    }
  }
]
```