### PR TITLE
fix(auto-rules): Check for null json before creating rule

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -130,7 +130,7 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
                     rule = gson.fromJson(params.getBody(), Rule.class);
 
                     if (rule == null) {
-                        throw new IllegalArgumentException("No JSON found");
+                        throw new IllegalArgumentException("POST body was null");
                     }
                 } catch (IllegalArgumentException | JsonSyntaxException e) {
                     throw new ApiException(400, e);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -128,6 +128,10 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
             case JSON:
                 try {
                     rule = gson.fromJson(params.getBody(), Rule.class);
+
+                    if (rule == null) {
+                        throw new IllegalArgumentException("No JSON found");
+                    }
                 } catch (IllegalArgumentException | JsonSyntaxException e) {
                     throw new ApiException(400, e);
                 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -245,6 +245,19 @@ class RulesPostHandlerTest {
         }
 
         @Test
+        void throwsIfJsonBodyNull() {
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            Mockito.when(params.getHeaders()).thenReturn(headers);
+            headers.set(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
+
+            Mockito.when(params.getBody()).thenReturn(null);
+
+            ApiException ex =
+                    Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @Test
         void addsRuleWithFormAndReturnsResponse() {
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
             Mockito.when(params.getHeaders()).thenReturn(headers);


### PR DESCRIPTION
Fixes #570

Cause of the error is from `RulesPostHandler line 130`:
- `gson.fromJson` returns `null` without throwing an exception
- `null` is passed to `addRule()` which throws an `IOException`/`500`
```
public <T> T fromJson(String json, Type typeOfT) throws JsonSyntaxException {
    if (json == null) {
      return null;
    }
    StringReader reader = new StringReader(json);
    T target = (T) fromJson(reader, typeOfT);
    return target;
  }