### PR TITLE
More itest refactoring, cleanup, slight stabilization

### DIFF
--- a/src/test/java/itest/ApiListingIT.java
+++ b/src/test/java/itest/ApiListingIT.java
@@ -40,17 +40,16 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpRequest;
-import itest.bases.TestBase;
-
-public class ApiListingIT extends TestBase {
+public class ApiListingIT extends StandardSelfTest {
 
     HttpRequest<Buffer> req;
 

--- a/src/test/java/itest/ApiListingIT.java
+++ b/src/test/java/itest/ApiListingIT.java
@@ -40,13 +40,15 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpRequest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.TestBase;
 
 public class ApiListingIT extends TestBase {
 

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -45,6 +45,13 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import io.cryostat.net.web.http.HttpMimeType;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -53,15 +60,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import io.cryostat.net.web.http.HttpMimeType;
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.TestBase;
-import itest.util.Podman;
-
 @TestMethodOrder(OrderAnnotation.class)
-class AutoRulesIT extends TestBase {
+class AutoRulesIT extends StandardSelfTest {
 
     static final List<String> CONTAINERS = new ArrayList<>();
     static final Map<String, String> NULL_RESULT = new HashMap<>();

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -45,12 +45,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import io.cryostat.net.web.http.HttpMimeType;
-
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -58,6 +52,13 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import io.cryostat.net.web.http.HttpMimeType;
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.TestBase;
+import itest.util.Podman;
 
 @TestMethodOrder(OrderAnnotation.class)
 class AutoRulesIT extends TestBase {

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -50,7 +50,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import itest.bases.StandardSelfTest;
+import itest.bases.ExternalTargetsTest;
 import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -61,7 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @TestMethodOrder(OrderAnnotation.class)
-class AutoRulesIT extends StandardSelfTest {
+class AutoRulesIT extends ExternalTargetsTest {
 
     static final List<String> CONTAINERS = new ArrayList<>();
     static final Map<String, String> NULL_RESULT = new HashMap<>();

--- a/src/test/java/itest/BasicCommandChannelIT.java
+++ b/src/test/java/itest/BasicCommandChannelIT.java
@@ -43,14 +43,16 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.TestBase;
+import itest.util.Utils;
 
 // Disabled - broken by WebSocket Notification channel noise, but the CommandChannel is deprecated
 // in favour of the HTTP API anyway. The WebSocket connection will only be used for the Notification

--- a/src/test/java/itest/BasicCommandChannelIT.java
+++ b/src/test/java/itest/BasicCommandChannelIT.java
@@ -43,22 +43,21 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.TestBase;
-import itest.util.Utils;
-
 // Disabled - broken by WebSocket Notification channel noise, but the CommandChannel is deprecated
 // in favour of the HTTP API anyway. The WebSocket connection will only be used for the Notification
 // channel going forward. FIXME add Notification channel tests.
 @Disabled
-public class BasicCommandChannelIT extends TestBase {
+public class BasicCommandChannelIT extends StandardSelfTest {
 
     @Test
     public void shouldGetPingResponse() throws Exception {

--- a/src/test/java/itest/ClientAssetsIT.java
+++ b/src/test/java/itest/ClientAssetsIT.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+import itest.bases.TestBase;
+
 @DisabledIfSystemProperty(named = "isMinimalBuild", matches = "true")
 public class ClientAssetsIT extends TestBase {
 

--- a/src/test/java/itest/ClientAssetsIT.java
+++ b/src/test/java/itest/ClientAssetsIT.java
@@ -40,6 +40,7 @@ package itest;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
@@ -51,10 +52,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-import itest.bases.TestBase;
-
 @DisabledIfSystemProperty(named = "isMinimalBuild", matches = "true")
-public class ClientAssetsIT extends TestBase {
+public class ClientAssetsIT extends StandardSelfTest {
 
     static File file;
     static Document doc;

--- a/src/test/java/itest/ClientUrlIT.java
+++ b/src/test/java/itest/ClientUrlIT.java
@@ -40,13 +40,15 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
-import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.TestBase;
+import itest.util.Utils;
 
 public class ClientUrlIT extends TestBase {
 

--- a/src/test/java/itest/ClientUrlIT.java
+++ b/src/test/java/itest/ClientUrlIT.java
@@ -40,17 +40,16 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.StandardSelfTest;
+import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
-import itest.bases.TestBase;
-import itest.util.Utils;
-
-public class ClientUrlIT extends TestBase {
+public class ClientUrlIT extends StandardSelfTest {
 
     HttpRequest<Buffer> req;
 

--- a/src/test/java/itest/GrafanaSetupIT.java
+++ b/src/test/java/itest/GrafanaSetupIT.java
@@ -40,11 +40,13 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.TestBase;
 
 public class GrafanaSetupIT extends TestBase {
 

--- a/src/test/java/itest/GrafanaSetupIT.java
+++ b/src/test/java/itest/GrafanaSetupIT.java
@@ -40,15 +40,14 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
-import itest.bases.TestBase;
-
-public class GrafanaSetupIT extends TestBase {
+public class GrafanaSetupIT extends StandardSelfTest {
 
     @Test
     public void shouldHaveConfiguredDatasource() throws Exception {

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -47,19 +47,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.TestBase;
-import itest.util.Podman;
-
-class InterleavedExternalTargetRequestsIT extends TestBase {
+class InterleavedExternalTargetRequestsIT extends StandardSelfTest {
 
     static final int NUM_EXT_CONTAINERS = 8;
     static final List<String> CONTAINERS = new ArrayList<>();

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -47,17 +47,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import itest.bases.ExternalTargetsTest;
 import itest.util.Podman;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
 

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -56,8 +56,12 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(OrderAnnotation.class)
 class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
 
     static final int NUM_EXT_CONTAINERS = 8;
@@ -92,6 +96,7 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
     }
 
     @Test
+    @Order(1)
     void testOtherContainersFound() throws Exception {
         JsonArray listResp = queryTargets().get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         Set<Map<String, String>> actual = new HashSet<>(listResp.getList());
@@ -119,6 +124,7 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
     }
 
     @Test
+    @Order(2)
     public void testInterleavedRequests() throws Exception {
         long start = System.nanoTime();
 

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -89,7 +89,6 @@ class InterleavedExternalTargetRequestsIT extends ExternalTargetsTest {
         for (String id : CONTAINERS) {
             Podman.kill(id);
         }
-        waitForDiscovery(0);
     }
 
     @Test

--- a/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
+++ b/src/test/java/itest/InterleavedExternalTargetRequestsIT.java
@@ -47,15 +47,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.TestBase;
+import itest.util.Podman;
 
 class InterleavedExternalTargetRequestsIT extends TestBase {
 

--- a/src/test/java/itest/NoopAuthIT.java
+++ b/src/test/java/itest/NoopAuthIT.java
@@ -40,16 +40,15 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
-import itest.bases.TestBase;
-
-public class NoopAuthIT extends TestBase {
+public class NoopAuthIT extends StandardSelfTest {
 
     HttpRequest<Buffer> req;
 

--- a/src/test/java/itest/NoopAuthIT.java
+++ b/src/test/java/itest/NoopAuthIT.java
@@ -40,12 +40,14 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import itest.bases.TestBase;
 
 public class NoopAuthIT extends TestBase {
 

--- a/src/test/java/itest/RecordingWorkflowIT.java
+++ b/src/test/java/itest/RecordingWorkflowIT.java
@@ -41,14 +41,16 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.TestBase;
 
 public class RecordingWorkflowIT extends TestBase {
 

--- a/src/test/java/itest/RecordingWorkflowIT.java
+++ b/src/test/java/itest/RecordingWorkflowIT.java
@@ -41,18 +41,17 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.TestBase;
-
-public class RecordingWorkflowIT extends TestBase {
+public class RecordingWorkflowIT extends StandardSelfTest {
 
     static final String TARGET_ID = "localhost";
     static final String TEST_RECORDING_NAME = "workflow_itest";

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -41,16 +41,15 @@ import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.multipart.MultipartForm;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.multipart.MultipartForm;
-import itest.bases.TestBase;
-
-public class UploadCertificateIT extends TestBase {
+public class UploadCertificateIT extends StandardSelfTest {
 
     static final String CERT_NAME = "cert";
     static final String FILE_NAME = "empty.cer";

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -41,12 +41,14 @@ import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.multipart.MultipartForm;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.multipart.MultipartForm;
+import itest.bases.TestBase;
 
 public class UploadCertificateIT extends TestBase {
 

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -40,16 +40,18 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import itest.bases.TestBase;
 
 public class UploadRecordingIT extends TestBase {
 

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -40,6 +40,11 @@ package itest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -47,13 +52,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
-import itest.bases.TestBase;
-
-public class UploadRecordingIT extends TestBase {
+public class UploadRecordingIT extends StandardSelfTest {
 
     static final String TARGET_ID = "localhost";
     static final String RECORDING_NAME = "upload_recording_it_rec";

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -60,8 +60,8 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
             if (numTargets == expectedTargets + 1) {
                 System.out.println(
                         String.format(
-                                "expected target count observed, counting success %d/%d",
-                                ++successes, STABILITY_COUNT));
+                                "expected target count (%d) observed, counting success %d/%d",
+                                numTargets + 1, ++successes, STABILITY_COUNT));
                 if (successes >= STABILITY_COUNT) {
                     System.out.println("discovery complete");
                     break;
@@ -70,7 +70,7 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
             } else if (numTargets < expectedTargets + 1) {
                 System.err.println(
                         String.format(
-                                "%d targets found - waiting for discovery to complete", numTargets));
+                                "%d/%d targets found - waiting for discovery to complete", numTargets, expectedTargets + 1));
                 if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
                     throw new Exception("discovery failed - timed out");
                 }
@@ -80,12 +80,12 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
                 if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
                     throw new Exception(
                             String.format(
-                                    "%d targets found - too many after timeout!", numTargets));
+                                    "%d targets found - too many (expected %d) after timeout!", numTargets, expectedTargets + 1));
                 }
                 System.err.println(
                         String.format(
-                                "%d targets found - too many! Waiting to see if JDP settles...",
-                                numTargets));
+                                "%d targets found - too many (expected %d)! Waiting to see if JDP settles...",
+                                numTargets, expectedTargets + 1));
                 successes = 0;
                 Thread.sleep(DISCOVERY_POLL_PERIOD_MS);
             }

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.json.JsonArray;
+import org.junit.jupiter.api.AfterAll;
 
 public abstract class ExternalTargetsTest extends StandardSelfTest {
 
@@ -49,6 +50,12 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
     static final int DISCOVERY_BASE_MS = 30_000;
     static final int DISCOVERY_TIMEOUT_MS =
             DISCOVERY_BASE_MS + (STABILITY_COUNT * DISCOVERY_POLL_PERIOD_MS);
+
+    @AfterAll
+    static void waitForExternalTargetsRemoval() throws Exception {
+        // if the subclass doesn't clean itself up then this will time out and fail
+        waitForDiscovery(0);
+    }
 
     public static void waitForDiscovery(int expectedTargets) throws Exception {
         // Repeatedly query targets, waiting until we have discovered the expected number JDP

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest.bases;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.json.JsonArray;
+
+public abstract class ExternalTargetsTest extends StandardSelfTest {
+
+    static final int DISCOVERY_POLL_PERIOD_MS = 7_500;
+    static final int STABILITY_COUNT = 3;
+    static final int DISCOVERY_BASE_MS = 30_000;
+    static final int DISCOVERY_TIMEOUT_MS =
+            DISCOVERY_BASE_MS + (STABILITY_COUNT * DISCOVERY_POLL_PERIOD_MS);
+
+    public static void waitForDiscovery(int expectedTargets) throws Exception {
+        // Repeatedly query targets, waiting until we have discovered the expected number JDP
+        // (expectedTargets, + 1 for Cryostat itself).
+        long startTime = System.currentTimeMillis();
+        int successes = 0;
+        while (true) {
+            int numTargets = queryTargets().get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS).size();
+            if (numTargets == expectedTargets + 1) {
+                System.out.println(
+                        String.format(
+                                "expected target count observed, counting success %d/%d",
+                                ++successes, STABILITY_COUNT));
+                if (successes >= STABILITY_COUNT) {
+                    System.out.println("discovery complete");
+                    break;
+                }
+                Thread.sleep(DISCOVERY_POLL_PERIOD_MS);
+            } else if (numTargets < expectedTargets + 1) {
+                System.err.println(
+                        String.format(
+                                "%d targets found - waiting for discovery to complete", numTargets));
+                if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
+                    throw new Exception("discovery failed - timed out");
+                }
+                successes = 0;
+                Thread.sleep(DISCOVERY_POLL_PERIOD_MS);
+            } else {
+                if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
+                    throw new Exception(
+                            String.format(
+                                    "%d targets found - too many after timeout!", numTargets));
+                }
+                System.err.println(
+                        String.format(
+                                "%d targets found - too many! Waiting to see if JDP settles...",
+                                numTargets));
+                successes = 0;
+                Thread.sleep(DISCOVERY_POLL_PERIOD_MS);
+            }
+        }
+        System.out.println(
+                String.format("discovery completed in %dms", System.currentTimeMillis() - startTime));
+    }
+
+    public static CompletableFuture<JsonArray> queryTargets() throws Exception {
+        CompletableFuture<JsonArray> resp = new CompletableFuture<>();
+        webClient
+                .get("/api/v1/targets")
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, resp)) {
+                                resp.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        return resp;
+    }
+
+}

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -70,7 +70,8 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
             } else if (numTargets < expectedTargets + 1) {
                 System.err.println(
                         String.format(
-                                "%d/%d targets found - waiting for discovery to complete", numTargets, expectedTargets + 1));
+                                "%d/%d targets found - waiting for discovery to complete",
+                                numTargets, expectedTargets + 1));
                 if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
                     throw new Exception("discovery failed - timed out");
                 }
@@ -80,7 +81,8 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
                 if (System.currentTimeMillis() > startTime + DISCOVERY_TIMEOUT_MS) {
                     throw new Exception(
                             String.format(
-                                    "%d targets found - too many (expected %d) after timeout!", numTargets, expectedTargets + 1));
+                                    "%d targets found - too many (expected %d) after timeout!",
+                                    numTargets, expectedTargets + 1));
                 }
                 System.err.println(
                         String.format(
@@ -91,7 +93,8 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
             }
         }
         System.out.println(
-                String.format("discovery completed in %dms", System.currentTimeMillis() - startTime));
+                String.format(
+                        "discovery completed in %dms", System.currentTimeMillis() - startTime));
     }
 
     public static CompletableFuture<JsonArray> queryTargets() throws Exception {
@@ -106,5 +109,4 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
                         });
         return resp;
     }
-
 }

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -68,7 +68,7 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
                 System.out.println(
                         String.format(
                                 "expected target count (%d) observed, counting success %d/%d",
-                                numTargets + 1, ++successes, STABILITY_COUNT));
+                                expectedTargets + 1, ++successes, STABILITY_COUNT));
                 if (successes >= STABILITY_COUNT) {
                     System.out.println("discovery complete");
                     break;

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -62,7 +62,7 @@ import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 
-public abstract class TestBase {
+public abstract class StandardSelfTest {
 
     public static final int REQUEST_TIMEOUT_SECONDS = 30;
     public static final WebClient webClient = Utils.getWebClient();

--- a/src/test/java/itest/bases/TestBase.java
+++ b/src/test/java/itest/bases/TestBase.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package itest;
+package itest.bases;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,10 +64,10 @@ import org.hamcrest.Matchers;
 
 public abstract class TestBase {
 
-    static final int REQUEST_TIMEOUT_SECONDS = 30;
-    static final WebClient webClient = Utils.getWebClient();
+    public static final int REQUEST_TIMEOUT_SECONDS = 30;
+    public static final WebClient webClient = Utils.getWebClient();
 
-    static CompletableFuture<JsonObject> sendMessage(String command, String... args)
+    public static CompletableFuture<JsonObject> sendMessage(String command, String... args)
             throws InterruptedException, ExecutionException, TimeoutException {
         CompletableFuture<JsonObject> future = new CompletableFuture<>();
 
@@ -111,15 +111,15 @@ public abstract class TestBase {
         return future;
     }
 
-    static void assertResponseStatus(JsonObject response) {
+    public static void assertResponseStatus(JsonObject response) {
         assertResponseStatus(response, 0);
     }
 
-    static void assertResponseStatus(JsonObject response, int status) {
+    public static void assertResponseStatus(JsonObject response, int status) {
         MatcherAssert.assertThat(response.getInteger("status"), Matchers.equalTo(status));
     }
 
-    static boolean assertRequestStatus(
+    public static boolean assertRequestStatus(
             AsyncResult<HttpResponse<Buffer>> result, CompletableFuture<?> future) {
         if (result.failed()) {
             result.cause().printStackTrace();
@@ -151,11 +151,11 @@ public abstract class TestBase {
         return future;
     }
 
-    static CompletableFuture<Path> downloadFile(String url, String name, String suffix) {
+    public static CompletableFuture<Path> downloadFile(String url, String name, String suffix) {
         return fireDownloadRequest(webClient.get(url), name, suffix);
     }
 
-    static CompletableFuture<Path> downloadFileAbs(String url, String name, String suffix) {
+    public static CompletableFuture<Path> downloadFileAbs(String url, String name, String suffix) {
         return fireDownloadRequest(webClient.getAbs(url), name, suffix);
     }
 


### PR DESCRIPTION
This refactors the TestBase class into bases/StandardSelfTest, creates a new bases/ExternalTargetsTest, and sets the InterleavedExternalTargetRequestsIT and AutoRulesIT to extend ExternalTargetsTest. This is mostly just to clean up the test class and remove common setup/teardown logic from test logic, and it also allows AutoRulesIT to do the same timed-retry-polling on teardown as InterleavedExternalTargetRequestsIT already does, which may also help to stabilize JDP discovery-related intermittent failures.