### PR TITLE
feat(rules): implement "archive" rules

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1398,8 +1398,9 @@ The handler-specific descriptions below describe how each handler populates the
     attributes `"name"`, `"matchExpression"`, and `"eventSpecifier"` must be
     provided.
 
-    `"name"`: the name of this rule definition. This must be unique. This name
-    will also be used to generate the name of the associated recordings.
+    `"name"`: the name of this rule definition. This must be unique, except in
+    the case of "archiver rules" (see `eventSpecifier` below). This name will
+    also be used to generate the name of the associated recordings.
 
     `"matchExpression"`: a string expression used to determine which target JVMs
     this rule will apply to. The expression has a variable named `target` in
@@ -1412,9 +1413,15 @@ The handler-specific descriptions below describe how each handler populates the
     The simple expression `true` may also be used to create a rule which applies
     to any and all discovered targets.
 
-    `"eventSpecifier"`: a string of the form `template=Foo,type=TYPE`. This
+    `"eventSpecifier"`: a string of the form `template=Foo,type=TYPE`, which
     defines the event template that will be used for creating new recordings in
-    matching targets.
+    matching targets; or, the special string `"archive"`, which signifies that
+    this rule should cause all matching targets to have their current (at the
+    time of rule creation) JFR data copied to the Cryostat archives as a
+    one-time operation. When using `"archive"`, it is invalid to provide
+    `archivalPeriodSeconds`, `preservedArchives`, `maxSizeBytes`, or
+    `maxAgeSeconds`. Such "archiver rules" are only processed once and are not
+    persisted, so the `name` and `description` become optional.
 
     The following attributes are optional:
 

--- a/src/main/java/io/cryostat/rules/MatchExpressionValidator.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionValidator.java
@@ -49,7 +49,11 @@ public class MatchExpressionValidator {
 
     String validate(Rule rule) throws MatchExpressionValidationException {
         try {
-            CompilationUnitTree cut = parser.parse(rule.getName(), rule.getMatchExpression(), null);
+            String name = rule.getName();
+            if (name == null) {
+                name = "";
+            }
+            CompilationUnitTree cut = parser.parse(name, rule.getMatchExpression(), null);
             if (cut == null) {
                 throw new IllegalMatchExpressionException();
             }

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -64,10 +64,14 @@ public class Rule {
     private final int maxSizeBytes;
 
     Rule(Builder builder) throws MatchExpressionValidationException {
-        this.name = sanitizeRuleName(requireNonBlank(builder.name, Attribute.NAME));
+        this.eventSpecifier = builder.eventSpecifier;
+        if (isArchiver()) {
+            this.name = builder.name;
+        } else {
+            this.name = sanitizeRuleName(requireNonBlank(builder.name, Attribute.NAME));
+        }
         this.description = builder.description == null ? "" : builder.description;
         this.matchExpression = builder.matchExpression;
-        this.eventSpecifier = builder.eventSpecifier;
         this.archivalPeriodSeconds = builder.archivalPeriodSeconds;
         this.preservedArchives = builder.preservedArchives;
         this.maxAgeSeconds =
@@ -131,11 +135,8 @@ public class Rule {
     }
 
     public void validate() throws IllegalArgumentException, MatchExpressionValidationException {
-        requireNonBlank(this.name, Attribute.NAME);
         requireNonBlank(this.matchExpression, Attribute.MATCH_EXPRESSION);
         validateEventSpecifier(requireNonBlank(this.eventSpecifier, Attribute.EVENT_SPECIFIER));
-        requireNonNegative(this.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
-        requireNonNegative(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
         validateMatchExpression(this);
 
         if (isArchiver()) {
@@ -143,6 +144,10 @@ public class Rule {
             requireNonPositive(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
             requireNonPositive(this.maxSizeBytes, Attribute.MAX_SIZE_BYTES);
             requireNonPositive(this.maxAgeSeconds, Attribute.MAX_AGE_SECONDS);
+        } else {
+            requireNonBlank(this.name, Attribute.NAME);
+            requireNonNegative(this.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
+            requireNonNegative(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
         }
     }
 
@@ -188,10 +193,10 @@ public class Rule {
     }
 
     public static class Builder {
-        private String name;
-        private String description;
-        private String matchExpression;
-        private String eventSpecifier;
+        private String name = "";
+        private String description = "";
+        private String matchExpression = "";
+        private String eventSpecifier = "";
         private int archivalPeriodSeconds = 0;
         private int preservedArchives = 0;
         private int maxAgeSeconds = -1;

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -39,13 +39,15 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
-import io.cryostat.recordings.RecordingTargetHelper;
-
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import io.vertx.core.MultiMap;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import io.cryostat.recordings.RecordingTargetHelper;
+import io.vertx.core.MultiMap;
 
 public class Rule {
 
@@ -270,13 +272,11 @@ public class Rule {
         public static Builder from(JsonObject jsonObj) throws IllegalArgumentException {
             Rule.Builder builder =
                     new Rule.Builder()
-                            .name(jsonObj.get(Rule.Attribute.NAME.getSerialKey()).getAsString())
+                            .name(getAsNullableString(jsonObj, Rule.Attribute.NAME))
                             .matchExpression(
                                     jsonObj.get(Rule.Attribute.MATCH_EXPRESSION.getSerialKey())
                                             .getAsString())
-                            .description(
-                                    jsonObj.get(Rule.Attribute.DESCRIPTION.getSerialKey())
-                                            .getAsString())
+                            .description(getAsNullableString(jsonObj, Rule.Attribute.DESCRIPTION))
                             .eventSpecifier(
                                     jsonObj.get(Rule.Attribute.EVENT_SPECIFIER.getSerialKey())
                                             .getAsString());
@@ -286,6 +286,14 @@ public class Rule {
             builder.setOptionalInt(Rule.Attribute.MAX_SIZE_BYTES, jsonObj);
 
             return builder;
+        }
+
+        private static String getAsNullableString(JsonObject jsonObj, Rule.Attribute attr) {
+            JsonElement el = jsonObj.get(attr.getSerialKey());
+            if (el == null) {
+                return null;
+            }
+            return el.getAsString();
         }
 
         private Builder setOptionalInt(Rule.Attribute key, MultiMap formAttributes)

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -39,15 +39,14 @@ package io.cryostat.rules;
 
 import java.util.function.Function;
 
+import io.cryostat.recordings.RecordingTargetHelper;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
+import io.vertx.core.MultiMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
-import io.cryostat.recordings.RecordingTargetHelper;
-import io.vertx.core.MultiMap;
 
 public class Rule {
 

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -52,6 +52,8 @@ public class Rule {
     private static final MatchExpressionValidator MATCH_EXPRESSION_VALIDATOR =
             new MatchExpressionValidator();
 
+    static final String ARCHIVE_EVENT = "archive";
+
     private final String name;
     private final String description;
     private final String matchExpression;
@@ -93,6 +95,10 @@ public class Rule {
 
     public String getEventSpecifier() {
         return this.eventSpecifier;
+    }
+
+    public boolean isArchiver() {
+        return ARCHIVE_EVENT.equals(getEventSpecifier());
     }
 
     public int getArchivalPeriodSeconds() {
@@ -148,6 +154,9 @@ public class Rule {
 
     private static String validateEventSpecifier(String eventSpecifier)
             throws IllegalArgumentException {
+        if (eventSpecifier.equals(ARCHIVE_EVENT)) {
+            return eventSpecifier;
+        }
         // throws if cannot be parsed
         RecordingTargetHelper.parseEventSpecifierToTemplate(eventSpecifier);
         return eventSpecifier;

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -177,8 +177,8 @@ public class Rule {
         private String description;
         private String matchExpression;
         private String eventSpecifier;
-        private int archivalPeriodSeconds = 30;
-        private int preservedArchives = 1;
+        private int archivalPeriodSeconds = 0;
+        private int preservedArchives = 0;
         private int maxAgeSeconds = -1;
         private int maxSizeBytes = -1;
 

--- a/src/main/java/io/cryostat/rules/Rule.java
+++ b/src/main/java/io/cryostat/rules/Rule.java
@@ -137,6 +137,13 @@ public class Rule {
         requireNonNegative(this.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
         requireNonNegative(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
         validateMatchExpression(this);
+
+        if (isArchiver()) {
+            requireNonPositive(this.archivalPeriodSeconds, Attribute.ARCHIVAL_PERIOD_SECONDS);
+            requireNonPositive(this.preservedArchives, Attribute.PRESERVED_ARCHIVES);
+            requireNonPositive(this.maxSizeBytes, Attribute.MAX_SIZE_BYTES);
+            requireNonPositive(this.maxAgeSeconds, Attribute.MAX_AGE_SECONDS);
+        }
     }
 
     private static String validateMatchExpression(Rule rule)
@@ -148,6 +155,14 @@ public class Rule {
         if (i < 0) {
             throw new IllegalArgumentException(
                     String.format("\"%s\" cannot be negative, was \"%d\"", attr, i));
+        }
+        return i;
+    }
+
+    private static int requireNonPositive(int i, Attribute attr) {
+        if (i > 0) {
+            throw new IllegalArgumentException(
+                    String.format("\"%s\" cannot be positive, was \"%d\"", attr, i));
         }
         return i;
     }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -255,13 +255,12 @@ public class RuleProcessor
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(connection.getService())
-                                    .name(rule.getRecordingName())
-                                    .toDisk(true);
+                                    .name(rule.getRecordingName());
                     if (rule.getMaxAgeSeconds() > 0) {
-                        builder = builder.maxAge(rule.getMaxAgeSeconds());
+                        builder = builder.maxAge(rule.getMaxAgeSeconds()).toDisk(true);
                     }
                     if (rule.getMaxSizeBytes() > 0) {
-                        builder = builder.maxSize(rule.getMaxSizeBytes());
+                        builder = builder.maxSize(rule.getMaxSizeBytes()).toDisk(true);
                     }
                     Pair<String, TemplateType> template =
                             RecordingTargetHelper.parseEventSpecifierToTemplate(

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -235,7 +235,7 @@ public class RuleProcessor
                         builder = builder.maxSize(rule.getMaxSizeBytes());
                     }
                     Pair<String, TemplateType> template =
-                            recordingTargetHelper.parseEventSpecifierToTemplate(
+                            RecordingTargetHelper.parseEventSpecifierToTemplate(
                                     rule.getEventSpecifier());
                     recordingTargetHelper.startRecording(
                             true,

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -100,14 +100,16 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
                             "Rule with name \"%s\" already exists; refusing to overwrite",
                             rule.getName()));
         }
-        Path destination = rulesDir.resolve(rule.getName() + ".json");
-        this.fs.writeString(
-                destination,
-                gson.toJson(rule),
-                StandardOpenOption.WRITE,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING);
-        loadRules();
+        if (!rule.isArchiver()) {
+            Path destination = rulesDir.resolve(rule.getName() + ".json");
+            this.fs.writeString(
+                    destination,
+                    gson.toJson(rule),
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+            loadRules();
+        }
         emit(RuleEvent.ADDED, rule);
         return rule;
     }
@@ -138,7 +140,10 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
         if (!serviceRef.getAlias().isPresent()) {
             return Set.of();
         }
-        return rules.stream().filter(r -> applies(r, serviceRef)).collect(Collectors.toSet());
+        return rules.stream()
+                .filter(r -> !r.isArchiver())
+                .filter(r -> applies(r, serviceRef))
+                .collect(Collectors.toSet());
     }
 
     public Set<Rule> getRules() {

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -94,13 +94,13 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
     }
 
     public Rule addRule(Rule rule) throws IOException {
-        if (hasRuleByName(rule.getName())) {
-            throw new RuleException(
-                    String.format(
-                            "Rule with name \"%s\" already exists; refusing to overwrite",
-                            rule.getName()));
-        }
         if (!rule.isArchiver()) {
+            if (hasRuleByName(rule.getName())) {
+                throw new RuleException(
+                        String.format(
+                                "Rule with name \"%s\" already exists; refusing to overwrite",
+                                rule.getName()));
+            }
             Path destination = rulesDir.resolve(rule.getName() + ".json");
             this.fs.writeString(
                     destination,

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -140,9 +140,7 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
         if (!serviceRef.getAlias().isPresent()) {
             return Set.of();
         }
-        return rules.stream()
-                .filter(r -> applies(r, serviceRef))
-                .collect(Collectors.toSet());
+        return rules.stream().filter(r -> applies(r, serviceRef)).collect(Collectors.toSet());
     }
 
     public Set<Rule> getRules() {

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -141,7 +141,6 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
             return Set.of();
         }
         return rules.stream()
-                .filter(r -> !r.isArchiver())
                 .filter(r -> applies(r, serviceRef))
                 .collect(Collectors.toSet());
     }

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -209,8 +209,24 @@ class RuleTest {
 
     @Test
     void shouldAcceptEventSpecifierArchiveSpecialCase() throws Exception {
+        Rule rule = builder.matchExpression(MATCH_EXPRESSION).eventSpecifier("archive").build();
+        MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo("archive"));
+    }
+
+    @Test
+    void shouldAcceptEventSpecifierArchiveSpecialCaseWithName() throws Exception {
         Rule rule =
                 builder.name("Some Rule")
+                        .matchExpression(MATCH_EXPRESSION)
+                        .eventSpecifier("archive")
+                        .build();
+        MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo("archive"));
+    }
+
+    @Test
+    void shouldAcceptEventSpecifierArchiveSpecialCaseWithDescription() throws Exception {
+        Rule rule =
+                builder.description("Unused description")
                         .matchExpression(MATCH_EXPRESSION)
                         .eventSpecifier("archive")
                         .build();
@@ -223,8 +239,7 @@ class RuleTest {
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
                         () -> {
-                            builder.name(NAME)
-                                    .matchExpression(MATCH_EXPRESSION)
+                            builder.matchExpression(MATCH_EXPRESSION)
                                     .eventSpecifier("archive")
                                     .archivalPeriodSeconds(5)
                                     .build();
@@ -240,8 +255,7 @@ class RuleTest {
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
                         () -> {
-                            builder.name(NAME)
-                                    .matchExpression(MATCH_EXPRESSION)
+                            builder.matchExpression(MATCH_EXPRESSION)
                                     .eventSpecifier("archive")
                                     .preservedArchives(5)
                                     .build();
@@ -257,8 +271,7 @@ class RuleTest {
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
                         () -> {
-                            builder.name(NAME)
-                                    .matchExpression(MATCH_EXPRESSION)
+                            builder.matchExpression(MATCH_EXPRESSION)
                                     .eventSpecifier("archive")
                                     .maxSizeBytes(5)
                                     .build();
@@ -274,8 +287,7 @@ class RuleTest {
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
                         () -> {
-                            builder.name(NAME)
-                                    .matchExpression(MATCH_EXPRESSION)
+                            builder.matchExpression(MATCH_EXPRESSION)
                                     .eventSpecifier("archive")
                                     .maxAgeSeconds(5)
                                     .build();

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -216,4 +216,72 @@ class RuleTest {
                         .build();
         MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo("archive"));
     }
+
+    @Test
+    void shouldThrowOnArchiverWithArchivalPeriod() throws Exception {
+        IllegalArgumentException ex =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            builder.name(NAME)
+                                    .matchExpression(MATCH_EXPRESSION)
+                                    .eventSpecifier("archive")
+                                    .archivalPeriodSeconds(5)
+                                    .build();
+                        });
+        MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.containsString("\"archivalPeriodSeconds\" cannot be positive, was \"5\""));
+    }
+
+    @Test
+    void shouldThrowOnArchiverWithPreservedArchives() throws Exception {
+        IllegalArgumentException ex =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            builder.name(NAME)
+                                    .matchExpression(MATCH_EXPRESSION)
+                                    .eventSpecifier("archive")
+                                    .preservedArchives(5)
+                                    .build();
+                        });
+        MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.containsString("\"preservedArchives\" cannot be positive, was \"5\""));
+    }
+
+    @Test
+    void shouldThrowOnArchiverWithMaxSizeBytes() throws Exception {
+        IllegalArgumentException ex =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            builder.name(NAME)
+                                    .matchExpression(MATCH_EXPRESSION)
+                                    .eventSpecifier("archive")
+                                    .maxSizeBytes(5)
+                                    .build();
+                        });
+        MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.containsString("\"maxSizeBytes\" cannot be positive, was \"5\""));
+    }
+
+    @Test
+    void shouldThrowOnArchiverWithMaxAgeSeconds() throws Exception {
+        IllegalArgumentException ex =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            builder.name(NAME)
+                                    .matchExpression(MATCH_EXPRESSION)
+                                    .eventSpecifier("archive")
+                                    .maxAgeSeconds(5)
+                                    .build();
+                        });
+        MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.containsString("\"maxAgeSeconds\" cannot be positive, was \"5\""));
+    }
 }

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -206,4 +206,14 @@ class RuleTest {
                         .build();
         MatcherAssert.assertThat(rule.getRecordingName(), Matchers.equalTo("auto_Some_Rule"));
     }
+
+    @Test
+    void shouldAcceptEventSpecifierArchiveSpecialCase() throws Exception {
+        Rule rule =
+                builder.name("Some Rule")
+                        .matchExpression(MATCH_EXPRESSION)
+                        .eventSpecifier("archive")
+                        .build();
+        MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo("archive"));
+    }
 }

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -123,7 +123,8 @@ class RuleTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    void shouldThrowOnBlankEventSpecifier(String s) {
+    @ValueSource(strings = {"invalid", "events=incorrect", "tenplate=typo"})
+    void shouldThrowOnInvalidEventSpecifier(String s) {
         IllegalArgumentException ex =
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
@@ -135,7 +136,10 @@ class RuleTest {
                         });
         MatcherAssert.assertThat(
                 ex.getMessage(),
-                Matchers.containsString("\"eventSpecifier\" cannot be blank, was \"" + s + "\""));
+                Matchers.either(
+                                Matchers.equalTo(
+                                        "\"eventSpecifier\" cannot be blank, was \"" + s + "\""))
+                        .or(Matchers.equalTo(s)));
     }
 
     @Test

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -38,7 +38,7 @@
 package io.cryostat.rules;
 
 import com.google.gson.JsonObject;
-
+import io.vertx.core.MultiMap;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -50,8 +50,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.vertx.core.MultiMap;
 
 @ExtendWith(MockitoExtension.class)
 class RuleTest {
@@ -309,7 +307,8 @@ class RuleTest {
         class Json {
 
             @Test
-            void testCompleteRule() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testCompleteRule()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String name = "Some Rule";
                 String description = "This is a description";
                 String matchExpression = "target.alias=='TheAlias'";
@@ -332,18 +331,21 @@ class RuleTest {
 
                 MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
                 MatcherAssert.assertThat(rule.getDescription(), Matchers.equalTo(description));
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
                 MatcherAssert.assertThat(rule.getMaxAgeSeconds(), Matchers.equalTo(maxAgeSeconds));
                 MatcherAssert.assertThat(rule.getMaxSizeBytes(), Matchers.equalTo(maxSizeBytes));
-                MatcherAssert.assertThat(rule.getArchivalPeriodSeconds(),
-                        Matchers.equalTo(archivalPeriodSeconds));
-                MatcherAssert.assertThat(rule.getPreservedArchives(),
-                        Matchers.equalTo(preservedArchives));
+                MatcherAssert.assertThat(
+                        rule.getArchivalPeriodSeconds(), Matchers.equalTo(archivalPeriodSeconds));
+                MatcherAssert.assertThat(
+                        rule.getPreservedArchives(), Matchers.equalTo(preservedArchives));
             }
 
             @Test
-            void testRuleWithoutOptionalFields() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testRuleWithoutOptionalFields()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String name = "Some Rule";
                 String matchExpression = "target.alias=='TheAlias'";
                 String eventSpecifier = "template=Foo";
@@ -355,12 +357,15 @@ class RuleTest {
                 Rule rule = Rule.Builder.from(json).build();
 
                 MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
             }
 
             @Test
-            void testArchiverWithoutName() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testArchiverWithoutName()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String matchExpression = "target.alias=='TheAlias'";
                 String eventSpecifier = "archive";
 
@@ -369,16 +374,19 @@ class RuleTest {
                 json.addProperty("eventSpecifier", eventSpecifier);
                 Rule rule = Rule.Builder.from(json).build();
 
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
             }
-
         }
+
         @Nested
         class Form {
 
             @Test
-            void testCompleteRule() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testCompleteRule()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String name = "Some Rule";
                 String description = "This is a description";
                 String matchExpression = "target.alias=='TheAlias'";
@@ -401,18 +409,21 @@ class RuleTest {
 
                 MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
                 MatcherAssert.assertThat(rule.getDescription(), Matchers.equalTo(description));
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
                 MatcherAssert.assertThat(rule.getMaxAgeSeconds(), Matchers.equalTo(maxAgeSeconds));
                 MatcherAssert.assertThat(rule.getMaxSizeBytes(), Matchers.equalTo(maxSizeBytes));
-                MatcherAssert.assertThat(rule.getArchivalPeriodSeconds(),
-                        Matchers.equalTo(archivalPeriodSeconds));
-                MatcherAssert.assertThat(rule.getPreservedArchives(),
-                        Matchers.equalTo(preservedArchives));
+                MatcherAssert.assertThat(
+                        rule.getArchivalPeriodSeconds(), Matchers.equalTo(archivalPeriodSeconds));
+                MatcherAssert.assertThat(
+                        rule.getPreservedArchives(), Matchers.equalTo(preservedArchives));
             }
 
             @Test
-            void testRuleWithoutOptionalFields() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testRuleWithoutOptionalFields()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String name = "Some Rule";
                 String matchExpression = "target.alias=='TheAlias'";
                 String eventSpecifier = "template=Foo";
@@ -424,12 +435,15 @@ class RuleTest {
                 Rule rule = Rule.Builder.from(form).build();
 
                 MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
             }
 
             @Test
-            void testArchiverWithoutName() throws IllegalArgumentException, MatchExpressionValidationException {
+            void testArchiverWithoutName()
+                    throws IllegalArgumentException, MatchExpressionValidationException {
                 String matchExpression = "target.alias=='TheAlias'";
                 String eventSpecifier = "archive";
 
@@ -438,11 +452,11 @@ class RuleTest {
                 form.set("eventSpecifier", eventSpecifier);
                 Rule rule = Rule.Builder.from(form).build();
 
-                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
-                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(
+                        rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(
+                        rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
             }
-
         }
-
     }
 }

--- a/src/test/java/io/cryostat/rules/RuleTest.java
+++ b/src/test/java/io/cryostat/rules/RuleTest.java
@@ -37,16 +37,21 @@
  */
 package io.cryostat.rules;
 
+import com.google.gson.JsonObject;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.MultiMap;
 
 @ExtendWith(MockitoExtension.class)
 class RuleTest {
@@ -295,5 +300,149 @@ class RuleTest {
         MatcherAssert.assertThat(
                 ex.getMessage(),
                 Matchers.containsString("\"maxAgeSeconds\" cannot be positive, was \"5\""));
+    }
+
+    @Nested
+    class Deserialization {
+
+        @Nested
+        class Json {
+
+            @Test
+            void testCompleteRule() throws IllegalArgumentException, MatchExpressionValidationException {
+                String name = "Some Rule";
+                String description = "This is a description";
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "template=Foo";
+                int maxAgeSeconds = 60;
+                int maxSizeBytes = 32 * 1024;
+                int archivalPeriodSeconds = 300;
+                int preservedArchives = 5;
+
+                JsonObject json = new JsonObject();
+                json.addProperty("name", name);
+                json.addProperty("description", description);
+                json.addProperty("matchExpression", matchExpression);
+                json.addProperty("eventSpecifier", eventSpecifier);
+                json.addProperty("maxAgeSeconds", maxAgeSeconds);
+                json.addProperty("maxSizeBytes", maxSizeBytes);
+                json.addProperty("archivalPeriodSeconds", archivalPeriodSeconds);
+                json.addProperty("preservedArchives", preservedArchives);
+                Rule rule = Rule.Builder.from(json).build();
+
+                MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
+                MatcherAssert.assertThat(rule.getDescription(), Matchers.equalTo(description));
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(rule.getMaxAgeSeconds(), Matchers.equalTo(maxAgeSeconds));
+                MatcherAssert.assertThat(rule.getMaxSizeBytes(), Matchers.equalTo(maxSizeBytes));
+                MatcherAssert.assertThat(rule.getArchivalPeriodSeconds(),
+                        Matchers.equalTo(archivalPeriodSeconds));
+                MatcherAssert.assertThat(rule.getPreservedArchives(),
+                        Matchers.equalTo(preservedArchives));
+            }
+
+            @Test
+            void testRuleWithoutOptionalFields() throws IllegalArgumentException, MatchExpressionValidationException {
+                String name = "Some Rule";
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "template=Foo";
+
+                JsonObject json = new JsonObject();
+                json.addProperty("name", name);
+                json.addProperty("matchExpression", matchExpression);
+                json.addProperty("eventSpecifier", eventSpecifier);
+                Rule rule = Rule.Builder.from(json).build();
+
+                MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+            }
+
+            @Test
+            void testArchiverWithoutName() throws IllegalArgumentException, MatchExpressionValidationException {
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "archive";
+
+                JsonObject json = new JsonObject();
+                json.addProperty("matchExpression", matchExpression);
+                json.addProperty("eventSpecifier", eventSpecifier);
+                Rule rule = Rule.Builder.from(json).build();
+
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+            }
+
+        }
+        @Nested
+        class Form {
+
+            @Test
+            void testCompleteRule() throws IllegalArgumentException, MatchExpressionValidationException {
+                String name = "Some Rule";
+                String description = "This is a description";
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "template=Foo";
+                int maxAgeSeconds = 60;
+                int maxSizeBytes = 32 * 1024;
+                int archivalPeriodSeconds = 300;
+                int preservedArchives = 5;
+
+                MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                form.set("name", name);
+                form.set("description", description);
+                form.set("matchExpression", matchExpression);
+                form.set("eventSpecifier", eventSpecifier);
+                form.set("maxAgeSeconds", String.valueOf(maxAgeSeconds));
+                form.set("maxSizeBytes", String.valueOf(maxSizeBytes));
+                form.set("archivalPeriodSeconds", String.valueOf(archivalPeriodSeconds));
+                form.set("preservedArchives", String.valueOf(preservedArchives));
+                Rule rule = Rule.Builder.from(form).build();
+
+                MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
+                MatcherAssert.assertThat(rule.getDescription(), Matchers.equalTo(description));
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+                MatcherAssert.assertThat(rule.getMaxAgeSeconds(), Matchers.equalTo(maxAgeSeconds));
+                MatcherAssert.assertThat(rule.getMaxSizeBytes(), Matchers.equalTo(maxSizeBytes));
+                MatcherAssert.assertThat(rule.getArchivalPeriodSeconds(),
+                        Matchers.equalTo(archivalPeriodSeconds));
+                MatcherAssert.assertThat(rule.getPreservedArchives(),
+                        Matchers.equalTo(preservedArchives));
+            }
+
+            @Test
+            void testRuleWithoutOptionalFields() throws IllegalArgumentException, MatchExpressionValidationException {
+                String name = "Some Rule";
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "template=Foo";
+
+                MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                form.set("name", name);
+                form.set("matchExpression", matchExpression);
+                form.set("eventSpecifier", eventSpecifier);
+                Rule rule = Rule.Builder.from(form).build();
+
+                MatcherAssert.assertThat(rule.getName(), Matchers.equalTo("Some_Rule"));
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+            }
+
+            @Test
+            void testArchiverWithoutName() throws IllegalArgumentException, MatchExpressionValidationException {
+                String matchExpression = "target.alias=='TheAlias'";
+                String eventSpecifier = "archive";
+
+                MultiMap form = MultiMap.caseInsensitiveMultiMap();
+                form.set("matchExpression", matchExpression);
+                form.set("eventSpecifier", eventSpecifier);
+                Rule rule = Rule.Builder.from(form).build();
+
+                MatcherAssert.assertThat(rule.getMatchExpression(), Matchers.equalTo(matchExpression));
+                MatcherAssert.assertThat(rule.getEventSpecifier(), Matchers.equalTo(eventSpecifier));
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
Closes #645

Fixes #643

This implements an alternative and simplified version of the "one-shot" rules.

If a Rule definition is given where `"eventSpecifier":"archive"`, the rule definition will not be persisted, does not require a unique name, may not have `archivalPeriodSeconds/preservedArchives/maxAge/maxSize`, and rather than starting a new recording will cause a snapshot to be taken, copied to archives, and the snapshot immediately removed.

The motivation is to allow a user to have a workflow such as the following:

```
POST /api/v2/rules
```
```json
{
    "name": "monitor",
    "description": "Monitor application, all the time",
    "eventSpecifier": "template=Continuous",
    "matchExpression": "target.labels.app=='MyApp'",
    "archivalPeriodSeconds": 3600,
    "maxAgeSeconds": 300,
    "preservedArchives": 6
}
```

Wait some time and observe application metrics (JFR or otherwise), either manually or by an external automated process. When some trigger event occurs, such as resource utilization exceeding a threshold for longer than some duration, the user wants to get copies of their application's JFR data at that moment and for the previous lookback window (5min in this case due to `maxAgeSeconds`).

Note that this rule configuration gives the user a 5min window of data in the recording at any time, and that that 5 minute sample will be copied to archives only once per hour (3600 seconds). 6 such copies will be retained in the archives at any given time. Such a configuration could be used to gather ongoing continuous monitoring data, leaving long gaps in between archival periods to prevent excessive use of disk space, for example.

Alternatively, the rule definition may only start a continuous recording in the targets, without any configuration for periodic archiving.

```
POST /api/v2/rules
```
```json
{
    "eventSpecifier": "archive",
    "matchExpression": "target.labels.app=='MyApp'"
}
```

After POSTing this second rule definition, Cryostat will connect to all of the same original set of targets and perform the snapshot/archive/remove snapshot procedure as explained earlier. The original recordings created by the first rule are still in place and running, so the user may re-POST the second rule definition as many times as they wish in the future as more external trigger events occur.