### PR TITLE
ci(ci): Push built CI images to Quay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: query-pom
+      name: Get properties from POM
       # Query POM for core and image version and save as output parameter
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
@@ -65,7 +66,8 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
-    - run: >
+    - name: Tag images
+      run: >
         podman tag
         ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
         ${{ env.CRYOSTAT_IMG }}:${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [get-pom-properties, build-deps]
+    env:
+      CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:
     - uses: actions/checkout@v2
       with:
@@ -65,9 +67,9 @@ jobs:
     - run: mvn -B -U clean verify
     - run: >
         podman tag
-        quay.io/cryostat/cryostat:${{ needs.get-pom-properties.outputs.image-version }}
-        quay.io/cryostat/cryostat:${{ github.sha }}
-        quay.io/cryostat/cryostat:latest
+        ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
+        ${{ env.CRYOSTAT_IMG }}:${{ github.sha }}
+        ${{ env.CRYOSTAT_IMG }}:latest
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
@@ -76,7 +78,7 @@ jobs:
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: quay.io/cryostat/cryostat
+        image: ${{ env.CRYOSTAT_IMG }}
         tags: >
           ${{ needs.get-pom-properties.outputs.image-version }}
           ${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI build
+name: CI build and push
 
 on:
   push:
@@ -7,26 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
-  get-core-version:
+  get-pom-properties:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - id: query-pom
-      # Query POM for core version and save as output parameter
+      # Query POM for core and image version and save as output parameter
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
         echo "::set-output name=core-version::v$CORE_VERSION"
+        IMAGE_VERSION="$(mvn help:evaluate -Dexpression=cryostat.imageVersion -q -DforceStdout)"
+        echo "::set-output name=image-version::$IMAGE_VERSION"
     outputs:
       core-version: ${{ steps.query-pom.outputs.core-version }}
+      image-version: ${{ steps.query-pom.outputs.image-version }}
 
   build-deps:
     runs-on: ubuntu-latest
-    needs: [get-core-version]
+    needs: [get-pom-properties]
     steps:
     - uses: actions/checkout@v2
       with:
         repository: cryostatio/cryostat-core
-        ref: ${{ needs.get-core-version.outputs.core-version }}
+        ref: ${{ needs.get-pom-properties.outputs.core-version }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
@@ -41,7 +44,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [build-deps]
+    needs: [get-pom-properties, build-deps]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -60,6 +63,28 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
+    - run: >
+        podman tag
+        quay.io/cryostat/cryostat:${{ needs.get-pom-properties.outputs.image-version }}
+        quay.io/cryostat/cryostat:${{ github.sha }}
+        quay.io/cryostat/cryostat:latest
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: quay.io/cryostat/cryostat
+        tags: >
+          ${{ needs.get-pom-properties.outputs.image-version }}
+          ${{ github.sha }}
+          latest
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ env.CRYOSTAT_IMG }}
+        image: cryostat
         tags: >
           ${{ needs.get-pom-properties.outputs.image-version }}
           ${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     - run: mvn -B -U -DskipTests=true clean install
     - uses: actions/upload-artifact@v2
       with:
-        name: container-jfr-core
+        name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - uses: skjolber/maven-cache-github-action@v1
       with:
@@ -60,7 +60,7 @@ jobs:
         step: restore
     - uses: actions/download-artifact@v2
       with:
-        name: container-jfr-core
+        name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: git submodule init
     - run: git submodule update


### PR DESCRIPTION
This PR adds steps to our CI workflow that push the build image to Quay. This uses the `redhat-actions/push-to-registry` action. The step only runs on push, excluding forks. The image tags pushed to Quay are the image version defined in the POM (currently `2.0.0-SNAPSHOT`), `latest`, and the commit SHA. The latter creates a new tag upon each commit. I'm not sure if we want this. It's nice for traceability, but will end up creating a lot of tags.

The push is done by a robot account in Quay, whose credentials will be stored in a Github secret [1]. To test, I temporarily substituted the Cryostat account for my own. The results can be seen below:

CI on PR, not pushed to Quay: https://github.com/ebaron/cryostat/runs/2975581732
CI on push, pushed to Quay: https://github.com/ebaron/cryostat/runs/2975629893

[1] https://docs.github.com/en/actions/reference/encrypted-secrets