### PR TITLE
ci(log): print podman logs on CI failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,9 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
+    - name: Print itest logs
+      if: ${{ failure() }}
+      run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - name: Tag images
       run: >
         podman tag

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,21 @@
           </configuration>
         </execution>
         <execution>
+          <id>capture-oci-logs</id>
+          <phase>post-integration-test</phase>
+          <goals>
+            <goal>exec</goal>
+          </goals>
+          <configuration>
+            <executable>${imageBuilder}</executable>
+            <arguments>
+              <argument>logs</argument>
+              <argument>cryostat-itest</argument>
+            </arguments>
+            <outputFile>${project.build.directory}/cryostat-itest-${maven.build.timestamp}.log</outputFile>
+          </configuration>
+        </execution>
+        <execution>
           <id>stop-jfr-datasource</id>
           <phase>post-integration-test</phase>
           <goals>


### PR DESCRIPTION
If there are itest failures, the log output of the cryostat container itself will be printed out in the workflow action run to aid troubleshooting. As it is now, only the itest runner's side of the output is seen, but not the cryostat backend's internal logging, which would likely contain additional details.