### PR TITLE
Conditionally disable web-client testing on minimal builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,6 +575,20 @@
     <properties>
       <cryostat.imageVersion>${project.version}-minimal</cryostat.imageVersion>
     </properties>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${org.apache.maven.plugins.failsafe.version}</version>
+          <configuration>
+            <excludes>
+              <exclude>ClientAssetsIT.java</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
   </profile>
   <profile>
     <id>non-minimal</id>

--- a/pom.xml
+++ b/pom.xml
@@ -582,9 +582,9 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${org.apache.maven.plugins.failsafe.version}</version>
           <configuration>
-            <excludes>
-              <exclude>ClientAssetsIT.java</exclude>
-            </excludes>
+            <systemPropertyVariables>
+              <isMinimalBuild>true</isMinimalBuild>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
       </plugins>
@@ -631,6 +631,9 @@
                 </includes>
               </fileset>
             </filesets>
+            <systemPropertyVariables>
+              <isMinimalBuild>false</isMinimalBuild>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>

--- a/src/test/java/itest/ClientAssetsIT.java
+++ b/src/test/java/itest/ClientAssetsIT.java
@@ -49,7 +49,9 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+@DisabledIfSystemProperty(named = "isMinimalBuild", matches = "true")
 public class ClientAssetsIT extends TestBase {
 
     static File file;


### PR DESCRIPTION
Disable web-client testing, specifically `ClientAssetsIT`, when running integration tests on minimal builds.

Fixes #525 

