### PR TITLE
test(auto-rules): Add POST rule itests

### DIFF
--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -193,30 +193,6 @@ class AutoRulesIT extends ExternalTargetsTest {
 
     @Test
     @Order(2)
-    void testAddRuleThrowsWhenJsonIntegerAttributesNegative() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
-        JsonObject invalidRule = new JsonObject();
-        invalidRule.put("name", "Invalid_Rule");
-        invalidRule.put("description", "AutoRulesIT automated rule");
-        invalidRule.put("eventSpecifier", "template=Continuous,type=TARGET");
-        invalidRule.put("targetAlias", "es.andrewazor.demo.Main");
-        invalidRule.put("archivalPeriodSeconds", -60);
-        invalidRule.put("preservedArchives", -3);
-
-        webClient
-                .post("/api/v2/rules")
-                .sendJsonObject(
-                        invalidRule,
-                        ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(400));
-                            }
-                        });
-    }
-
-    @Test
-    @Order(3)
     void testAddCredentials() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
@@ -242,7 +218,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     void testNewContainerHasRuleApplied() throws Exception {
         CONTAINERS.add(
                 Podman.run(
@@ -299,7 +275,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(5)
+    @Order(4)
     void testRuleCanBeDeleted() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
@@ -321,7 +297,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(6)
+    @Order(5)
     void testCredentialsCanBeDeleted() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import io.cryostat.net.web.http.HttpMimeType;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import itest.bases.ExternalTargetsTest;
+import itest.util.Podman;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@TestMethodOrder(OrderAnnotation.class)
+class RulesPostFormIT extends ExternalTargetsTest {
+
+    static final List<String> CONTAINERS = new ArrayList<>();
+    static final Map<String, String> NULL_RESULT = new HashMap<>();
+
+    final String jmxServiceUrl =
+            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
+    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+
+    static {
+        NULL_RESULT.put("result", null);
+    }
+
+    static MultiMap testRule = MultiMap.caseInsensitiveMultiMap();
+
+    @BeforeAll
+    static void setup() throws Exception {
+        testRule.add("name", "Auto Rule");
+        testRule.add(
+                "matchExpression",
+                "target.annotations.cryostat.JAVA_MAIN=='es.andrewazor.demo.Main'");
+        testRule.add("description", "AutoRulesIT automated rule");
+        testRule.add("eventSpecifier", "template=Continuous,type=TARGET");
+        testRule.add("archivalPeriodSeconds", "60");
+        testRule.add("preservedArchives", "3");
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        for (String id : CONTAINERS) {
+            Podman.kill(id);
+        }
+    }
+
+    @Test
+    @Order(1)
+    void testAddRuleThrowsWhenFormAttributesNull() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.MULTIPART_FORM.mime())
+                .sendForm(
+                        null,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(400));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(2)
+    void testAddRuleThrowsWhenMimeNull() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "")
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(3)
+    void testAddRuleThrowsWhenMimeUnsupported() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "NOTAMIME;text/plain")
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(4)
+    void testAddRuleThrowsWhenMimeInvalid() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "NOTAMIME")
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(5)
+    void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.MULTIPART_FORM.mime())
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(201));
+                            }
+                        });
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.MULTIPART_FORM.mime())
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(409));
+                            }
+                        });
+    }
+}

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -37,10 +37,6 @@
  */
 package itest;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -49,44 +45,24 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import itest.bases.ExternalTargetsTest;
-import itest.util.Podman;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class RulesPostFormIT extends ExternalTargetsTest {
-
-    static final List<String> CONTAINERS = new ArrayList<>();
-    static final Map<String, String> NULL_RESULT = new HashMap<>();
-
-    final String jmxServiceUrl =
-            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
-    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
-
-    static {
-        NULL_RESULT.put("result", null);
-    }
+class RulesPostFormIT extends StandardSelfTest {
 
     static MultiMap testRule;
 
     @BeforeAll
     static void setup() throws Exception {
         testRule = MultiMap.caseInsensitiveMultiMap();
-        testRule.add("name", "Auto Rule");
+        testRule.add("name", "Test Rule");
         testRule.add("targetAlias", "es.andrewazor.demo.Main");
         testRule.add("description", "AutoRulesIT automated rule");
         testRule.add("eventSpecifier", "template=Continuous,type=TARGET");
-    }
-
-    @AfterAll
-    static void cleanup() throws Exception {
-        for (String id : CONTAINERS) {
-            Podman.kill(id);
-        }
     }
 
     @Test
@@ -140,13 +116,14 @@ class RulesPostFormIT extends ExternalTargetsTest {
 
         // clean up rule before running next test
         webClient
-                .delete(String.format("/api/v2/rules/%s", "Auto_Rule"))
+                .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
                 .send(
                         ar -> {
                             if (assertRequestStatus(ar, deleteResponse)) {
                                 deleteResponse.complete(ar.result().bodyAsJsonObject());
                             }
                         });
+        deleteResponse.get();
     }
 
     @Test

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import io.cryostat.net.web.http.HttpMimeType;
 
@@ -53,6 +54,7 @@ import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -106,36 +108,43 @@ class RulesPostFormIT extends ExternalTargetsTest {
 
     @Test
     void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
-        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
 
         webClient
                 .post("/api/v2/rules")
                 .sendForm(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
+                            if (assertRequestStatus(ar, postResponse)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(201));
+                                postResponse.complete(ar.result().bodyAsJsonObject());
                             }
                         });
+        postResponse.get();
 
         webClient
                 .post("/api/v2/rules")
                 .sendForm(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
+                            if (assertRequestStatus(ar, duplicatePostResponse)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(409));
+                                duplicatePostResponse.complete(ar.result().bodyAsJsonObject());
                             }
                         });
+        Assertions.assertThrows(ExecutionException.class, () -> duplicatePostResponse.get());
+
         // clean up rule before running next test
         webClient
                 .delete(String.format("/api/v2/rules/%s", "Auto_Rule"))
                 .send(
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
+                            if (assertRequestStatus(ar, deleteResponse)) {
+                                deleteResponse.complete(ar.result().bodyAsJsonObject());
                             }
                         });
     }

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -139,4 +139,23 @@ class RulesPostFormIT extends ExternalTargetsTest {
                             }
                         });
     }
+
+    @Test
+    void testAddRuleThrowsWhenIntegerAttributesNegative() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        testRule.add("archivalPeriodSeconds", "-60");
+        testRule.add("preservedArchives", "-3");
+
+        webClient
+                .post("/api/v2/rules")
+                .sendForm(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(400));
+                            }
+                        });
+    }
 }

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -94,61 +94,65 @@ class RulesPostFormIT extends StandardSelfTest {
     void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
-        webClient
-                .post("/api/v2/rules")
-                .sendForm(
-                        testRule,
-                        ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
+        try {
+            webClient
+                    .post("/api/v2/rules")
+                    .sendForm(
+                            testRule,
+                            ar -> {
+                                if (assertRequestStatus(ar, response)) {
+                                    response.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
 
-        JsonObject expectedResponse =
-                new JsonObject(
-                        Map.of(
-                                "meta",
-                                        Map.of(
-                                                "type",
-                                                HttpMimeType.PLAINTEXT.mime(),
-                                                "status",
-                                                "Created"),
-                                "data", Map.of("result", "Test_Rule")));
-        MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedResponse));
+            JsonObject expectedResponse =
+                    new JsonObject(
+                            Map.of(
+                                    "meta",
+                                            Map.of(
+                                                    "type",
+                                                    HttpMimeType.PLAINTEXT.mime(),
+                                                    "status",
+                                                    "Created"),
+                                    "data", Map.of("result", "Test_Rule")));
+            MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedResponse));
 
-        CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
-        webClient
-                .post("/api/v2/rules")
-                .sendForm(
-                        testRule,
-                        ar -> {
-                            assertRequestStatus(ar, duplicatePostResponse);
-                        });
+            CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
+            webClient
+                    .post("/api/v2/rules")
+                    .sendForm(
+                            testRule,
+                            ar -> {
+                                assertRequestStatus(ar, duplicatePostResponse);
+                            });
 
-        ExecutionException ex =
-                Assertions.assertThrows(
-                        ExecutionException.class, () -> duplicatePostResponse.get());
-        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
+            ExecutionException ex =
+                    Assertions.assertThrows(
+                            ExecutionException.class, () -> duplicatePostResponse.get());
+            MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
-        // clean up rule before running next test
-        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
-        webClient
-                .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
-                .send(
-                        ar -> {
-                            if (assertRequestStatus(ar, deleteResponse)) {
-                                deleteResponse.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
+        } finally {
+            // clean up rule before running next test
+            CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
+            webClient
+                    .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteResponse)) {
+                                    deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
 
-        JsonObject expectedDeleteResponse =
-                new JsonObject(
-                        Map.of(
-                                "meta",
-                                Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
-                                "data",
-                                NULL_RESULT));
-        MatcherAssert.assertThat(deleteResponse.get(), Matchers.equalTo(expectedDeleteResponse));
+            JsonObject expectedDeleteResponse =
+                    new JsonObject(
+                            Map.of(
+                                    "meta",
+                                    Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
+                                    "data",
+                                    NULL_RESULT));
+            MatcherAssert.assertThat(
+                    deleteResponse.get(), Matchers.equalTo(expectedDeleteResponse));
+        }
     }
 
     @Test

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -121,6 +121,8 @@ class RulesPostFormIT extends StandardSelfTest {
                         ar -> {
                             if (assertRequestStatus(ar, deleteResponse)) {
                                 deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
                             }
                         });
         deleteResponse.get();

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -37,10 +37,6 @@
  */
 package itest;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -48,44 +44,24 @@ import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import itest.bases.ExternalTargetsTest;
-import itest.util.Podman;
+import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class RulesPostJsonIT extends ExternalTargetsTest {
-
-    static final List<String> CONTAINERS = new ArrayList<>();
-    static final Map<String, String> NULL_RESULT = new HashMap<>();
-
-    final String jmxServiceUrl =
-            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
-    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
-
-    static {
-        NULL_RESULT.put("result", null);
-    }
+class RulesPostJsonIT extends StandardSelfTest {
 
     static JsonObject testRule;
 
     @BeforeAll
     static void setup() throws Exception {
         testRule = new JsonObject();
-        testRule.put("name", "Test_Rule");
+        testRule.put("name", "Test Rule");
         testRule.put("targetAlias", "es.andrewazor.demo.Main");
         testRule.put("description", "AutoRulesIT automated rule");
         testRule.put("eventSpecifier", "template=Continuous,type=TARGET");
-    }
-
-    @AfterAll
-    static void cleanup() throws Exception {
-        for (String id : CONTAINERS) {
-            Podman.kill(id);
-        }
     }
 
     @Test
@@ -173,13 +149,14 @@ class RulesPostJsonIT extends ExternalTargetsTest {
 
         // clean up rule before running next test
         webClient
-                .delete(String.format("/api/v2/rules/%s", "Auto_Rule"))
+                .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
                 .send(
                         ar -> {
                             if (assertRequestStatus(ar, deleteResponse)) {
                                 deleteResponse.complete(ar.result().bodyAsJsonObject());
                             }
                         });
+        deleteResponse.get();
     }
 
     @Test

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -174,4 +174,23 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                             }
                         });
     }
+
+    @Test
+    void testAddRuleThrowsWhenIntegerAttributesNegative() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        testRule.put("archivalPeriodSeconds", -60);
+        testRule.put("preservedArchives", -3);
+
+        webClient
+                .post("/api/v2/rules")
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(400));
+                            }
+                        });
+    }
 }

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -53,12 +53,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
-@TestMethodOrder(OrderAnnotation.class)
 class RulesPostJsonIT extends ExternalTargetsTest {
 
     static final List<String> CONTAINERS = new ArrayList<>();
@@ -78,11 +74,9 @@ class RulesPostJsonIT extends ExternalTargetsTest {
     static void setup() throws Exception {
         testRule = new JsonObject();
         testRule.put("name", "Test_Rule");
+        testRule.put("targetAlias", "es.andrewazor.demo.Main");
         testRule.put("description", "AutoRulesIT automated rule");
         testRule.put("eventSpecifier", "template=Continuous,type=TARGET");
-        testRule.put(
-                "matchExpression",
-                "target.annotations.cryostat.JAVA_MAIN=='es.andrewazor.demo.Main'");
     }
 
     @AfterAll
@@ -93,9 +87,8 @@ class RulesPostJsonIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(1)
     void testAddRuleThrowsWhenJsonAttributesNull() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
         webClient
                 .post("/api/v2/rules")
@@ -103,7 +96,7 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                 .sendJsonObject(
                         null,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
+                            if (assertRequestStatus(ar, response)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(400));
                             }
@@ -111,27 +104,8 @@ class RulesPostJsonIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(2)
-    void testAddRuleThrowsWhenMimeNull() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
-
-        webClient
-                .post("/api/v2/rules")
-                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "")
-                .sendJsonObject(
-                        testRule,
-                        ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(415));
-                            }
-                        });
-    }
-
-    @Test
-    @Order(3)
     void testAddRuleThrowsWhenMimeUnsupported() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
         webClient
                 .post("/api/v2/rules")
@@ -139,7 +113,7 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
+                            if (assertRequestStatus(ar, response)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(415));
                             }
@@ -147,9 +121,8 @@ class RulesPostJsonIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(4)
     void testAddRuleThrowsWhenMimeInvalid() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
         webClient
                 .post("/api/v2/rules")
@@ -157,7 +130,7 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
+                            if (assertRequestStatus(ar, response)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(415));
                             }
@@ -165,9 +138,8 @@ class RulesPostJsonIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(5)
     void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
         webClient
                 .post("/api/v2/rules")
@@ -175,7 +147,7 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
+                            if (assertRequestStatus(ar, response)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(201));
                             }
@@ -187,9 +159,18 @@ class RulesPostJsonIT extends ExternalTargetsTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
+                            if (assertRequestStatus(ar, response)) {
                                 MatcherAssert.assertThat(
                                         ar.result().statusCode(), Matchers.equalTo(409));
+                            }
+                        });
+        // clean up rule before running next test
+        webClient
+                .delete(String.format("/api/v2/rules/%s", "Auto_Rule"))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
                             }
                         });
     }

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import io.cryostat.net.web.http.HttpMimeType;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import itest.bases.ExternalTargetsTest;
+import itest.util.Podman;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@TestMethodOrder(OrderAnnotation.class)
+class RulesPostJsonIT extends ExternalTargetsTest {
+
+    static final List<String> CONTAINERS = new ArrayList<>();
+    static final Map<String, String> NULL_RESULT = new HashMap<>();
+
+    final String jmxServiceUrl =
+            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
+    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+
+    static {
+        NULL_RESULT.put("result", null);
+    }
+
+    static JsonObject testRule;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        testRule = new JsonObject();
+        testRule.put("name", "Test_Rule");
+        testRule.put("description", "AutoRulesIT automated rule");
+        testRule.put("eventSpecifier", "template=Continuous,type=TARGET");
+        testRule.put(
+                "matchExpression",
+                "target.annotations.cryostat.JAVA_MAIN=='es.andrewazor.demo.Main'");
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        for (String id : CONTAINERS) {
+            Podman.kill(id);
+        }
+    }
+
+    @Test
+    @Order(1)
+    void testAddRuleThrowsWhenJsonAttributesNull() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.JSON.mime())
+                .sendJsonObject(
+                        null,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(400));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(2)
+    void testAddRuleThrowsWhenMimeNull() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "")
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(3)
+    void testAddRuleThrowsWhenMimeUnsupported() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "NOTAMIME;text/plain")
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(4)
+    void testAddRuleThrowsWhenMimeInvalid() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "NOTAMIME")
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(415));
+                            }
+                        });
+    }
+
+    @Test
+    @Order(5)
+    void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
+        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.JSON.mime())
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(201));
+                            }
+                        });
+
+        webClient
+                .post("/api/v2/rules")
+                .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.JSON.mime())
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, postResponse)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(409));
+                            }
+                        });
+    }
+}

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -37,6 +37,8 @@
  */
 package itest;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -54,6 +56,12 @@ import org.junit.jupiter.api.Test;
 class RulesPostJsonIT extends StandardSelfTest {
 
     static JsonObject testRule;
+
+    static final Map<String, String> NULL_RESULT = new HashMap<>();
+
+    static {
+        NULL_RESULT.put("result", null);
+    }
 
     @BeforeAll
     static void setup() throws Exception {
@@ -74,11 +82,11 @@ class RulesPostJsonIT extends StandardSelfTest {
                 .sendJsonObject(
                         null,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(400));
-                            }
+                            assertRequestStatus(ar, response);
                         });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
     @Test
@@ -91,11 +99,12 @@ class RulesPostJsonIT extends StandardSelfTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(415));
-                            }
+                            assertRequestStatus(ar, response);
                         });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
 
     @Test
@@ -108,62 +117,78 @@ class RulesPostJsonIT extends StandardSelfTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(415));
-                            }
+                            assertRequestStatus(ar, response);
                         });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
 
     @Test
     void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+
+        webClient
+                .post("/api/v2/rules")
+                .sendJsonObject(
+                        testRule,
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+
+        JsonObject expectedresponse =
+                new JsonObject(
+                        Map.of(
+                                "meta",
+                                        Map.of(
+                                                "type",
+                                                HttpMimeType.PLAINTEXT.mime(),
+                                                "status",
+                                                "Created"),
+                                "data", Map.of("result", "Test_Rule")));
+        MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedresponse));
+
         CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
-        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
-
         webClient
                 .post("/api/v2/rules")
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(201));
-                                postResponse.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, duplicatePostResponse);
                         });
-        postResponse.get();
 
-        webClient
-                .post("/api/v2/rules")
-                .sendJsonObject(
-                        testRule,
-                        ar -> {
-                            if (assertRequestStatus(ar, duplicatePostResponse)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(409));
-                                duplicatePostResponse.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
-        Assertions.assertThrows(ExecutionException.class, () -> duplicatePostResponse.get());
+        ExecutionException ex =
+                Assertions.assertThrows(
+                        ExecutionException.class, () -> duplicatePostResponse.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
         // clean up rule before running next test
+        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
         webClient
                 .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
                 .send(
                         ar -> {
                             if (assertRequestStatus(ar, deleteResponse)) {
                                 deleteResponse.complete(ar.result().bodyAsJsonObject());
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(200));
                             }
                         });
-        deleteResponse.get();
+
+        JsonObject expectedDeleteResponse =
+                new JsonObject(
+                        Map.of(
+                                "meta",
+                                Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
+                                "data",
+                                NULL_RESULT));
+        MatcherAssert.assertThat(deleteResponse.get(), Matchers.equalTo(expectedDeleteResponse));
     }
 
     @Test
     void testAddRuleThrowsWhenIntegerAttributesNegative() throws Exception {
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
         testRule.put("archivalPeriodSeconds", -60);
         testRule.put("preservedArchives", -3);
@@ -173,10 +198,11 @@ class RulesPostJsonIT extends StandardSelfTest {
                 .sendJsonObject(
                         testRule,
                         ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
-                                MatcherAssert.assertThat(
-                                        ar.result().statusCode(), Matchers.equalTo(400));
-                            }
+                            assertRequestStatus(ar, response);
                         });
+
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -129,61 +129,65 @@ class RulesPostJsonIT extends StandardSelfTest {
     void testAddRuleThrowsWhenRuleNameAlreadyExists() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
 
-        webClient
-                .post("/api/v2/rules")
-                .sendJsonObject(
-                        testRule,
-                        ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
+        try {
+            webClient
+                    .post("/api/v2/rules")
+                    .sendJsonObject(
+                            testRule,
+                            ar -> {
+                                if (assertRequestStatus(ar, response)) {
+                                    response.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
 
-        JsonObject expectedresponse =
-                new JsonObject(
-                        Map.of(
-                                "meta",
-                                        Map.of(
-                                                "type",
-                                                HttpMimeType.PLAINTEXT.mime(),
-                                                "status",
-                                                "Created"),
-                                "data", Map.of("result", "Test_Rule")));
-        MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedresponse));
+            JsonObject expectedresponse =
+                    new JsonObject(
+                            Map.of(
+                                    "meta",
+                                            Map.of(
+                                                    "type",
+                                                    HttpMimeType.PLAINTEXT.mime(),
+                                                    "status",
+                                                    "Created"),
+                                    "data", Map.of("result", "Test_Rule")));
+            MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedresponse));
 
-        CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
-        webClient
-                .post("/api/v2/rules")
-                .sendJsonObject(
-                        testRule,
-                        ar -> {
-                            assertRequestStatus(ar, duplicatePostResponse);
-                        });
+            CompletableFuture<JsonObject> duplicatePostResponse = new CompletableFuture<>();
+            webClient
+                    .post("/api/v2/rules")
+                    .sendJsonObject(
+                            testRule,
+                            ar -> {
+                                assertRequestStatus(ar, duplicatePostResponse);
+                            });
 
-        ExecutionException ex =
-                Assertions.assertThrows(
-                        ExecutionException.class, () -> duplicatePostResponse.get());
-        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
+            ExecutionException ex =
+                    Assertions.assertThrows(
+                            ExecutionException.class, () -> duplicatePostResponse.get());
+            MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
-        // clean up rule before running next test
-        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
-        webClient
-                .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
-                .send(
-                        ar -> {
-                            if (assertRequestStatus(ar, deleteResponse)) {
-                                deleteResponse.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
+        } finally {
+            // clean up rule before running next test
+            CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
+            webClient
+                    .delete(String.format("/api/v2/rules/%s", "Test_Rule"))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteResponse)) {
+                                    deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
 
-        JsonObject expectedDeleteResponse =
-                new JsonObject(
-                        Map.of(
-                                "meta",
-                                Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
-                                "data",
-                                NULL_RESULT));
-        MatcherAssert.assertThat(deleteResponse.get(), Matchers.equalTo(expectedDeleteResponse));
+            JsonObject expectedDeleteResponse =
+                    new JsonObject(
+                            Map.of(
+                                    "meta",
+                                    Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
+                                    "data",
+                                    NULL_RESULT));
+            MatcherAssert.assertThat(
+                    deleteResponse.get(), Matchers.equalTo(expectedDeleteResponse));
+        }
     }
 
     @Test

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -154,6 +154,8 @@ class RulesPostJsonIT extends StandardSelfTest {
                         ar -> {
                             if (assertRequestStatus(ar, deleteResponse)) {
                                 deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
                             }
                         });
         deleteResponse.get();


### PR DESCRIPTION
Related #474 

Adds integration tests to cover `4xx` status codes defined by `RulesPostHandler.java`.