### PR TITLE
Add JMX connection status events

### DIFF
--- a/src/main/extras/app/Cryostat.xml
+++ b/src/main/extras/app/Cryostat.xml
@@ -3,6 +3,30 @@
      see Window -> Flight Recorder Template Manager.
 -->
 <configuration version="2.0" label="Cryostat" description="Continuous self-profiling for Cryostat" provider="Cryostat">
+ <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionOpened">
+  <setting name="enabled">
+   true
+  </setting>
+  <setting name="threshold">
+   0 ms
+  </setting>
+ </event>
+ <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionClosed">
+  <setting name="enabled">
+   true
+  </setting>
+  <setting name="threshold">
+   0 ms
+  </setting>
+ </event>
+ <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionFailed">
+  <setting name="enabled">
+   true
+  </setting>
+  <setting name="threshold">
+   0 ms
+  </setting>
+ </event>
  <event name="io.cyostat.net.web.WebServer.WebServerRequestEvent">
   <setting name="enabled">
    true

--- a/src/main/extras/app/Cryostat.xml
+++ b/src/main/extras/app/Cryostat.xml
@@ -19,14 +19,6 @@
    0 ms
   </setting>
  </event>
- <event name="io.cryostat.net.TargetConnectionManager.JMXConnectionFailed">
-  <setting name="enabled">
-   true
-  </setting>
-  <setting name="threshold">
-   0 ms
-  </setting>
- </event>
  <event name="io.cyostat.net.web.WebServer.WebServerRequestEvent">
   <setting name="enabled">
    true

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -90,7 +90,8 @@ public class TargetConnectionManager {
                                     public void onRemoval(
                                             ConnectionDescriptor descriptor,
                                             JFRConnection connection,
-                                            RemovalCause cause) {
+                                            RemovalCause cause)
+                                            throws RuntimeException {
                                         if (descriptor == null) {
                                             logger.warn(
                                                     "Connection eviction triggered with null descriptor");
@@ -109,8 +110,9 @@ public class TargetConnectionManager {
                                         evt.begin();
                                         try {
                                             connection.close();
-                                        } catch (Exception e) {
+                                        } catch (RuntimeException e) {
                                             evt.setExceptionThrown(true);
+                                            throw e;
                                         } finally {
                                             evt.end();
                                             if (evt.shouldCommit()) {

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -90,8 +90,7 @@ public class TargetConnectionManager {
                                     public void onRemoval(
                                             ConnectionDescriptor descriptor,
                                             JFRConnection connection,
-                                            RemovalCause cause)
-                                            throws RuntimeException {
+                                            RemovalCause cause) {
                                         if (descriptor == null) {
                                             logger.warn(
                                                     "Connection eviction triggered with null descriptor");

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -104,7 +104,8 @@ public class TargetConnectionManager {
                                         logger.info(
                                                 "Removing cached connection for {}",
                                                 descriptor.getTargetId());
-                                        JMXConnectionClosed evt = new JMXConnectionClosed(descriptor.getTargetId());
+                                        JMXConnectionClosed evt =
+                                                new JMXConnectionClosed(descriptor.getTargetId());
                                         evt.begin();
                                         connection.close();
                                         evt.end();
@@ -182,13 +183,14 @@ public class TargetConnectionManager {
         evtOpened.begin();
         evtFailed.begin();
         try {
-            JFRConnection connection = 
+            JFRConnection connection =
                     jfrConnectionToolkit
                             .get()
                             .connect(
                                     url,
                                     credentials.orElse(null),
-                                    Collections.singletonList(() -> this.connections.invalidate(cacheKey)));
+                                    Collections.singletonList(
+                                            () -> this.connections.invalidate(cacheKey)));
             evtOpened.end();
             evtFailed.end();
             if (evtOpened.shouldCommit()) {
@@ -235,7 +237,6 @@ public class TargetConnectionManager {
         JMXConnectionClosed(String JMXServiceURL) {
             this.JMXServiceURL = JMXServiceURL;
         }
-
     }
 
     @Name("io.cryostat.net.TargetConnectionManager.JMXConnectionFailed")


### PR DESCRIPTION
Related #461 

Add custom JFR events for monitoring JMX connection status (opened, closed and failed). 

Example output:

![Screenshot from 2021-06-18 13-34-14](https://user-images.githubusercontent.com/41028544/122601008-a6cdff80-d03e-11eb-8cb1-2a04f298490e.png)