### PR TITLE
fix(archive): sanitize target alias when writing file

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -326,7 +327,12 @@ public class RecordingArchiveHelper {
 
         String timestamp =
                 clock.now().truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        String destination = String.format("%s_%s_%s", targetName, recordingName, timestamp);
+        String destination =
+                String.format(
+                        "%s_%s_%s",
+                        URLEncoder.encode(targetName, StandardCharsets.UTF_8),
+                        URLEncoder.encode(recordingName, StandardCharsets.UTF_8),
+                        timestamp);
         // TODO byte-sized rename limit is arbitrary. Probably plenty since recordings are also
         // differentiated by second-resolution timestamp
         byte count = 1;


### PR DESCRIPTION
Fixes #665

The target alias is currently included as-is in the destination filename when writing a JFR file to disk. This can be problematic since the target alias can contain characters like '/', for example `/deployments/quarkus-run.jar` in the quarkus-test sample application.  The solution presented here is to URL encode the alias before including it in the destination filename, so the alias is transformed into ex. `%2Fdeployments%2Fquarkus-run.jar`.

To test:
Check the current behaviour upstream with `sh smoketest.sh`. Create a new recording on the quarkus-test application, then attempt to archive this recording. The request will fail with an AccessDeniedException.

Then retry this procedure but starting from `CRYOSTAT_IMAGE=quay.io/andrewazores/cryostat:sanitize-archive-alias sh smoketest.sh`. The recording should be successfully archived with the alias encoded. Archiving recordings on the other targets, which already have "safe" aliases, should produce the same resultant archive filename as before.