### PR TITLE
Validate JSON document during auto-rules creation

### DIFF
--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -117,7 +117,7 @@ public abstract class MainModule {
                 .serializeNulls()
                 .disableHtmlEscaping()
                 .registerTypeAdapter(JMXServiceURL.class, new GsonJmxServiceUrlAdapter(logger))
-                .registerTypeAdapter(Rule.class, new GsonRuleAdapter(logger))
+                .registerTypeAdapter(Rule.class, new GsonRuleAdapter())
                 .registerTypeAdapter(HttpMimeType.class, new HttpMimeTypeAdapter())
                 .registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
                 .create();

--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -60,9 +60,9 @@ import io.cryostat.rules.RulesModule;
 import io.cryostat.sys.SystemModule;
 import io.cryostat.templates.TemplatesModule;
 import io.cryostat.util.GsonJmxServiceUrlAdapter;
-import io.cryostat.util.GsonRuleAdapter;
 import io.cryostat.util.HttpMimeTypeAdapter;
 import io.cryostat.util.PathTypeAdapter;
+import io.cryostat.util.RuleDeserializer;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -117,9 +117,9 @@ public abstract class MainModule {
                 .serializeNulls()
                 .disableHtmlEscaping()
                 .registerTypeAdapter(JMXServiceURL.class, new GsonJmxServiceUrlAdapter(logger))
-                .registerTypeAdapter(Rule.class, new GsonRuleAdapter())
                 .registerTypeAdapter(HttpMimeType.class, new HttpMimeTypeAdapter())
                 .registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
+                .registerTypeAdapter(Rule.class, new RuleDeserializer())
                 .create();
     }
 

--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -55,10 +55,12 @@ import io.cryostat.messaging.MessagingModule;
 import io.cryostat.net.NetworkModule;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.PlatformModule;
+import io.cryostat.rules.Rule;
 import io.cryostat.rules.RulesModule;
 import io.cryostat.sys.SystemModule;
 import io.cryostat.templates.TemplatesModule;
 import io.cryostat.util.GsonJmxServiceUrlAdapter;
+import io.cryostat.util.GsonRuleAdapter;
 import io.cryostat.util.HttpMimeTypeAdapter;
 import io.cryostat.util.PathTypeAdapter;
 
@@ -115,6 +117,7 @@ public abstract class MainModule {
                 .serializeNulls()
                 .disableHtmlEscaping()
                 .registerTypeAdapter(JMXServiceURL.class, new GsonJmxServiceUrlAdapter(logger))
+                .registerTypeAdapter(Rule.class, new GsonRuleAdapter(logger))
                 .registerTypeAdapter(HttpMimeType.class, new HttpMimeTypeAdapter())
                 .registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
                 .create();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -118,7 +118,8 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
             case MULTIPART_FORM:
             case URLENCODED_FORM:
                 try {
-                    rule = Rule.buildRule(params.getFormAttributes());
+                    Rule.Builder builder = Rule.Builder.from(params.getFormAttributes());
+                    rule = builder.build();
                 } catch (IllegalArgumentException iae) {
                     throw new ApiException(400, iae);
                 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -50,6 +50,7 @@ import io.cryostat.rules.Rule;
 import io.cryostat.rules.RuleRegistry;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -149,8 +150,8 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
             case JSON:
                 try {
                     rule = gson.fromJson(params.getBody(), Rule.class);
-                } catch (IllegalArgumentException iae) {
-                    throw new ApiException(400, iae);
+                } catch (IllegalArgumentException | JsonSyntaxException e) {
+                    throw new ApiException(400, e);
                 }
                 break;
             default:

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -147,7 +147,11 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
                 }
                 break;
             case JSON:
-                rule = gson.fromJson(params.getBody(), Rule.class);
+                try {
+                    rule = gson.fromJson(params.getBody(), Rule.class);
+                } catch (IllegalArgumentException iae) {
+                    throw new ApiException(400, iae);
+                }
                 break;
             default:
                 throw new ApiException(415, "Bad content type: " + rawMime);

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -56,18 +56,16 @@ public class Rule {
     private final int maxSizeBytes;
 
     Rule(Builder builder) {
-        this.name = sanitizeRuleName(requireNonBlank(builder.name, Attribute.NAME));
+        this.name = sanitizeRuleName(builder.name);
         this.description = builder.description == null ? "" : builder.description;
-        this.targetAlias = requireNonBlank(builder.targetAlias, Attribute.TARGET_ALIAS);
-        this.eventSpecifier = requireNonBlank(builder.eventSpecifier, Attribute.EVENT_SPECIFIER);
-        this.archivalPeriodSeconds =
-                requireNonNegative(
-                        builder.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
-        this.preservedArchives =
-                requireNonNegative(builder.preservedArchives, Attribute.PRESERVED_ARCHIVES);
+        this.targetAlias = builder.targetAlias;
+        this.eventSpecifier = builder.eventSpecifier;
+        this.archivalPeriodSeconds = builder.archivalPeriodSeconds;
+        this.preservedArchives = builder.preservedArchives;
         this.maxAgeSeconds =
                 builder.maxAgeSeconds > 0 ? builder.maxAgeSeconds : this.archivalPeriodSeconds;
         this.maxSizeBytes = builder.maxSizeBytes;
+        this.validate();
     }
 
     public String getName() {
@@ -109,7 +107,7 @@ public class Rule {
 
     static String sanitizeRuleName(String name) {
         // FIXME this is not robust
-        return name.replaceAll("\\s", "_");
+        return requireNonBlank(name, Attribute.NAME).replaceAll("\\s", "_");
     }
 
     private static String requireNonBlank(String s, Attribute attr) {
@@ -126,6 +124,15 @@ public class Rule {
                     String.format("\"%s\" cannot be negative, was \"%d\"", attr, i));
         }
         return i;
+    }
+
+    public void validate() throws IllegalArgumentException {
+
+        requireNonBlank(this.name, Attribute.NAME);
+        requireNonBlank(this.targetAlias, Attribute.TARGET_ALIAS);
+        requireNonBlank(this.eventSpecifier, Attribute.EVENT_SPECIFIER);
+        requireNonNegative(this.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
+        requireNonNegative(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
     }
 
     @Override

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -39,9 +39,7 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.vertx.core.MultiMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -226,12 +224,6 @@ public class Rule {
         }
 
         public static Builder from(JsonObject jsonObj) throws IllegalArgumentException {
-
-            // sanitize name
-            String name = Rule.Attribute.NAME.getSerialKey();
-            String dirty = jsonObj.get(name).getAsString();
-            JsonElement sanitized = JsonParser.parseString(Rule.sanitizeRuleName(dirty));
-            jsonObj.add(name, sanitized);
 
             Rule.Builder builder =
                     new Rule.Builder()

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -56,7 +56,7 @@ public class Rule {
     private final int maxSizeBytes;
 
     Rule(Builder builder) {
-        this.name = sanitizeRuleName(builder.name);
+        this.name = sanitizeRuleName(requireNonBlank(builder.name, Attribute.NAME));
         this.description = builder.description == null ? "" : builder.description;
         this.targetAlias = builder.targetAlias;
         this.eventSpecifier = builder.eventSpecifier;
@@ -107,7 +107,7 @@ public class Rule {
 
     static String sanitizeRuleName(String name) {
         // FIXME this is not robust
-        return requireNonBlank(name, Attribute.NAME).replaceAll("\\s", "_");
+        return name.replaceAll("\\s", "_");
     }
 
     private static String requireNonBlank(String s, Attribute attr) {

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -105,7 +105,7 @@ public class Rule {
         return this.maxSizeBytes;
     }
 
-    static String sanitizeRuleName(String name) {
+    public static String sanitizeRuleName(String name) {
         // FIXME this is not robust
         return name.replaceAll("\\s", "_");
     }

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -39,7 +39,9 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.vertx.core.MultiMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -202,6 +204,125 @@ public class Rule {
         public Rule build() {
             return new Rule(this);
         }
+
+        public static Builder from(MultiMap formAttributes) {
+            Rule.Builder builder =
+                    new Rule.Builder()
+                            .name(formAttributes.get(Rule.Attribute.NAME.getSerialKey()))
+                            .targetAlias(
+                                    formAttributes.get(Rule.Attribute.TARGET_ALIAS.getSerialKey()))
+                            .description(
+                                    formAttributes.get(Rule.Attribute.DESCRIPTION.getSerialKey()))
+                            .eventSpecifier(
+                                    formAttributes.get(
+                                            Rule.Attribute.EVENT_SPECIFIER.getSerialKey()));
+
+            builder.setOptionalInt(Rule.Attribute.ARCHIVAL_PERIOD_SECONDS, formAttributes);
+            builder.setOptionalInt(Rule.Attribute.PRESERVED_ARCHIVES, formAttributes);
+            builder.setOptionalInt(Rule.Attribute.MAX_AGE_SECONDS, formAttributes);
+            builder.setOptionalInt(Rule.Attribute.MAX_SIZE_BYTES, formAttributes);
+
+            return builder;
+        }
+
+        public static Builder from(JsonObject jsonObj) throws IllegalArgumentException {
+
+            // sanitize name
+            String name = Rule.Attribute.NAME.getSerialKey();
+            String dirty = jsonObj.get(name).getAsString();
+            JsonElement sanitized = JsonParser.parseString(Rule.sanitizeRuleName(dirty));
+            jsonObj.add(name, sanitized);
+
+            Rule.Builder builder =
+                    new Rule.Builder()
+                            .name(jsonObj.get(Rule.Attribute.NAME.getSerialKey()).getAsString())
+                            .targetAlias(
+                                    jsonObj.get(Rule.Attribute.TARGET_ALIAS.getSerialKey())
+                                            .getAsString())
+                            .description(
+                                    jsonObj.get(Rule.Attribute.DESCRIPTION.getSerialKey())
+                                            .getAsString())
+                            .eventSpecifier(
+                                    jsonObj.get(Rule.Attribute.EVENT_SPECIFIER.getSerialKey())
+                                            .getAsString());
+            builder.setOptionalInt(Rule.Attribute.ARCHIVAL_PERIOD_SECONDS, jsonObj);
+            builder.setOptionalInt(Rule.Attribute.PRESERVED_ARCHIVES, jsonObj);
+            builder.setOptionalInt(Rule.Attribute.MAX_AGE_SECONDS, jsonObj);
+            builder.setOptionalInt(Rule.Attribute.MAX_SIZE_BYTES, jsonObj);
+
+            return builder;
+        }
+
+        private Builder setOptionalInt(Rule.Attribute key, MultiMap formAttributes)
+                throws IllegalArgumentException {
+
+            if (!formAttributes.contains(key.getSerialKey())) {
+                return this;
+            }
+
+            Function<Integer, Rule.Builder> fn = this.selectAttribute(key);
+
+            int value;
+            try {
+                value = Integer.parseInt(formAttributes.get(key.getSerialKey()));
+            } catch (NumberFormatException nfe) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "\"%s\" is an invalid (non-integer) value for \"%s\"",
+                                formAttributes.get(key.getSerialKey()), key),
+                        nfe);
+            }
+            return fn.apply(value);
+        }
+
+        private Builder setOptionalInt(Rule.Attribute key, JsonObject jsonObj)
+                throws IllegalArgumentException {
+
+            if (jsonObj.get(key.getSerialKey()) == null) {
+                return this;
+            }
+
+            Function<Integer, Rule.Builder> fn = this.selectAttribute(key);
+
+            int value;
+            String attr = key.getSerialKey();
+
+            try {
+                value = jsonObj.get(attr).getAsInt();
+            } catch (ClassCastException | IllegalStateException e) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "\"%s\" is an invalid (non-integer) value for \"%s\"",
+                                jsonObj.get(attr), attr),
+                        e);
+            }
+            return fn.apply(value);
+        }
+
+        private Function<Integer, Rule.Builder> selectAttribute(Rule.Attribute key)
+                throws IllegalArgumentException {
+
+            Function<Integer, Rule.Builder> fn;
+
+            switch (key) {
+                case ARCHIVAL_PERIOD_SECONDS:
+                    fn = this::archivalPeriodSeconds;
+                    break;
+                case PRESERVED_ARCHIVES:
+                    fn = this::preservedArchives;
+                    break;
+                case MAX_AGE_SECONDS:
+                    fn = this::maxAgeSeconds;
+                    break;
+                case MAX_SIZE_BYTES:
+                    fn = this::maxSizeBytes;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown key \"" + key + "\"");
+            }
+
+            return fn;
+        }
     }
 
     public enum Attribute {
@@ -229,118 +350,5 @@ public class Rule {
         public String toString() {
             return getSerialKey();
         }
-    }
-
-    public static Rule buildRule(MultiMap formAttributes) {
-        Rule.Builder builder =
-                new Rule.Builder()
-                        .name(formAttributes.get(Rule.Attribute.NAME.getSerialKey()))
-                        .targetAlias(formAttributes.get(Rule.Attribute.TARGET_ALIAS.getSerialKey()))
-                        .description(formAttributes.get(Rule.Attribute.DESCRIPTION.getSerialKey()))
-                        .eventSpecifier(
-                                formAttributes.get(Rule.Attribute.EVENT_SPECIFIER.getSerialKey()));
-
-        builder = setOptionalInt(builder, Rule.Attribute.ARCHIVAL_PERIOD_SECONDS, formAttributes);
-        builder = setOptionalInt(builder, Rule.Attribute.PRESERVED_ARCHIVES, formAttributes);
-        builder = setOptionalInt(builder, Rule.Attribute.MAX_AGE_SECONDS, formAttributes);
-        builder = setOptionalInt(builder, Rule.Attribute.MAX_SIZE_BYTES, formAttributes);
-
-        return builder.build();
-    }
-
-    public static Rule buildRule(JsonObject jsonObj) throws IllegalArgumentException {
-
-        Rule.Builder builder =
-                new Rule.Builder()
-                        .name(jsonObj.get(Rule.Attribute.NAME.getSerialKey()).getAsString())
-                        .targetAlias(
-                                jsonObj.get(Rule.Attribute.TARGET_ALIAS.getSerialKey())
-                                        .getAsString())
-                        .description(
-                                jsonObj.get(Rule.Attribute.DESCRIPTION.getSerialKey())
-                                        .getAsString())
-                        .eventSpecifier(
-                                jsonObj.get(Rule.Attribute.EVENT_SPECIFIER.getSerialKey())
-                                        .getAsString());
-        builder = setOptionalInt(builder, Rule.Attribute.ARCHIVAL_PERIOD_SECONDS, jsonObj);
-        builder = setOptionalInt(builder, Rule.Attribute.PRESERVED_ARCHIVES, jsonObj);
-        builder = setOptionalInt(builder, Rule.Attribute.MAX_AGE_SECONDS, jsonObj);
-        builder = setOptionalInt(builder, Rule.Attribute.MAX_SIZE_BYTES, jsonObj);
-
-        return builder.build();
-    }
-
-    public static Rule.Builder setOptionalInt(
-            Rule.Builder builder, Rule.Attribute key, MultiMap formAttributes)
-            throws IllegalArgumentException {
-
-        if (!formAttributes.contains(key.getSerialKey())) {
-            return builder;
-        }
-
-        Function<Integer, Rule.Builder> fn = selectAttribute(builder, key);
-
-        int value;
-        try {
-            value = Integer.parseInt(formAttributes.get(key.getSerialKey()));
-        } catch (NumberFormatException nfe) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "\"%s\" is an invalid (non-integer) value for \"%s\"",
-                            formAttributes.get(key.getSerialKey()), key),
-                    nfe);
-        }
-        return fn.apply(value);
-    }
-
-    public static Rule.Builder setOptionalInt(
-            Rule.Builder builder, Rule.Attribute key, JsonObject jsonObj)
-            throws IllegalArgumentException {
-
-        if (jsonObj.get(key.getSerialKey()) == null) {
-            return builder;
-        }
-
-        Function<Integer, Rule.Builder> fn = selectAttribute(builder, key);
-
-        int value;
-        String attr = key.getSerialKey();
-
-        try {
-            value = jsonObj.get(attr).getAsInt();
-        } catch (ClassCastException | IllegalStateException e) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "\"%s\" is an invalid (non-integer) value for \"%s\"",
-                            jsonObj.get(attr), attr),
-                    e);
-        }
-
-        return fn.apply(value);
-    }
-
-    private static Function<Integer, Rule.Builder> selectAttribute(
-            Rule.Builder builder, Rule.Attribute key) throws IllegalArgumentException {
-
-        Function<Integer, Rule.Builder> fn;
-
-        switch (key) {
-            case ARCHIVAL_PERIOD_SECONDS:
-                fn = builder::archivalPeriodSeconds;
-                break;
-            case PRESERVED_ARCHIVES:
-                fn = builder::preservedArchives;
-                break;
-            case MAX_AGE_SECONDS:
-                fn = builder::maxAgeSeconds;
-                break;
-            case MAX_SIZE_BYTES:
-                fn = builder::maxSizeBytes;
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown key \"" + key + "\"");
-        }
-
-        return fn;
     }
 }

--- a/src/main/java/io/cryostat/util/GsonRuleAdapter.java
+++ b/src/main/java/io/cryostat/util/GsonRuleAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.util;
+
+import java.lang.reflect.Type;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.rules.Rule;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class GsonRuleAdapter implements JsonDeserializer<Rule> {
+
+    private final Logger logger;
+
+    public GsonRuleAdapter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public Rule deserialize(JsonElement json, Type typeOf, JsonDeserializationContext context)
+            throws IllegalArgumentException {
+
+        try {
+            JsonObject jsonObject = json.getAsJsonObject();
+            Rule rule = new Gson().fromJson(jsonObject, Rule.class);
+
+            rule.validate();
+            return rule;
+
+        } catch (IllegalArgumentException iae) {
+            logger.warn(iae);
+            throw iae;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/util/GsonRuleAdapter.java
+++ b/src/main/java/io/cryostat/util/GsonRuleAdapter.java
@@ -39,7 +39,6 @@ package io.cryostat.util;
 
 import java.lang.reflect.Type;
 
-import io.cryostat.core.log.Logger;
 import io.cryostat.rules.Rule;
 
 import com.google.gson.Gson;
@@ -50,26 +49,14 @@ import com.google.gson.JsonObject;
 
 public class GsonRuleAdapter implements JsonDeserializer<Rule> {
 
-    private final Logger logger;
-
-    public GsonRuleAdapter(Logger logger) {
-        this.logger = logger;
-    }
-
     @Override
     public Rule deserialize(JsonElement json, Type typeOf, JsonDeserializationContext context)
             throws IllegalArgumentException {
 
-        try {
-            JsonObject jsonObject = json.getAsJsonObject();
-            Rule rule = new Gson().fromJson(jsonObject, Rule.class);
+        JsonObject jsonObject = json.getAsJsonObject();
+        Rule rule = new Gson().fromJson(jsonObject, Rule.class);
 
-            rule.validate();
-            return rule;
-
-        } catch (IllegalArgumentException iae) {
-            logger.warn(iae);
-            throw iae;
-        }
+        rule.validate();
+        return rule;
     }
 }

--- a/src/main/java/io/cryostat/util/RuleDeserializer.java
+++ b/src/main/java/io/cryostat/util/RuleDeserializer.java
@@ -46,6 +46,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class RuleDeserializer implements JsonDeserializer<Rule> {
 
@@ -54,6 +55,12 @@ public class RuleDeserializer implements JsonDeserializer<Rule> {
             throws IllegalArgumentException {
 
         JsonObject jsonObject = json.getAsJsonObject();
+
+        String name = Rule.Attribute.NAME.getSerialKey();
+        String dirty = jsonObject.get(name).getAsString();
+        JsonElement sanitized = JsonParser.parseString(Rule.sanitizeRuleName(dirty));
+        jsonObject.add(name, sanitized); // replaces field with sanitized name
+
         Rule rule = new Gson().fromJson(jsonObject, Rule.class);
 
         rule.validate();

--- a/src/main/java/io/cryostat/util/RuleDeserializer.java
+++ b/src/main/java/io/cryostat/util/RuleDeserializer.java
@@ -39,7 +39,6 @@ package io.cryostat.util;
 
 import java.lang.reflect.Type;
 
-import io.cryostat.net.web.http.api.v2.RulesPostHandler;
 import io.cryostat.rules.Rule;
 
 import com.google.gson.JsonDeserializationContext;
@@ -62,6 +61,6 @@ public class RuleDeserializer implements JsonDeserializer<Rule> {
         JsonElement sanitized = JsonParser.parseString(Rule.sanitizeRuleName(dirty));
         jsonObject.add(name, sanitized); // replaces field with sanitized name
 
-        return RulesPostHandler.buildRule(jsonObject);
+        return Rule.buildRule(jsonObject);
     }
 }

--- a/src/main/java/io/cryostat/util/RuleDeserializer.java
+++ b/src/main/java/io/cryostat/util/RuleDeserializer.java
@@ -47,7 +47,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-public class GsonRuleAdapter implements JsonDeserializer<Rule> {
+public class RuleDeserializer implements JsonDeserializer<Rule> {
 
     @Override
     public Rule deserialize(JsonElement json, Type typeOf, JsonDeserializationContext context)

--- a/src/main/java/io/cryostat/util/RuleDeserializer.java
+++ b/src/main/java/io/cryostat/util/RuleDeserializer.java
@@ -45,7 +45,6 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
 public class RuleDeserializer implements JsonDeserializer<Rule> {
@@ -56,11 +55,8 @@ public class RuleDeserializer implements JsonDeserializer<Rule> {
 
         JsonObject jsonObject = json.getAsJsonObject();
 
-        String name = Rule.Attribute.NAME.getSerialKey();
-        String dirty = jsonObject.get(name).getAsString();
-        JsonElement sanitized = JsonParser.parseString(Rule.sanitizeRuleName(dirty));
-        jsonObject.add(name, sanitized); // replaces field with sanitized name
+        Rule.Builder builder = Rule.Builder.from(jsonObject);
 
-        return Rule.buildRule(jsonObject);
+        return builder.build();
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.io.IOException;
+import java.util.Map;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
@@ -221,20 +222,20 @@ class RulesPostHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"-10", "", "one", "|", "[]"})
+        @ValueSource(strings = {"-10", "", "one", "|", "[1, 2, 3]"})
         void throwsIfOptionalJsonAttributesNegativeOrNonInteger(String val) {
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
             Mockito.when(params.getHeaders()).thenReturn(headers);
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
 
             String invalidRule =
-                    "{\"name\":\"Invalid_Rule\","
-                            + "\"description\":\"AutoRulesIT automated rule\","
-                            + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
-                            + "\"targetAlias\":\"es.andrewazor.demo.Main\","
-                            + "\"archivalPeriodSeconds\":"
-                            + val
-                            + "}";
+                    gson.toJson(
+                            Map.of(
+                                    "name", "Auto Rule ",
+                                    "description", "AutoRulesIT automated rule",
+                                    "eventSpecifier", "template=Continuous,type=TARGET",
+                                    "targetAlias", "es.andrewazor.demo.Main",
+                                    "archivalPeriodSeconds", val));
             Mockito.when(params.getBody()).thenReturn(invalidRule);
 
             ApiException ex =
@@ -273,22 +274,32 @@ class RulesPostHandlerTest {
             Mockito.when(params.getHeaders()).thenReturn(headers);
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
             String json =
-                    "{\"name\":\"foo Rule\","
-                            + "\"description\":\"AutoRulesIT automated rule\","
-                            + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
-                            + "\"targetAlias\":\"es.andrewazor.demo.Main\","
-                            + "\"archivalPeriodSeconds\":60,"
-                            + "\"preservedArchives\":5,"
-                            + "\"maxAgeSeconds\":60,"
-                            + "\"maxSizeBytes\":8192}";
+                    gson.toJson(
+                            Map.of(
+                                    "name",
+                                    "Auto Rule",
+                                    "description",
+                                    "AutoRulesIT automated rule",
+                                    "eventSpecifier",
+                                    "template=Continuous,type=TARGET",
+                                    "targetAlias",
+                                    "es.andrewazor.demo.Main",
+                                    "archivalPeriodSeconds",
+                                    60,
+                                    "preservedArchives",
+                                    5,
+                                    "maxAgeSeconds",
+                                    60,
+                                    "maxSizeBytes",
+                                    8192));
             Mockito.when(params.getBody()).thenReturn(json);
 
             IntermediateResponse<String> response = handler.handle(params);
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(201));
             MatcherAssert.assertThat(
                     response.getHeaders().get(HttpHeaders.LOCATION),
-                    Matchers.equalTo("/api/v2/rules/foo_Rule"));
-            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo("foo_Rule"));
+                    Matchers.equalTo("/api/v2/rules/Auto_Rule"));
+            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo("Auto_Rule"));
         }
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -241,7 +241,7 @@ class RulesPostHandlerTest {
         }
 
         @Test
-        void addsRuleAndReturnsResponse() {
+        void addsRuleWithFormAndReturnsResponse() {
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
             Mockito.when(params.getHeaders()).thenReturn(headers);
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.MULTIPART_FORM.mime());
@@ -255,6 +255,30 @@ class RulesPostHandlerTest {
             form.set(Rule.Attribute.PRESERVED_ARCHIVES.getSerialKey(), "5");
             form.set(Rule.Attribute.MAX_AGE_SECONDS.getSerialKey(), "60");
             form.set(Rule.Attribute.MAX_SIZE_BYTES.getSerialKey(), "8192");
+
+            IntermediateResponse<String> response = handler.handle(params);
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(201));
+            MatcherAssert.assertThat(
+                    response.getHeaders().get(HttpHeaders.LOCATION),
+                    Matchers.equalTo("/api/v2/rules/fooRule"));
+            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo("fooRule"));
+        }
+
+        @Test
+        void addsRuleWithJsonAndReturnsResponse() {
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            Mockito.when(params.getHeaders()).thenReturn(headers);
+            headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
+            String json =
+                    "{\"name\":\"fooRule\","
+                            + "\"description\":\"AutoRulesIT automated rule\","
+                            + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
+                            + "\"targetAlias\":\"es.andrewazor.demo.Main\","
+                            + "\"archivalPeriodSeconds\":60,"
+                            + "\"preservedArchives\":5,"
+                            + "\"maxAgeSeconds\":60,"
+                            + "\"maxSizeBytes\":8192}";
+            Mockito.when(params.getBody()).thenReturn(json);
 
             IntermediateResponse<String> response = handler.handle(params);
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(201));

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -227,7 +227,11 @@ class RulesPostHandlerTest {
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
 
             String invalidRule =
-                    "{\"name\":\"Invalid_Rule\",\"description\":\"AutoRulesIT automated rule\",\"eventSpecifier\":\"template=Continuous,type=TARGET\",\"targetAlias\":\"es.andrewazor.demo.Main\",\"archivalPeriodSeconds\":-60,\"preservedArchives\":10,\"maxAgeSeconds\":0}";
+                    "{\"name\":\"Invalid_Rule\","
+                            + "\"description\":\"AutoRulesIT automated rule\","
+                            + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
+                            + "\"targetAlias\":\"es.andrewazor.demo.Main\","
+                            + "\"archivalPeriodSeconds\":-60}";
             Mockito.when(params.getBody()).thenReturn(invalidRule);
 
             ApiException ex =

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -270,7 +270,7 @@ class RulesPostHandlerTest {
             Mockito.when(params.getHeaders()).thenReturn(headers);
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
             String json =
-                    "{\"name\":\"fooRule\","
+                    "{\"name\":\"foo Rule\","
                             + "\"description\":\"AutoRulesIT automated rule\","
                             + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
                             + "\"targetAlias\":\"es.andrewazor.demo.Main\","
@@ -284,8 +284,8 @@ class RulesPostHandlerTest {
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(201));
             MatcherAssert.assertThat(
                     response.getHeaders().get(HttpHeaders.LOCATION),
-                    Matchers.equalTo("/api/v2/rules/fooRule"));
-            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo("fooRule"));
+                    Matchers.equalTo("/api/v2/rules/foo_Rule"));
+            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo("foo_Rule"));
         }
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -221,6 +221,22 @@ class RulesPostHandlerTest {
         }
 
         @Test
+        void throwsIfOptionalJsonIntegerAttributesNegative() {
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            Mockito.when(params.getHeaders()).thenReturn(headers);
+            headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
+
+            String invalidRule =
+                    "{\"name\":\"Invalid_Rule\",\"description\":\"AutoRulesIT automated rule\",\"eventSpecifier\":\"template=Continuous,type=TARGET\",\"targetAlias\":\"es.andrewazor.demo.Main\",\"archivalPeriodSeconds\":-60,\"preservedArchives\":10,\"maxAgeSeconds\":0}";
+            Mockito.when(params.getBody()).thenReturn(invalidRule);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.containsString("negative"));
+        }
+
+        @Test
         void addsRuleAndReturnsResponse() {
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
             Mockito.when(params.getHeaders()).thenReturn(headers);

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -220,8 +220,9 @@ class RulesPostHandlerTest {
             MatcherAssert.assertThat(ex.getFailureReason(), Matchers.containsString(val));
         }
 
-        @Test
-        void throwsIfOptionalJsonIntegerAttributesNegative() {
+        @ParameterizedTest
+        @ValueSource(strings = {"-10", "", "one", "|", "[]"})
+        void throwsIfOptionalJsonAttributesNegativeOrNonInteger(String val) {
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
             Mockito.when(params.getHeaders()).thenReturn(headers);
             headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
@@ -231,13 +232,15 @@ class RulesPostHandlerTest {
                             + "\"description\":\"AutoRulesIT automated rule\","
                             + "\"eventSpecifier\":\"template=Continuous,type=TARGET\","
                             + "\"targetAlias\":\"es.andrewazor.demo.Main\","
-                            + "\"archivalPeriodSeconds\":-60}";
+                            + "\"archivalPeriodSeconds\":"
+                            + val
+                            + "}";
             Mockito.when(params.getBody()).thenReturn(invalidRule);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.containsString("negative"));
+            MatcherAssert.assertThat(ex.getFailureReason(), Matchers.containsString(val));
         }
 
         @Test

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -192,6 +192,30 @@ class AutoRulesIT extends ExternalTargetsTest {
 
     @Test
     @Order(2)
+    void testAddRuleThrowsWhenJsonIntegerAttributesNegative() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        JsonObject invalidRule = new JsonObject();
+        invalidRule.put("name", "Invalid_Rule");
+        invalidRule.put("description", "AutoRulesIT automated rule");
+        invalidRule.put("eventSpecifier", "template=Continuous,type=TARGET");
+        invalidRule.put("targetAlias", "es.andrewazor.demo.Main");
+        invalidRule.put("archivalPeriodSeconds", -60);
+        invalidRule.put("preservedArchives", -3);
+
+        webClient
+                .post("/api/v2/rules")
+                .sendJsonObject(
+                        invalidRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(400));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(3)
     void testAddCredentials() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
@@ -217,7 +241,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void testNewContainerHasRuleApplied() throws Exception {
         CONTAINERS.add(
                 Podman.run(
@@ -266,7 +290,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void testRuleCanBeDeleted() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
@@ -288,7 +312,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void testCredentialsCanBeDeleted() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient


### PR DESCRIPTION
Fixes #530 

@andrewazores I found a `JsonDeserializer` that can reuse `requireNonNegative()` and I have some questions about how to implement it. 

`private final Gson gson` needs to be modified in order to register the `Type Adapter` for `IntegerDeserializer`. Why is `gson` `final`?

`IntegerDeserializer` gets passed JSON values without their keys, which means I'm not sure how to pass the correct `Attribute` to `requireNonNegative()`.

`IntegerDeserializer` only works if our numeric values are of type `Integer`, not `int`. How will this affect performance?

Here's the output as of now:
```
$ vi testRule.json

{
   "name": "test",
   "description": "AutoRulesIT automated rule",
   "eventSpecifier": "template=Continuous,type=TARGET",
   "targetAlias": "es.andrewazor.demo.Main",
   "archivalPeriodSeconds": 60,
   "preservedArchives": -10,
   "maxAgeSeconds": 60
}

$ curl -v --insecure -H "Content-Type: application/json"  -d @testRule.json https://0.0.0.0:8181/api/v2/rules/
...
< HTTP/1.1 400 Bad Request
< content-type: application/json
< content-length: 131
< 
* Connection #0 to host 0.0.0.0 left intact
{"meta":{"type":"text/plain","status":"Bad Request"},"data":{"reason":"\"archivalPeriodSeconds\" cannot be negative, was \"-10\""}}
```

Some of the other approaches I've thought of include parsing `params.getBody()` before calling `gson.fromJson(...)` or using a `Rule.Builder` similar to the JSON form pathway. I'd like to avoid parsing the JSON more than once though, and am not sure how to efficiently map key/value pairs from the `params.getBody()` string to the `Rule.Builder`.