### PR TITLE
test(report): Add report itests

### DIFF
--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -127,17 +127,29 @@ public class ReportIT extends StandardSelfTest {
 
         } finally {
             // Clean up recording
-            CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
+            CompletableFuture<JsonObject> deleteRecResponse = new CompletableFuture<>();
+            webClient
+                    .delete(String.format("%s/%s", RECORDING_REQ_URL, TEST_RECORDING_NAME))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteRecResponse)) {
+                                    deleteRecResponse.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
+
+            MatcherAssert.assertThat(deleteRecResponse.get(), Matchers.equalTo(null));
+
+            CompletableFuture<JsonObject> deleteArchivedRecResp = new CompletableFuture<>();
             webClient
                     .delete(String.format("/api/v1/recordings/%s", savedRecordingName.get()))
                     .send(
                             ar -> {
-                                if (assertRequestStatus(ar, deleteResponse)) {
-                                    deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                if (assertRequestStatus(ar, deleteArchivedRecResp)) {
+                                    deleteArchivedRecResp.complete(ar.result().bodyAsJsonObject());
                                 }
                             });
 
-            MatcherAssert.assertThat(deleteResponse.get(), Matchers.equalTo(null));
+            MatcherAssert.assertThat(deleteArchivedRecResp.get(), Matchers.equalTo(null));
         }
     }
 

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import io.cryostat.net.web.http.HttpMimeType;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+import itest.bases.StandardSelfTest;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReportIT extends StandardSelfTest {
+
+    static final String TEST_RECORDING_NAME = "someRecording";
+    static final String REPORT_REQ_URL =
+            String.format(
+                    "/api/v1/targets/%s/reports/%s", SELF_REFERENCE_TARGET_ID, TEST_RECORDING_NAME);
+    static final String RECORDING_REQ_URL =
+            String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);
+    static final String REPORT_URL_BASE =
+            String.format("/api/v1/targets/%s/reports", SELF_REFERENCE_TARGET_ID);
+
+    @Test
+    void testGetReportShouldSendFile() throws Exception {
+
+        try {
+            // Create a recording
+            CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.add("recordingName", TEST_RECORDING_NAME);
+            form.add("duration", "1");
+            form.add("events", "template=ALL");
+
+            webClient
+                    .post(RECORDING_REQ_URL)
+                    .sendForm(
+                            form,
+                            ar -> {
+                                if (assertRequestStatus(ar, postResponse)) {
+                                    MatcherAssert.assertThat(
+                                            ar.result().statusCode(), Matchers.equalTo(201));
+                                    postResponse.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
+
+            postResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Save the recording to archive
+            CompletableFuture<JsonObject> saveResponse = new CompletableFuture<>();
+
+            webClient
+                    .patch(String.format("%s/%s", RECORDING_REQ_URL, TEST_RECORDING_NAME))
+                    .sendBuffer(
+                            Buffer.buffer("SAVE"),
+                            ar -> {
+                                if (assertRequestStatus(ar, saveResponse)) {
+                                    MatcherAssert.assertThat(
+                                            ar.result().statusCode(), Matchers.equalTo(200));
+                                    saveResponse.complete(null);
+                                }
+                            });
+
+            saveResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Get a report for the above recording
+            CompletableFuture<Buffer> getResponse = new CompletableFuture<>();
+            webClient
+                    .get(REPORT_REQ_URL)
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, getResponse)) {
+                                    MatcherAssert.assertThat(
+                                            ar.result().statusCode(), Matchers.equalTo(200));
+                                    MatcherAssert.assertThat(
+                                            ar.result()
+                                                    .getHeader(HttpHeaders.CONTENT_TYPE.toString()),
+                                            Matchers.equalTo(HttpMimeType.HTML.mime()));
+                                    getResponse.complete(ar.result().bodyAsBuffer());
+                                }
+                            });
+
+            getResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        } finally {
+            // Clean up recording
+            CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
+            webClient
+                    .delete(String.format("%s/%s", RECORDING_REQ_URL, TEST_RECORDING_NAME))
+                    .send(
+                            ar -> {
+                                if (assertRequestStatus(ar, deleteResponse)) {
+                                    deleteResponse.complete(ar.result().bodyAsJsonObject());
+                                }
+                            });
+
+            MatcherAssert.assertThat(deleteResponse.get(), Matchers.equalTo(null));
+        }
+    }
+
+    @Test
+    void testGetReportThrowsWithNonExistentRecordingName() throws Exception {
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .get(REPORT_REQ_URL)
+                .send(
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                        });
+        ExecutionException ex =
+                Assertions.assertThrows(ExecutionException.class, () -> response.get());
+        MatcherAssert.assertThat(
+                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
+    }
+}

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -84,7 +84,7 @@ public class ReportIT extends StandardSelfTest {
                                 if (assertRequestStatus(ar, postResponse)) {
                                     MatcherAssert.assertThat(
                                             ar.result().statusCode(), Matchers.equalTo(201));
-                                    postResponse.complete(ar.result().bodyAsJsonObject());
+                                    postResponse.complete(null);
                                 }
                             });
 
@@ -101,6 +101,10 @@ public class ReportIT extends StandardSelfTest {
                                 if (assertRequestStatus(ar, saveResponse)) {
                                     MatcherAssert.assertThat(
                                             ar.result().statusCode(), Matchers.equalTo(200));
+                                    MatcherAssert.assertThat(
+                                            ar.result()
+                                                    .getHeader(HttpHeaders.CONTENT_TYPE.toString()),
+                                            Matchers.equalTo(HttpMimeType.PLAINTEXT.mime()));
                                     saveResponse.complete(null);
                                 }
                             });

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -59,11 +59,9 @@ public class ReportIT extends StandardSelfTest {
     static final String TEST_RECORDING_NAME = "someRecording";
     static final String REPORT_REQ_URL =
             String.format(
-                    "/api/v1/targets/%s/reports/%s", SELF_REFERENCE_TARGET_ID, TEST_RECORDING_NAME);
+                    "/api/v1/reports/%s", TEST_RECORDING_NAME);
     static final String RECORDING_REQ_URL =
             String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);
-    static final String REPORT_URL_BASE =
-            String.format("/api/v1/targets/%s/reports", SELF_REFERENCE_TARGET_ID);
 
     @Test
     void testGetReportShouldSendFile() throws Exception {

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -62,9 +62,10 @@ import org.junit.jupiter.api.Test;
 public class ReportIT extends StandardSelfTest {
 
     static final String TEST_RECORDING_NAME = "someRecording";
-    static final String REPORT_REQ_URL = "/api/v1/reports/";
+    static final String REPORT_REQ_URL = "/api/v1/reports";
     static final String RECORDING_REQ_URL =
             String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID);
+    static final String ARCHIVE_REQ_URL = "/api/v1/recordings";
     static final String TEMP_REPORT = "src/test/resources/reportTest.html";
     static File file;
     static Document doc;
@@ -179,7 +180,7 @@ public class ReportIT extends StandardSelfTest {
 
             CompletableFuture<JsonObject> deleteArchivedRecResp = new CompletableFuture<>();
             webClient
-                    .delete(String.format("/api/v1/recordings/%s", savedRecordingName.get()))
+                    .delete(String.format("%s/%s", ARCHIVE_REQ_URL, savedRecordingName.get()))
                     .send(
                             ar -> {
                                 if (assertRequestStatus(ar, deleteArchivedRecResp)) {

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -133,17 +133,19 @@ public class ReportIT extends StandardSelfTest {
 
         } finally {
             // Clean up recording
-            CompletableFuture<JsonObject> deleteRecResponse = new CompletableFuture<>();
+            CompletableFuture<JsonObject> deleteActiveRecResponse = new CompletableFuture<>();
             webClient
                     .delete(String.format("%s/%s", RECORDING_REQ_URL, TEST_RECORDING_NAME))
                     .send(
                             ar -> {
-                                if (assertRequestStatus(ar, deleteRecResponse)) {
-                                    deleteRecResponse.complete(ar.result().bodyAsJsonObject());
+                                if (assertRequestStatus(ar, deleteActiveRecResponse)) {
+                                    MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
+                                    deleteActiveRecResponse.complete(ar.result().bodyAsJsonObject());
                                 }
                             });
 
-            MatcherAssert.assertThat(deleteRecResponse.get(), Matchers.equalTo(null));
+            MatcherAssert.assertThat(deleteActiveRecResponse.get(), Matchers.equalTo(null));
 
             CompletableFuture<JsonObject> deleteArchivedRecResp = new CompletableFuture<>();
             webClient
@@ -151,6 +153,8 @@ public class ReportIT extends StandardSelfTest {
                     .send(
                             ar -> {
                                 if (assertRequestStatus(ar, deleteArchivedRecResp)) {
+                                    MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
                                     deleteArchivedRecResp.complete(ar.result().bodyAsJsonObject());
                                 }
                             });

--- a/src/test/java/itest/TargetReportIT.java
+++ b/src/test/java/itest/TargetReportIT.java
@@ -39,17 +39,11 @@ package itest;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-<<<<<<< HEAD
-
-=======
-import java.util.concurrent.TimeUnit;
-
 import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
->>>>>>> 8bf08e10 (Add ReportGet itest)
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import itest.bases.StandardSelfTest;
@@ -90,7 +84,7 @@ public class TargetReportIT extends StandardSelfTest {
                                 }
                             });
 
-            postResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            postResponse.get();
 
             // Get a report for the above recording
             CompletableFuture<Buffer> getResponse = new CompletableFuture<>();
@@ -109,7 +103,7 @@ public class TargetReportIT extends StandardSelfTest {
                                 }
                             });
 
-            getResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            getResponse.get();
 
         } finally {
             // Clean up recording

--- a/src/test/java/itest/TargetReportIT.java
+++ b/src/test/java/itest/TargetReportIT.java
@@ -113,6 +113,8 @@ public class TargetReportIT extends StandardSelfTest {
                     .send(
                             ar -> {
                                 if (assertRequestStatus(ar, deleteResponse)) {
+                                    MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
                                     deleteResponse.complete(ar.result().bodyAsJsonObject());
                                 }
                             });

--- a/src/test/java/itest/TargetReportIT.java
+++ b/src/test/java/itest/TargetReportIT.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
 import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.MultiMap;


### PR DESCRIPTION
Related #474 

Tests the HTTP `200` and `404` scenarios for the `TargetReportGetHandler` and `ReportGetHandler`. 

`TargetReportIT` downloads the report directly from the JVM whereas `ReportIT` also makes one more call to save the recording to archive before getting the report from the archive.

Update: All tests are passing
~~Summary of test failures:~~
~~1) `TargetReportGetHandler` throws `500` instead of `404` when getting a non-existent recording (should pass after #614 is merged)~~
~~2) When the Jsoup HTML parser parses the report, it returns a list of `Unexpected Token` errors. See review below~~