### PR TITLE
build(jib): Update-maven-jib-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,6 @@
           <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
           <entrypoint>${cryostat.entrypoint}</entrypoint>
           <mainClass>${cryostat.mainClass}</mainClass>
-          <extraClasspath>${env.CLASSPATH}</extraClasspath>
           <ports>
             <port>${cryostat.webPort}</port>
             <port>${cryostat.listenPort}</port>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   <org.codehaus.mojo.exec.plugin.version>3.0.0</org.codehaus.mojo.exec.plugin.version>
   <com.mycila.license.maven.plugin.version>4.0</com.mycila.license.maven.plugin.version>
   <org.owasp.dependency.check.version>6.1.5</org.owasp.dependency.check.version>
-  <com.google.cloud.tools.jib.maven.plugin.version>3.0.0</com.google.cloud.tools.jib.maven.plugin.version>
+  <com.google.cloud.tools.jib.maven.plugin.version>3.1.1</com.google.cloud.tools.jib.maven.plugin.version>
 
   <com.google.dagger.version>2.34.1</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
@@ -517,6 +517,8 @@
           <format>OCI</format>
           <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
           <entrypoint>${cryostat.entrypoint}</entrypoint>
+          <mainClass>io.cryostat.Cryostat</mainClass>
+          <extraClasspath>${env.CLASSPATH}</extraClasspath>
           <ports>
             <port>${cryostat.webPort}</port>
             <port>${cryostat.listenPort}</port>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   <cryostat.minimal>false</cryostat.minimal>
   <cryostat.imageStream>quay.io/cryostat/cryostat</cryostat.imageStream>
   <cryostat.entrypoint>/app/entrypoint.sh</cryostat.entrypoint>
+  <cryostat.mainClass>io.cryostat.Cryostat</cryostat.mainClass>
   <cryostat.rjmxPort>9091</cryostat.rjmxPort>
   <cryostat.webPort>8181</cryostat.webPort>
   <cryostat.listenPort>9090</cryostat.listenPort>
@@ -249,7 +250,7 @@
       <artifactId>exec-maven-plugin</artifactId>
       <version>${org.codehaus.mojo.exec.plugin.version}</version>
       <configuration>
-        <mainClass>io.cryostat.Cryostat</mainClass>
+        <mainClass>${cryostat.mainClass}</mainClass>
         <additionalClasspathElements>
           <additionalClasspathElement>${project.build.directory}/assets/app/resources</additionalClasspathElement>
         </additionalClasspathElements>
@@ -517,7 +518,7 @@
           <format>OCI</format>
           <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
           <entrypoint>${cryostat.entrypoint}</entrypoint>
-          <mainClass>io.cryostat.Cryostat</mainClass>
+          <mainClass>${cryostat.mainClass}</mainClass>
           <extraClasspath>${env.CLASSPATH}</extraClasspath>
           <ports>
             <port>${cryostat.webPort}</port>

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -162,6 +162,6 @@ export SSL_TRUSTSTORE_DIR
 set -x
 exec java \
     "${FLAGS[@]}" \
-    -cp "$CLASSPATH" \
-    io.cryostat.Cryostat \
+    -cp @/app/jib-classpath-file \
+    @/app/jib-main-class-file \
     "$@"

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -150,7 +150,7 @@ if [ -n "$CRYOSTAT_JUL_CONFIG" ]; then
     FLAGS+=("-Djava.util.logging.config.file=$CRYOSTAT_JUL_CONFIG")
 fi
 
-CLASSPATH="/app/resources:/app/classes:/app/libs/*"
+CLASSPATH="$( cat /app/jib-classpath-file )"
 if [ -n "CRYOSTAT_CLIENTLIB_PATH" ]; then
     CLASSPATH="$CLASSPATH:$CRYOSTAT_CLIENTLIB_PATH/*"
 fi
@@ -162,6 +162,6 @@ export SSL_TRUSTSTORE_DIR
 set -x
 exec java \
     "${FLAGS[@]}" \
-    -cp @/app/jib-classpath-file \
+    -cp "$CLASSPATH" \
     @/app/jib-main-class-file \
     "$@"


### PR DESCRIPTION
Resolves #529

Upgrades maven jib plugin to version 3.1.1 and uses the new JVM argument files `/app/jib-classpath-file` and `/app/jib-main-class-file` to set the custom container entrypoint.
