### PR TITLE
test(auto-rules): Add itests for credentials POST and DELETE

### DIFF
--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -69,6 +69,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -86,6 +88,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -103,6 +107,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -122,6 +128,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -139,6 +147,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -158,6 +168,8 @@ public class CredentialsIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -56,12 +56,13 @@ public class CredentialsIT extends StandardSelfTest {
     final String jmxServiceUrl =
             String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
     final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+    final String requestUrl = String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded);
 
     @Test
     void testDeleteThrowsOnNonExistentCredentials() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
-                .delete(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .delete(requestUrl)
                 .send(
                         ar -> {
                             assertRequestStatus(ar, response);
@@ -77,7 +78,7 @@ public class CredentialsIT extends StandardSelfTest {
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
 
         webClient
-                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {
@@ -94,7 +95,7 @@ public class CredentialsIT extends StandardSelfTest {
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
         form.add("password", "adminpass123");
         webClient
-                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {
@@ -113,7 +114,7 @@ public class CredentialsIT extends StandardSelfTest {
         form.add("username", username);
         form.add("password", "adminpass123");
         webClient
-                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {
@@ -130,7 +131,7 @@ public class CredentialsIT extends StandardSelfTest {
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
         form.add("username", "admin");
         webClient
-                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {
@@ -149,7 +150,7 @@ public class CredentialsIT extends StandardSelfTest {
         form.add("username", "admin");
         form.add("password", password);
         webClient
-                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {

--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import itest.util.Podman;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CredentialsIT extends StandardSelfTest {
+
+    final String jmxServiceUrl =
+            String.format("service:jmx:rmi:///jndi/rmi://%s:9093/jmxrmi", Podman.POD_NAME);
+    final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+
+    @Test
+    void testDeleteThrowsOnNonExistentCredentials() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .delete(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .send(
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
+    }
+
+    @Test
+    void testAddCredentialsThrowsOnEmptyForm() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+
+        webClient
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    void testAddCredentialsThrowsOnOmittedUsername() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("password", "adminpass123");
+        webClient
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void testAddCredentialsThrowsOnBlankUsername(String username) throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("username", username);
+        form.add("password", "adminpass123");
+        webClient
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    void testAddCredentialsThrowsOnOmittedPassword() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("username", "admin");
+        webClient
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "\t", "\n"})
+    void testAddCredentialsThrowsOnBlankPassword(String password) throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("username", "admin");
+        form.add("password", password);
+        webClient
+                .post(String.format("/api/v2/targets/%s/credentials", jmxServiceUrlEncoded))
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+}

--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
 import itest.util.Podman;
 import org.hamcrest.MatcherAssert;


### PR DESCRIPTION
Related #474 

While `AutoRulesIT.java` already tests successful creation and deletion of credentials, this PR tests `4xx` error handling when posting or deleting credentials.