### PR TITLE
New rule definitions trigger on existing targets

### DIFF
--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -55,6 +55,7 @@ import io.cryostat.messaging.MessagingModule;
 import io.cryostat.net.NetworkModule;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.PlatformModule;
+import io.cryostat.recordings.RecordingsModule;
 import io.cryostat.rules.Rule;
 import io.cryostat.rules.RulesModule;
 import io.cryostat.sys.SystemModule;
@@ -80,6 +81,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
             CommandsModule.class,
             TemplatesModule.class,
             RulesModule.class,
+            RecordingsModule.class,
         })
 public abstract class MainModule {
     public static final String RECORDINGS_PATH = "RECORDINGS_PATH";

--- a/src/main/java/io/cryostat/net/ConnectionDescriptor.java
+++ b/src/main/java/io/cryostat/net/ConnectionDescriptor.java
@@ -40,6 +40,7 @@ package io.cryostat.net;
 import java.util.Optional;
 
 import io.cryostat.core.net.Credentials;
+import io.cryostat.platform.ServiceRef;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -49,8 +50,16 @@ public class ConnectionDescriptor {
     private final String targetId;
     private final Optional<Credentials> credentials;
 
+    public ConnectionDescriptor(ServiceRef serviceRef) {
+        this(serviceRef.getServiceUri().toString());
+    }
+
     public ConnectionDescriptor(String targetId) {
         this(targetId, null);
+    }
+
+    public ConnectionDescriptor(ServiceRef serviceRef, Credentials credentials) {
+        this(serviceRef.getServiceUri().toString(), credentials);
     }
 
     public ConnectionDescriptor(String targetId, Credentials credentials) {

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -79,7 +79,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
-    // TODO extract this somewhere more appropriate
+    // TODO refactor this to use the RecordingCreationHelper after PR #486 is merged
     public static final Template ALL_EVENTS_TEMPLATE =
             new Template(
                     "ALL",

--- a/src/main/java/io/cryostat/recordings/RecordingCreationHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingCreationHelper.java
@@ -56,6 +56,7 @@ import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.HttpMimeType;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class RecordingCreationHelper {
@@ -123,7 +124,11 @@ public class RecordingCreationHelper {
             m.find();
             String templateName = m.group(1);
             String typeName = m.group(2);
-            return Pair.of(templateName, TemplateType.valueOf(typeName.toUpperCase()));
+            TemplateType templateType = null;
+            if (StringUtils.isNotBlank(typeName)) {
+                templateType = TemplateType.valueOf(typeName.toUpperCase());
+            }
+            return Pair.of(templateName, templateType);
         }
         throw new IllegalArgumentException(eventSpecifier);
     }

--- a/src/main/java/io/cryostat/recordings/RecordingCreationHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingCreationHelper.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.recordings;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import io.cryostat.commands.internal.EventOptionsBuilder;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.templates.TemplateType;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.web.http.HttpMimeType;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public class RecordingCreationHelper {
+
+    private static final String NOTIFICATION_CATEGORY = "RecordingCreated";
+
+    private static final Pattern TEMPLATE_PATTERN =
+            Pattern.compile("^template=([\\w]+)(?:,type=([\\w]+))?$");
+
+    private final TargetConnectionManager targetConnectionManager;
+    private final EventOptionsBuilder.Factory eventOptionsBuilderFactory;
+    private final NotificationFactory notificationFactory;
+
+    RecordingCreationHelper(
+            TargetConnectionManager targetConnectionManager,
+            EventOptionsBuilder.Factory eventOptionsBuilderFactory,
+            NotificationFactory notificationFactory) {
+        this.targetConnectionManager = targetConnectionManager;
+        this.eventOptionsBuilderFactory = eventOptionsBuilderFactory;
+        this.notificationFactory = notificationFactory;
+    }
+
+    public IRecordingDescriptor startRecording(
+            ConnectionDescriptor connectionDescriptor,
+            IConstrainedMap<String> recordingOptions,
+            String templateName,
+            TemplateType templateType)
+            throws Exception {
+        String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
+        return targetConnectionManager.executeConnectedTask(
+                connectionDescriptor,
+                connection -> {
+                    if (getDescriptorByName(connection, recordingName).isPresent()) {
+                        throw new IllegalArgumentException(
+                                String.format(
+                                        "Recording with name \"%s\" already exists",
+                                        recordingName));
+                    }
+                    IRecordingDescriptor desc =
+                            connection
+                                    .getService()
+                                    .start(
+                                            recordingOptions,
+                                            enableEvents(connection, templateName, templateType));
+                    notificationFactory
+                            .createBuilder()
+                            .metaCategory(NOTIFICATION_CATEGORY)
+                            .metaType(HttpMimeType.JSON)
+                            .message(
+                                    Map.of(
+                                            "recording",
+                                            recordingName,
+                                            "target",
+                                            connectionDescriptor.getTargetId()))
+                            .build()
+                            .send();
+                    return desc;
+                });
+    }
+
+    public static Pair<String, TemplateType> parseEventSpecifierToTemplate(String eventSpecifier)
+            throws IllegalArgumentException {
+        if (TEMPLATE_PATTERN.matcher(eventSpecifier).matches()) {
+            Matcher m = TEMPLATE_PATTERN.matcher(eventSpecifier);
+            m.find();
+            String templateName = m.group(1);
+            String typeName = m.group(2);
+            return Pair.of(templateName, TemplateType.valueOf(typeName.toUpperCase()));
+        }
+        throw new IllegalArgumentException(eventSpecifier);
+    }
+
+    private Optional<IRecordingDescriptor> getDescriptorByName(
+            JFRConnection connection, String recordingName) throws Exception {
+        return connection.getService().getAvailableRecordings().stream()
+                .filter(recording -> recording.getName().equals(recordingName))
+                .findFirst();
+    }
+
+    private IConstrainedMap<EventOptionID> enableEvents(
+            JFRConnection connection, String templateName, TemplateType templateType)
+            throws Exception {
+        if (templateName.equals("ALL")) {
+            return enableAllEvents(connection);
+        }
+        if (templateType != null) {
+            return connection
+                    .getTemplateService()
+                    .getEvents(templateName, templateType)
+                    .orElseThrow(
+                            () ->
+                                    new IllegalArgumentException(
+                                            String.format(
+                                                    "No template \"%s\" found with type %s",
+                                                    templateName, templateType)));
+        }
+        // if template type not specified, try to find a Custom template by that name. If none,
+        // fall back on finding a Target built-in template by the name. If not, throw an
+        // exception and bail out.
+        return connection
+                .getTemplateService()
+                .getEvents(templateName, TemplateType.CUSTOM)
+                .or(
+                        () -> {
+                            try {
+                                return connection
+                                        .getTemplateService()
+                                        .getEvents(templateName, TemplateType.TARGET);
+                            } catch (Exception e) {
+                                return Optional.empty();
+                            }
+                        })
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "Invalid/unknown event template %s",
+                                                templateName)));
+    }
+
+    private IConstrainedMap<EventOptionID> enableAllEvents(JFRConnection connection)
+            throws Exception {
+        EventOptionsBuilder builder = eventOptionsBuilderFactory.create(connection);
+
+        for (IEventTypeInfo eventTypeInfo : connection.getService().getAvailableEventTypes()) {
+            builder.addEvent(eventTypeInfo.getEventTypeID().getFullKey(), "enabled", "true");
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/io/cryostat/recordings/RecordingsModule.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsModule.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.recordings;
+
+import javax.inject.Singleton;
+
+import io.cryostat.commands.internal.EventOptionsBuilder;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.TargetConnectionManager;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public abstract class RecordingsModule {
+
+    @Provides
+    @Singleton
+    static RecordingCreationHelper provideRecordingCreationHelper(
+            TargetConnectionManager targetConnectionManager,
+            EventOptionsBuilder.Factory eventOptionsBuilderFactory,
+            NotificationFactory notificationFactory) {
+        return new RecordingCreationHelper(
+                targetConnectionManager, eventOptionsBuilderFactory, notificationFactory);
+    }
+}

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -118,6 +118,9 @@ public class RuleProcessor
     public synchronized void onEvent(Event<RuleEvent, Rule> event) {
         switch (event.getEventType()) {
             case ADDED:
+                platformClient.listDiscoverableServices().stream()
+                        .filter(serviceRef -> registry.applies(event.getPayload(), serviceRef))
+                        .forEach(serviceRef -> activate(event.getPayload(), serviceRef));
                 // FIXME the processor should also be able to apply new rules to targets that have
                 // already appeared
                 break;

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -181,6 +181,15 @@ public class RuleProcessor
     }
 
     private void deactivate(Rule rule, ServiceRef serviceRef) {
+        if (rule == null && serviceRef == null) {
+            throw new IllegalArgumentException("Both parameters cannot be null");
+        }
+        if (rule != null) {
+            logger.trace("Deactivating rule {}", rule.getName());
+        }
+        if (serviceRef != null) {
+            logger.trace("Deactivating rules for {}", serviceRef.getServiceUri());
+        }
         Iterator<Map.Entry<Pair<ServiceRef, Rule>, Future<?>>> it = tasks.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Pair<ServiceRef, Rule>, Future<?>> entry = it.next();

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -121,8 +121,6 @@ public class RuleProcessor
                 platformClient.listDiscoverableServices().stream()
                         .filter(serviceRef -> registry.applies(event.getPayload(), serviceRef))
                         .forEach(serviceRef -> activate(event.getPayload(), serviceRef));
-                // FIXME the processor should also be able to apply new rules to targets that have
-                // already appeared
                 break;
             case REMOVED:
                 deactivate(event.getPayload(), null);

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -116,13 +116,15 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
         return this.rules.stream().filter(r -> Objects.equals(r.getName(), name)).findFirst();
     }
 
+    public boolean applies(Rule rule, ServiceRef serviceRef) {
+        return Objects.equals(rule.getTargetAlias(), serviceRef.getAlias().get());
+    }
+
     public Set<Rule> getRules(ServiceRef serviceRef) {
         if (!serviceRef.getAlias().isPresent()) {
             return Set.of();
         }
-        return rules.stream()
-                .filter(r -> r.getTargetAlias().equals(serviceRef.getAlias().get()))
-                .collect(Collectors.toSet());
+        return rules.stream().filter(r -> applies(r, serviceRef)).collect(Collectors.toSet());
     }
 
     public Set<Rule> getRules() {

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -47,19 +47,18 @@ import java.util.function.Function;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import io.cryostat.commands.internal.EventOptionsBuilder;
 import io.cryostat.commands.internal.RecordingOptionsBuilderFactory;
 import io.cryostat.configuration.ConfigurationModule;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.core.sys.FileSystem;
-import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.NetworkConfiguration;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.platform.PlatformClient;
+import io.cryostat.recordings.RecordingCreationHelper;
 
 import com.google.gson.Gson;
 import dagger.Module;
@@ -101,10 +100,9 @@ public abstract class RulesModule {
             RuleRegistry registry,
             CredentialsManager credentialsManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
-            EventOptionsBuilder.Factory eventOptionsBuilderFactory,
             TargetConnectionManager targetConnectionManager,
+            RecordingCreationHelper recordingCreationHelper,
             PeriodicArchiverFactory periodicArchiverFactory,
-            NotificationFactory notificationFactory,
             Logger logger) {
         return new RuleProcessor(
                 platformClient,
@@ -112,10 +110,9 @@ public abstract class RulesModule {
                 Executors.newScheduledThreadPool(1),
                 credentialsManager,
                 recordingOptionsBuilderFactory,
-                eventOptionsBuilderFactory,
                 targetConnectionManager,
+                recordingCreationHelper,
                 periodicArchiverFactory,
-                notificationFactory,
                 logger);
     }
 

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -47,13 +47,17 @@ import java.util.function.Function;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import io.cryostat.commands.internal.EventOptionsBuilder;
+import io.cryostat.commands.internal.RecordingOptionsBuilderFactory;
 import io.cryostat.configuration.ConfigurationModule;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.core.sys.FileSystem;
+import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.NetworkConfiguration;
+import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.platform.PlatformClient;
 
@@ -96,18 +100,22 @@ public abstract class RulesModule {
             PlatformClient platformClient,
             RuleRegistry registry,
             CredentialsManager credentialsManager,
-            @Named(RULES_WEB_CLIENT) WebClient webClient,
+            RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
+            EventOptionsBuilder.Factory eventOptionsBuilderFactory,
+            TargetConnectionManager targetConnectionManager,
             PeriodicArchiverFactory periodicArchiverFactory,
-            @Named(RULES_HEADERS_FACTORY) Function<Credentials, MultiMap> headersFactory,
+            NotificationFactory notificationFactory,
             Logger logger) {
         return new RuleProcessor(
                 platformClient,
                 registry,
                 Executors.newScheduledThreadPool(1),
                 credentialsManager,
-                webClient,
+                recordingOptionsBuilderFactory,
+                eventOptionsBuilderFactory,
+                targetConnectionManager,
                 periodicArchiverFactory,
-                headersFactory,
+                notificationFactory,
                 logger);
     }
 

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -44,17 +44,16 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import io.cryostat.commands.internal.EventOptionsBuilder;
 import io.cryostat.commands.internal.RecordingOptionsBuilderFactory;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
-import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.TargetDiscoveryEvent;
+import io.cryostat.recordings.RecordingCreationHelper;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,10 +74,9 @@ class RuleProcessorTest {
     @Mock ScheduledExecutorService scheduler;
     @Mock CredentialsManager credentialsManager;
     @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
-    @Mock EventOptionsBuilder.Factory eventOptionsBuilderFactory;
     @Mock TargetConnectionManager targetConnectionManager;
+    @Mock RecordingCreationHelper recordingCreationHelper;
     @Mock PeriodicArchiverFactory periodicArchiverFactory;
-    @Mock NotificationFactory notificationFactory;
     @Mock Logger logger;
 
     @BeforeEach
@@ -90,10 +88,9 @@ class RuleProcessorTest {
                         scheduler,
                         credentialsManager,
                         recordingOptionsBuilderFactory,
-                        eventOptionsBuilderFactory,
                         targetConnectionManager,
+                        recordingCreationHelper,
                         periodicArchiverFactory,
-                        notificationFactory,
                         logger);
     }
 


### PR DESCRIPTION
With this change, adding a new rule definition causes that rule to become immediately activated for any matching targets that are already known. Prior to this change adding a new rule definition would only affect targets that (re)appear after the rule was added.

Example:

1. Run smoketest.sh
2.
```
$ http --verify=false -f https://0.0.0.0:8181/api/v2/rules name=foorule description="Rule for testing" targetAlias=es.andrewazor.demo.Main eventSpecifier="template=Continuous"
HTTP/1.1 201 Created
content-encoding: gzip
content-length: 94
location: /api/v2/rules/foorule

{"meta":{"type":"text/plain","status":"Created"},"data":{"result":"foorule"}}
```

3. Check that the vertx sample app listening on 9093 has a new recording named auto_foorule. The other vertx apps on 9094 and 9095 require credentials, so they will not have matching recordings, but Cryostat's logs should reveal that it attempted to start recordings on them and failed due to the lack of credentials.