### PR TITLE
ci(quay): remove Git SHA from image tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,6 @@ jobs:
       run: >
         podman tag
         ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
-        ${{ env.CRYOSTAT_IMG }}:${{ github.sha }}
         ${{ env.CRYOSTAT_IMG }}:latest
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
@@ -83,7 +82,6 @@ jobs:
         image: cryostat
         tags: >
           ${{ needs.get-pom-properties.outputs.image-version }}
-          ${{ github.sha }}
           latest
         registry: quay.io/cryostat
         username: cryostat+bot


### PR DESCRIPTION
This removes the Git SHA from image tags pushed to Quay from CI. We decided this would clutter up the list of tags too much.