### PR TITLE
test(itest): Send status code during exceptional future completion

### DIFF
--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -47,6 +47,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -87,6 +88,8 @@ class RulesPostFormIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -129,6 +132,8 @@ class RulesPostFormIT extends StandardSelfTest {
             ExecutionException ex =
                     Assertions.assertThrows(
                             ExecutionException.class, () -> duplicatePostResponse.get());
+            MatcherAssert.assertThat(
+                    ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
             MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
         } finally {
@@ -172,6 +177,8 @@ class RulesPostFormIT extends StandardSelfTest {
 
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -46,6 +46,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -86,6 +87,8 @@ class RulesPostJsonIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -104,6 +107,8 @@ class RulesPostJsonIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
+        MatcherAssert.assertThat(
                 ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
 
@@ -121,6 +126,8 @@ class RulesPostJsonIT extends StandardSelfTest {
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
         MatcherAssert.assertThat(
                 ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
@@ -164,6 +171,8 @@ class RulesPostJsonIT extends StandardSelfTest {
             ExecutionException ex =
                     Assertions.assertThrows(
                             ExecutionException.class, () -> duplicatePostResponse.get());
+            MatcherAssert.assertThat(
+                    ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
             MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
         } finally {
@@ -207,6 +216,8 @@ class RulesPostJsonIT extends StandardSelfTest {
 
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -58,6 +58,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.util.Podman;
 import itest.util.Utils;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -130,12 +131,14 @@ public abstract class StandardSelfTest {
         if (result.failed()) {
             result.cause().printStackTrace();
             future.completeExceptionally(result.cause());
+
             return false;
         }
         HttpResponse<Buffer> response = result.result();
         if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode())) {
             System.err.println("HTTP " + response.statusCode() + ": " + response.statusMessage());
-            future.completeExceptionally(new Exception(response.statusMessage()));
+            future.completeExceptionally(
+                    new HttpStatusException(response.statusCode(), response.statusMessage()));
             return false;
         }
         return true;


### PR DESCRIPTION
Related #474 

When a `CompleteableFuture` is completed exceptionally, `assertRequestStatus()` will also send the HTTP status code along with the exception. Integration tests can now verify that the correct error code was returned along with the exception message.

e.g
```
webClient
                .post("/api/v2/rules")
                .sendForm(
                        testRule,
                        ar -> {
                            assertRequestStatus(ar, response);
                        });

        ExecutionException ex =
                Assertions.assertThrows(ExecutionException.class, () -> response.get());
        MatcherAssert.assertThat(
                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
```

Edit: I have also added status code checks to `RulesPostJsonIT.java` and `RulesPostFormIT.java`.