### PR TITLE
ci(quay): apply latest tag only in main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,14 +71,16 @@ jobs:
       run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - name: Tag images
       id: tag-image
+      env:
+        IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
       run: |
         if [ "$GITHUB_REF" == "refs/heads/main" ]; then
           podman tag \
-          ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }} \
+          ${{ env.CRYOSTAT_IMG }}:$IMAGE_VERSION \
           ${{ env.CRYOSTAT_IMG }}:latest
-          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }} latest"
+          echo "::set-output name=tags::$IMAGE_VERSION latest"
         else
-          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }}"}
+          echo "::set-output name=tags::$IMAGE_VERSION"}
         fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,9 +66,6 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
-    - name: Print itest logs
-      if: ${{ failure() }}
-      run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - name: Tag images
       id: tag-image
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
           ${{ env.CRYOSTAT_IMG }}:latest
           echo "::set-output name=tags::$IMAGE_VERSION latest"
         else
-          echo "::set-output name=tags::$IMAGE_VERSION"}
+          echo "::set-output name=tags::$IMAGE_VERSION"
         fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [get-pom-properties, build-deps]
+    env:
+      CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:
     - uses: actions/checkout@v2
       with:
@@ -64,6 +66,21 @@ jobs:
     - run: git submodule init
     - run: git submodule update
     - run: mvn -B -U clean verify
+    - name: Print itest logs
+      if: ${{ failure() }}
+      run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
+    - name: Tag images
+      id: tag-image
+      run: |
+        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          podman tag \
+          ${{ env.CRYOSTAT_IMG }}:${{ needs.get-pom-properties.outputs.image-version }} \
+          ${{ env.CRYOSTAT_IMG }}:latest
+          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }} latest"
+        else
+          echo "::set-output name=tags::${{ needs.get-pom-properties.outputs.image-version }}"}
+        fi
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save
@@ -72,8 +89,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat
-        tags: >
-          ${{ needs.get-pom-properties.outputs.image-version }}
+        tags: ${{ steps.tag-image.outputs.tags }}
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
This is a backport of #600. It doesn't fix an issue in `v1`, but brings the CI workflow in line with that in `main`.

Test run showing image not being tagged as `latest`:
https://github.com/ebaron/cryostat/runs/3138492861

Fixes #595