### PR TITLE
test(recordings): itest for loading a recording to jfr-datasource

### DIFF
--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -37,9 +37,7 @@
  */
 package itest;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -161,12 +159,10 @@ public class UploadRecordingIT extends StandardSelfTest {
         // Query Data Source for recording metrics
         final CompletableFuture<JsonArray> queryRespFuture = new CompletableFuture<>();
 
-        final Calendar fromDate = Calendar.getInstance();
-        fromDate.add(Calendar.SECOND, -RECORDING_DURATION_SECONDS);
-
-        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        final String FROM = dateFormat.format(fromDate.getTime());
-        final String TO = dateFormat.format(Calendar.getInstance().getTime());
+        Instant toDate = Instant.now(); // Capture the current moment in UTC
+        Instant fromDate = toDate.plusSeconds(-REQUEST_TIMEOUT_SECONDS);
+        final String FROM = fromDate.toString();
+        final String TO = toDate.toString();
         final String TARGET_METRIC = "jdk.CPULoad.machineTotal";
 
         final JsonObject query =

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -97,6 +97,8 @@ public class UploadRecordingIT extends StandardSelfTest {
                 .send(
                         ar -> {
                             if (assertRequestStatus(ar, deleteRespFuture)) {
+                                MatcherAssert.assertThat(
+                                        ar.result().statusCode(), Matchers.equalTo(200));
                                 deleteRespFuture.complete(null);
                             }
                         });
@@ -150,10 +152,6 @@ public class UploadRecordingIT extends StandardSelfTest {
         MatcherAssert.assertThat(
                 getRespFuture.get().trim(), Matchers.equalTo(String.format("%s", RECORDING_NAME)));
 
-        // Wait for recording to finish to gather more data?
-        // Grafana still gives me no datapoints
-        Thread.sleep(5000);
-
         // Query Grafana for recording metrics
         CompletableFuture<JsonArray> queryRespFuture = new CompletableFuture<>();
 
@@ -163,11 +161,12 @@ public class UploadRecordingIT extends StandardSelfTest {
         final String FROM = dateFormat.format(lastFiveSecs.getTime());
         final String TO = dateFormat.format(Calendar.getInstance().getTime());
         final String TARGET_METRIC = "jdk.CPULoad.machineTotal";
+        final int PANEL_ID = 4; // from inspecting dashboard html
 
         JsonObject query =
                 new JsonObject(
                         Map.ofEntries(
-                                Map.entry("panelId", 1),
+                                Map.entry("panelId", PANEL_ID),
                                 Map.entry(
                                         "range",
                                         Map.of(

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -150,11 +150,11 @@ public class UploadRecordingIT extends StandardSelfTest {
 
         CompletableFuture<JsonArray> queryRespFuture = new CompletableFuture<>();
 
-        Calendar yesterday = Calendar.getInstance();
-        yesterday.add(Calendar.DATE, -1);
+        Calendar lastMinute = Calendar.getInstance();
+        lastMinute.add(Calendar.MINUTE, -1);
         final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        final String NOW = dateFormat.format(Calendar.getInstance().getTime());
-        final String YESTERDAY = dateFormat.format(yesterday.getTime());
+        final String END = dateFormat.format(Calendar.getInstance().getTime());
+        final String START = dateFormat.format(lastMinute.getTime());
 
         JsonObject query =
                 new JsonObject(
@@ -164,24 +164,20 @@ public class UploadRecordingIT extends StandardSelfTest {
                                 "range",
                                 Map.of(
                                         "from",
-                                        YESTERDAY,
+                                        START,
                                         "to",
-                                        NOW,
+                                        END,
                                         "raw",
-                                        Map.of("now-24hr", "now")),
+                                        Map.of("now-1m", "now")),
                                 "rangeRaw",
-                                Map.of("from", "now-24hr", "to", "now"),
-                                "interval",
-                                "30s",
-                                "intervalMs",
-                                "30000",
+                                Map.of("from", "now-1m", "to", "now"),
                                 "targets",
                                 List.of(
                                         Map.of(
                                                 "target",
-                                                "upper_50?",
+                                                "jdk.CPULoad.machineTotal",
                                                 "refId",
-                                                "cryostat?",
+                                                "A",
                                                 "type",
                                                 "timeseries")),
                                 "format",
@@ -204,7 +200,6 @@ public class UploadRecordingIT extends StandardSelfTest {
                         });
         // FIXME the /query response shouldn't be empty
         JsonArray expectedQueryResponse = new JsonArray();
-        expectedQueryResponse.add(Map.of());
 
         MatcherAssert.assertThat(queryRespFuture.get(), Matchers.equalTo(expectedQueryResponse));
     }

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -159,8 +159,10 @@ public class UploadRecordingIT extends StandardSelfTest {
         JsonObject query =
                 new JsonObject(
                         Map.of(
+                                "timezone",
+                                "browser",
                                 "panelId",
-                                1,
+                                2,
                                 "range",
                                 Map.of(
                                         "from",
@@ -168,22 +170,22 @@ public class UploadRecordingIT extends StandardSelfTest {
                                         "to",
                                         END,
                                         "raw",
-                                        Map.of("now-1m", "now")),
+                                        Map.of("from", START, "to", END)),
                                 "rangeRaw",
-                                Map.of("from", "now-1m", "to", "now"),
+                                Map.of("from", START, "to", END),
                                 "targets",
                                 List.of(
                                         Map.of(
                                                 "target",
-                                                "jdk.CPULoad.machineTotal",
+                                                "upper_50",
                                                 "refId",
                                                 "A",
                                                 "type",
-                                                "timeseries")),
+                                                "timeserie")),
                                 "format",
                                 "json",
                                 "maxDataPoints",
-                                550));
+                                500));
         webClient
                 .post(8080, "localhost", "/query")
                 .sendJsonObject(
@@ -200,6 +202,7 @@ public class UploadRecordingIT extends StandardSelfTest {
                         });
         // FIXME the /query response shouldn't be empty
         JsonArray expectedQueryResponse = new JsonArray();
+        expectedQueryResponse.add(Map.of());
 
         MatcherAssert.assertThat(queryRespFuture.get(), Matchers.equalTo(expectedQueryResponse));
     }

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -124,9 +124,10 @@ public class UploadRecordingIT extends StandardSelfTest {
                         });
 
         final String expectedUploadResponse =
-                String.format("Uploaded: %s\nSet: %s\n", RECORDING_NAME, RECORDING_NAME);
+                String.format("Uploaded: %s\nSet: %s", RECORDING_NAME, RECORDING_NAME);
 
-        MatcherAssert.assertThat(uploadRespFuture.get(), Matchers.equalTo(expectedUploadResponse));
+        MatcherAssert.assertThat(
+                uploadRespFuture.get().trim(), Matchers.equalTo(expectedUploadResponse));
 
         // Confirm recording appears in Grafana
         CompletableFuture<String> getRespFuture = new CompletableFuture<>();
@@ -145,7 +146,7 @@ public class UploadRecordingIT extends StandardSelfTest {
                         });
 
         MatcherAssert.assertThat(
-                getRespFuture.get(), Matchers.equalTo(String.format("%s\n", RECORDING_NAME)));
+                getRespFuture.get().trim(), Matchers.equalTo(String.format("%s", RECORDING_NAME)));
 
         CompletableFuture<JsonArray> queryRespFuture = new CompletableFuture<>();
 
@@ -201,7 +202,7 @@ public class UploadRecordingIT extends StandardSelfTest {
                                 queryRespFuture.complete(ar.result().bodyAsJsonArray());
                             }
                         });
-        //FIXME the /query response shouldn't be empty
+        // FIXME the /query response shouldn't be empty
         JsonArray expectedQueryResponse = new JsonArray();
         expectedQueryResponse.add(Map.of());
 


### PR DESCRIPTION
Related #474 

Addresses the `TODO` in `UploadRecordingIT`:
```
TODO, this test needs to be updated to actually trigger a file to be uploaded to
jfr-datasource/grafana-dashboard now that the integration tests have these additional
containers configured
```