### PR TITLE
ci(quay): apply latest tag only in main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,14 +71,16 @@ jobs:
       run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - name: Tag images
       id: tag-image
+      env:
+        IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
       run: |
         if [ "$GITHUB_REF" == "refs/heads/main" ]; then
           podman tag \
-          ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }} \
+          ${{ env.CRYOSTAT_IMG }}:$IMAGE_VERSION \
           ${{ env.CRYOSTAT_IMG }}:latest
-          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }} latest"
+          echo "::set-output name=tags::$IMAGE_VERSION latest"
         else
-          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }}"}
+          echo "::set-output name=tags::$IMAGE_VERSION"}
         fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,10 +70,16 @@ jobs:
       if: ${{ failure() }}
       run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - name: Tag images
-      run: >
-        podman tag
-        ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }}
-        ${{ env.CRYOSTAT_IMG }}:latest
+      id: tag-image
+      run: |
+        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          podman tag \
+          ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }} \
+          ${{ env.CRYOSTAT_IMG }}:latest
+          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }} latest"
+        else
+          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }}"}
+        fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
@@ -83,9 +89,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat
-        tags: >
-          ${{ needs.get-pom-properties.outputs.image-version }}
-          latest
+        tags: ${{ steps.tag-image.outputs.tags }}
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
           ${{ env.CRYOSTAT_IMG }}:latest
           echo "::set-output name=tags::$IMAGE_VERSION latest"
         else
-          echo "::set-output name=tags::$IMAGE_VERSION"}
+          echo "::set-output name=tags::$IMAGE_VERSION"
         fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1


### PR DESCRIPTION
This PR adds a check that the branch name is `main` before applying the `latest` tag. This allows us to be sure that when we branch for v2, the existing Github workflow won't tag v2 builds as `latest`.

Example run: https://github.com/ebaron/cryostat/actions/runs/1057516228

Relates to: #595 