### PR TITLE
ci(quay): push built CI images to Quay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI build and push
 
 on:
   push:
-    branches: [ main, v1 ]
+    branches: [ v1 ]
   pull_request:
-    branches: [ main, v1]
+    branches: [ v1 ]
 
 jobs:
   get-pom-properties:
@@ -70,7 +70,6 @@ jobs:
       run: >
         podman tag
         ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
-        ${{ env.CRYOSTAT_IMG }}:latest
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
@@ -82,7 +81,6 @@ jobs:
         image: cryostat
         tags: >
           ${{ needs.get-pom-properties.outputs.image-version }}
-          latest
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI build
+name: CI build and push
 
 on:
   push:
@@ -7,33 +7,37 @@ on:
     branches: [ main, v1]
 
 jobs:
-  get-core-version:
+  get-pom-properties:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - id: query-pom
-      # Query POM for core version and save as output parameter
+      name: Get properties from POM
+      # Query POM for core and image version and save as output parameter
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
         echo "::set-output name=core-version::v$CORE_VERSION"
+        IMAGE_VERSION="$(mvn help:evaluate -Dexpression=cryostat.imageVersion -q -DforceStdout)"
+        echo "::set-output name=image-version::$IMAGE_VERSION"
     outputs:
       core-version: ${{ steps.query-pom.outputs.core-version }}
+      image-version: ${{ steps.query-pom.outputs.image-version }}
 
   build-deps:
     runs-on: ubuntu-latest
-    needs: [get-core-version]
+    needs: [get-pom-properties]
     steps:
     - uses: actions/checkout@v2
       with:
         repository: cryostatio/cryostat-core
-        ref: ${{ needs.get-core-version.outputs.core-version }}
+        ref: ${{ needs.get-pom-properties.outputs.core-version }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
     - run: mvn -B -U -DskipTests=true clean install
     - uses: actions/upload-artifact@v2
       with:
-        name: container-jfr-core
+        name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - uses: skjolber/maven-cache-github-action@v1
       with:
@@ -41,7 +45,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [build-deps]
+    needs: [get-pom-properties, build-deps]
+    env:
+      CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:
     - uses: actions/checkout@v2
       with:
@@ -55,11 +61,34 @@ jobs:
         step: restore
     - uses: actions/download-artifact@v2
       with:
-        name: container-jfr-core
+        name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
+    - name: Tag images
+      run: >
+        podman tag
+        ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
+        ${{ env.CRYOSTAT_IMG }}:${{ github.sha }}
+        ${{ env.CRYOSTAT_IMG }}:latest
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat
+        tags: >
+          ${{ needs.get-pom-properties.outputs.image-version }}
+          ${{ github.sha }}
+          latest
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [get-pom-properties, build-deps]
-    env:
-      CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:
     - uses: actions/checkout@v2
       with:
@@ -66,11 +64,6 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
-    - name: Tag images
-      run: >
-        podman tag
-        ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,6 @@ jobs:
       run: >
         podman tag
         ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
-        ${{ env.CRYOSTAT_IMG }}:${{ github.sha }}
         ${{ env.CRYOSTAT_IMG }}:latest
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
@@ -83,7 +82,6 @@ jobs:
         image: cryostat
         tags: >
           ${{ needs.get-pom-properties.outputs.image-version }}
-          ${{ github.sha }}
           latest
         registry: quay.io/cryostat
         username: cryostat+bot


### PR DESCRIPTION
Backport of #545 and #558 

This backport does not push to the `latest` tag, only the image version tag. As a result, the step for tagging images is no longer needed.

This PR also removes the `main` branch from the event triggers.