### PR TITLE
test(recordings): Add itests for target recordings POST handler

### DIFF
--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -39,23 +39,25 @@ package itest;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import itest.bases.StandardSelfTest;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
-
+import itest.bases.StandardSelfTest;
+import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RecordingsPostIT extends StandardSelfTest {
-    static final String TARGET_ID = "localhost";
+
+    static final String jmxServiceUrl =
+            String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
+    static final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
+    static final String requestUrl =
+            String.format("/api/v1/targets/%s/recordings", jmxServiceUrlEncoded);
     static final String TEST_RECORDING_NAME = "workflow_itest";
-    static final String REQ_URL = String.format("/api/v1/targets/%s/recordings", TARGET_ID);
 
     @Test
     public void testPostRecordingThrowsOnEmptyRecordingName() throws Exception {
@@ -67,11 +69,11 @@ public class RecordingsPostIT extends StandardSelfTest {
         form.add("events", "template=ALL");
 
         webClient
-                .post(REQ_URL)
+                .post(requestUrl)
                 .sendForm(
                         form,
                         ar -> {
-                            if(assertRequestStatus(ar, response)) {
+                            if (assertRequestStatus(ar, response)) {
                                 response.complete(ar.result().bodyAsJsonObject());
                             }
                         });

--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -44,7 +44,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
-import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -57,13 +56,81 @@ public class RecordingsPostIT extends StandardSelfTest {
     static final String TEST_RECORDING_NAME = "workflow_itest";
 
     @Test
+    public void testPostRecordingThrowsOnNullForm() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        null,
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
     public void testPostRecordingThrowsOnEmptyRecordingName() throws Exception {
 
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
         form.add("recordingName", "");
-        form.add("duration", "5");
         form.add("events", "template=ALL");
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    public void testPostRecordingThrowsOnEmptyEvents() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", TEST_RECORDING_NAME);
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    public void testPostRecordingThrowsOnInvalidFormArugment() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", TEST_RECORDING_NAME);
+        form.add("events", "template=ALL");
+        form.add("duration", "notAnInt");
 
         webClient
                 .post(REQ_URL)

--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RecordingsPostIT extends StandardSelfTest {
+    static final String TARGET_ID = "localhost";
+    static final String TEST_RECORDING_NAME = "workflow_itest";
+    static final String REQ_URL = String.format("/api/v1/targets/%s/recordings", TARGET_ID);
+
+    @Test
+    public void testPostRecordingThrowsOnEmptyRecordingName() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", "");
+        form.add("duration", "5");
+        form.add("events", "template=ALL");
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            if(assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+}

--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -39,13 +39,16 @@ package itest;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +57,21 @@ public class RecordingsPostIT extends StandardSelfTest {
     static final String REQ_URL =
             String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);
     static final String TEST_RECORDING_NAME = "workflow_itest";
+
+    @AfterAll
+    static void verifyNoRecordingsCreated() throws Exception {
+        CompletableFuture<JsonArray> listRespFuture1 = new CompletableFuture<>();
+        webClient
+                .get(REQ_URL)
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, listRespFuture1)) {
+                                listRespFuture1.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray listResp = listRespFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertTrue(listResp.isEmpty());
+    }
 
     @Test
     public void testPostRecordingThrowsOnNullForm() throws Exception {

--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -124,13 +124,38 @@ public class RecordingsPostIT extends StandardSelfTest {
     }
 
     @Test
-    public void testPostRecordingThrowsOnInvalidFormArugment() throws Exception {
+    public void testPostRecordingThrowsOnInvalidIntegerArugment() throws Exception {
 
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
         form.add("recordingName", TEST_RECORDING_NAME);
         form.add("events", "template=ALL");
         form.add("duration", "notAnInt");
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            if (assertRequestStatus(ar, response)) {
+                                response.complete(ar.result().bodyAsJsonObject());
+                            }
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    public void testPostRecordingThrowsOnInvalidDiskOption() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", TEST_RECORDING_NAME);
+        form.add("events", "template=ALL");
+        form.add("toDisk", "notABool");
 
         webClient
                 .post(REQ_URL)

--- a/src/test/java/itest/RecordingsPostIT.java
+++ b/src/test/java/itest/RecordingsPostIT.java
@@ -52,11 +52,8 @@ import org.junit.jupiter.api.Test;
 
 public class RecordingsPostIT extends StandardSelfTest {
 
-    static final String jmxServiceUrl =
-            String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
-    static final String jmxServiceUrlEncoded = jmxServiceUrl.replaceAll("/", "%2F");
-    static final String requestUrl =
-            String.format("/api/v1/targets/%s/recordings", jmxServiceUrlEncoded);
+    static final String REQ_URL =
+            String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);
     static final String TEST_RECORDING_NAME = "workflow_itest";
 
     @Test
@@ -69,7 +66,7 @@ public class RecordingsPostIT extends StandardSelfTest {
         form.add("events", "template=ALL");
 
         webClient
-                .post(requestUrl)
+                .post(REQ_URL)
                 .sendForm(
                         form,
                         ar -> {

--- a/src/test/java/itest/TargetRecordingsPostIT.java
+++ b/src/test/java/itest/TargetRecordingsPostIT.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class RecordingsPostIT extends StandardSelfTest {
+public class TargetRecordingsPostIT extends StandardSelfTest {
 
     static final String REQ_URL =
             String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);

--- a/src/test/java/itest/TargetRecordingsPostIT.java
+++ b/src/test/java/itest/TargetRecordingsPostIT.java
@@ -93,6 +93,48 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
     }
 
     @Test
+    public void testPostRecordingThrowsWithoutRecordingNameAttribute() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("events", "template=ALL");
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
+    public void testPostRecordingThrowsWithoutEventsAttribute() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("recordingName", TEST_RECORDING_NAME);
+
+        webClient
+                .post(REQ_URL)
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
+    }
+
+    @Test
     public void testPostRecordingThrowsOnEmptyRecordingName() throws Exception {
 
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
@@ -120,6 +162,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
         form.add("recordingName", TEST_RECORDING_NAME);
+        form.add("events", "");
 
         webClient
                 .post(REQ_URL)

--- a/src/test/java/itest/TargetRecordingsPostIT.java
+++ b/src/test/java/itest/TargetRecordingsPostIT.java
@@ -83,9 +83,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
                 .sendForm(
                         null,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, response);
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
@@ -107,9 +105,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
                 .sendForm(
                         form,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, response);
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
@@ -130,9 +126,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
                 .sendForm(
                         form,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, response);
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
@@ -155,9 +149,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
                 .sendForm(
                         form,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, response);
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
@@ -180,9 +172,7 @@ public class TargetRecordingsPostIT extends StandardSelfTest {
                 .sendForm(
                         form,
                         ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonObject());
-                            }
+                            assertRequestStatus(ar, response);
                         });
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());


### PR DESCRIPTION
Related #474 

Tests the `4xx` errors handled by the `TargetRecordingsPostHandler`.