### PR TITLE
fix(recordings): Throw 404 when deleting non-existent recording

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -48,7 +48,7 @@ import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingArchiveHelper;
-
+import io.cryostat.recordings.RecordingNotFoundException;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
@@ -96,6 +96,8 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
 
         try {
             recordingArchiveHelper.deleteRecording(connectionDescriptor, recordingName);
+        } catch (RecordingNotFoundException e) {
+            throw new HttpStatusException(404, e);
         } catch (Exception e) {
             throw new HttpStatusException(500, e);
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -49,6 +49,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
+
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;

--- a/src/main/java/io/cryostat/recordings/RecordingNotFoundException.java
+++ b/src/main/java/io/cryostat/recordings/RecordingNotFoundException.java
@@ -40,7 +40,7 @@ package io.cryostat.recordings;
 import java.io.IOException;
 
 public class RecordingNotFoundException extends IOException {
-    RecordingNotFoundException(String recordingName) {
+    public RecordingNotFoundException(String recordingName) {
         super(String.format("No recording with name \"%s\" found", recordingName));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
@@ -52,13 +52,13 @@ import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
+
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -148,10 +148,13 @@ class TargetRecordingDeleteHandlerTest {
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(ctx.request().headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
-        Mockito.doThrow(new RecordingNotFoundException("someRecording")).when(recordingArchiveHelper).deleteRecording(Mockito.any(), Mockito.anyString());
+        Mockito.doThrow(new RecordingNotFoundException("someRecording"))
+                .when(recordingArchiveHelper)
+                .deleteRecording(Mockito.any(), Mockito.anyString());
 
         HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                Assertions.assertThrows(
+                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 }


### PR DESCRIPTION
Fixes #596 

When attempting to delete a non-existent recording, the `TargetRecordingDeleteHandler` will throw an HTTP `404` status code instead of an HTTP `500` error. The error message is the same as before.

```
> DELETE /api/v1/targets/localhost:0/recordings/nonExistentRecording HTTP/1.1
> Host: 0.0.0.0:8181
> User-Agent: curl/7.71.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< content-type: text/plain
< content-length: 99
< 
* Connection #0 to host 0.0.0.0 left intact
Not Found caused by RecordingNotFoundException: No recording with name "nonExistentRecording" found
```