### PR TITLE
test(auto-rules): Test GET or DELETE rule not found

### DIFF
--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -51,6 +51,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.ExternalTargetsTest;
 import itest.util.Podman;
 import itest.util.Utils;

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -347,7 +347,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(7)
+    @Order(6)
     void testGetNonExistentRuleThrows() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
@@ -363,7 +363,7 @@ class AutoRulesIT extends ExternalTargetsTest {
     }
 
     @Test
-    @Order(8)
+    @Order(7)
     void testDeleteNonExistentRuleThrows() throws Exception {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
@@ -377,5 +377,4 @@ class AutoRulesIT extends ExternalTargetsTest {
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
-
 }

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import io.cryostat.net.web.http.HttpMimeType;
@@ -56,6 +57,7 @@ import itest.util.Utils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -343,4 +345,37 @@ class AutoRulesIT extends ExternalTargetsTest {
                                 NULL_RESULT));
         MatcherAssert.assertThat(response.get(), Matchers.equalTo(expectedResponse));
     }
+
+    @Test
+    @Order(7)
+    void testGetNonExistentRuleThrows() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .get("/api/v2/rules/Auto_Rule")
+                .send(
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
+    }
+
+    @Test
+    @Order(8)
+    void testDeleteNonExistentRuleThrows() throws Exception {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .delete("/api/v2/rules/Auto_Rule")
+                .send(
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
+    }
+
 }

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -359,6 +359,8 @@ class AutoRulesIT extends ExternalTargetsTest {
 
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -375,6 +377,8 @@ class AutoRulesIT extends ExternalTargetsTest {
 
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }


### PR DESCRIPTION
Related #474

Added itests to confirm that the `RuleGetHandler` and `RuleDeleteHandler` throw `404` when a non-existent rule is requested.