### PR TITLE
fix(assembly): add cryostat.jfc to assembly

### DIFF
--- a/src/assembly/dist.xml
+++ b/src/assembly/dist.xml
@@ -17,6 +17,7 @@
       <directory>${project.basedir}/src/main/extras</directory>
       <includes>
         <include>${cryostat.entrypoint}</include>
+        <include>cryostat.jfc</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>


### PR DESCRIPTION
This adds `cryostat.jfc` to the root of the assembly. The consumer of the assembly can move it to the appropriate JRE directory.

Fixes #652 