### PR TITLE
fix(certificates): Empty cert uploads throw 400 instead of 500

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -154,7 +155,7 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
             Collection<? extends Certificate> certificates = certValidator.parseCertificates(fis);
 
             if (certificates.isEmpty()) {
-                throw new ApiException(500, "No certificates found");
+                throw new FileNotFoundException("No certificates found");
             }
 
             try (FileOutputStream out = outputStreamFunction.apply(filePath.toFile())) {
@@ -165,6 +166,8 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
                 }
             }
 
+        } catch (FileNotFoundException e) {
+            throw new ApiException(400, e.getMessage(), e);
         } catch (IOException ioe) {
             throw new ApiException(500, ioe.getMessage(), ioe);
         } catch (CertificateEncodingException cee) {


### PR DESCRIPTION
Fixes #603

Source of bug: Inside the `try-with-resources` block, the handler throws an `ApiException(500, "No certificates found")` when it finds an empty file. If I replace the `500` with `400`, I still receive a `500` because the `try-with-resources` block catches all `Exception`s and re-throws them as `500`.

This fix throws a `FileNotFoundException` instead of an `ApiException`, which gets caught and rethrown as an `ApiException` with status code `400`.