### PR TITLE
fix(serviceref): guard against nulls

### DIFF
--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -46,7 +46,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -42,9 +42,11 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.google.gson.annotations.SerializedName;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -57,7 +59,7 @@ public class ServiceRef {
     private final Annotations annotations = new Annotations();
 
     public ServiceRef(URI uri, String alias) {
-        this.serviceUri = uri;
+        this.serviceUri = Objects.requireNonNull(uri);
         this.alias = alias;
     }
 
@@ -71,6 +73,9 @@ public class ServiceRef {
 
     public void setLabels(Map<String, String> labels) {
         this.labels.clear();
+        if (labels == null) {
+            labels = Map.of();
+        }
         this.labels.putAll(labels);
     }
 
@@ -80,6 +85,9 @@ public class ServiceRef {
 
     public void setPlatformAnnotations(Map<String, String> annotations) {
         this.annotations.platform.clear();
+        if (annotations == null) {
+            annotations = Map.of();
+        }
         this.annotations.platform.putAll(annotations);
     }
 
@@ -89,6 +97,9 @@ public class ServiceRef {
 
     public void setCryostatAnnotations(Map<AnnotationKey, String> annotations) {
         this.annotations.cryostat.clear();
+        if (annotations == null) {
+            annotations = Map.of();
+        }
         this.annotations.cryostat.putAll(annotations);
     }
 

--- a/src/test/java/io/cryostat/platform/ServiceRefTest.java
+++ b/src/test/java/io/cryostat/platform/ServiceRefTest.java
@@ -41,12 +41,12 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 
+import io.cryostat.platform.ServiceRef.AnnotationKey;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import io.cryostat.platform.ServiceRef.AnnotationKey;
 
 class ServiceRefTest {
 
@@ -118,8 +118,8 @@ class ServiceRefTest {
     @Test
     void shouldBeAbleToSetNonEmptyCryostatAnnotations() {
         ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
-        Map<AnnotationKey, String> annotations = Map.of(AnnotationKey.HOST, "fooHost",
-                AnnotationKey.JAVA_MAIN, "some.App");
+        Map<AnnotationKey, String> annotations =
+                Map.of(AnnotationKey.HOST, "fooHost", AnnotationKey.JAVA_MAIN, "some.App");
         sr.setCryostatAnnotations(annotations);
         MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(annotations));
     }
@@ -127,8 +127,8 @@ class ServiceRefTest {
     @Test
     void shouldBeAbleToReplaceCryostatAnnotations() {
         ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
-        Map<AnnotationKey, String> annotations = Map.of(AnnotationKey.HOST, "fooHost",
-                AnnotationKey.JAVA_MAIN, "some.App");
+        Map<AnnotationKey, String> annotations =
+                Map.of(AnnotationKey.HOST, "fooHost", AnnotationKey.JAVA_MAIN, "some.App");
         sr.setCryostatAnnotations(annotations);
         MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(annotations));
         sr.setCryostatAnnotations(Map.of());
@@ -165,5 +165,4 @@ class ServiceRefTest {
         sr.setPlatformAnnotations(Map.of());
         MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
     }
-
 }

--- a/src/test/java/io/cryostat/platform/ServiceRefTest.java
+++ b/src/test/java/io/cryostat/platform/ServiceRefTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.platform;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.cryostat.platform.ServiceRef.AnnotationKey;
+
+class ServiceRefTest {
+
+    static final String URI_STRING = "service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi";
+    static final URI EXAMPLE_URI = URI.create(URI_STRING);
+    static final String EXAMPLE_ALIAS = "some.app.Alias";
+
+    @Test
+    void testConstruct() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        MatcherAssert.assertThat(sr.getServiceUri(), Matchers.equalTo(EXAMPLE_URI));
+        MatcherAssert.assertThat(sr.getAlias(), Matchers.equalTo(Optional.of(EXAMPLE_ALIAS)));
+    }
+
+    @Test
+    void shouldThrowOnNullUri() {
+        Assertions.assertThrows(NullPointerException.class, () -> new ServiceRef(null, "alias"));
+    }
+
+    @Test
+    void shouldAllowEmptyAlias() {
+        Assertions.assertTrue(new ServiceRef(EXAMPLE_URI, null).getAlias().isEmpty());
+    }
+
+    @Test
+    void shouldHaveEmptyLabels() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        MatcherAssert.assertThat(sr.getLabels(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetEmptyLabels() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        sr.setLabels(Map.of());
+        MatcherAssert.assertThat(sr.getLabels(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetNonEmptyLabels() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<String, String> labels = Map.of("a", "1", "foo", "bar");
+        sr.setLabels(labels);
+        MatcherAssert.assertThat(sr.getLabels(), Matchers.equalTo(labels));
+    }
+
+    @Test
+    void shouldBeAbleToReplaceLabels() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<String, String> labels = Map.of("a", "1", "foo", "bar");
+        sr.setLabels(labels);
+        MatcherAssert.assertThat(sr.getLabels(), Matchers.equalTo(labels));
+        sr.setLabels(Map.of());
+        MatcherAssert.assertThat(sr.getLabels(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldHaveEmptyCryostatAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetEmptyCryostatAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        sr.setLabels(Map.of());
+        MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetNonEmptyCryostatAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<AnnotationKey, String> annotations = Map.of(AnnotationKey.HOST, "fooHost",
+                AnnotationKey.JAVA_MAIN, "some.App");
+        sr.setCryostatAnnotations(annotations);
+        MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(annotations));
+    }
+
+    @Test
+    void shouldBeAbleToReplaceCryostatAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<AnnotationKey, String> annotations = Map.of(AnnotationKey.HOST, "fooHost",
+                AnnotationKey.JAVA_MAIN, "some.App");
+        sr.setCryostatAnnotations(annotations);
+        MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(annotations));
+        sr.setCryostatAnnotations(Map.of());
+        MatcherAssert.assertThat(sr.getCryostatAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldHaveEmptyPlatformAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetEmptyPlatformAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        sr.setPlatformAnnotations(Map.of());
+        MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+    @Test
+    void shouldBeAbleToSetNonEmptyPlatformAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<String, String> annotations = Map.of("a", "1", "foo", "bar");
+        sr.setPlatformAnnotations(annotations);
+        MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(annotations));
+    }
+
+    @Test
+    void shouldBeAbleToReplacePlatformAnnotations() {
+        ServiceRef sr = new ServiceRef(EXAMPLE_URI, EXAMPLE_ALIAS);
+        Map<String, String> annotations = Map.of("a", "1", "foo", "bar");
+        sr.setPlatformAnnotations(annotations);
+        MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(annotations));
+        sr.setPlatformAnnotations(Map.of());
+        MatcherAssert.assertThat(sr.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
+    }
+
+}

--- a/src/test/java/io/cryostat/rules/RuleRegistryTest.java
+++ b/src/test/java/io/cryostat/rules/RuleRegistryTest.java
@@ -49,8 +49,14 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import com.google.gson.Gson;
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.RuleRegistry.RuleEvent;
+import io.cryostat.util.events.Event;
 
+import com.google.gson.Gson;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -61,13 +67,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.sys.FileSystem;
-import io.cryostat.platform.ServiceRef;
-import io.cryostat.rules.RuleRegistry.RuleEvent;
-import io.cryostat.util.events.Event;
 
 @ExtendWith(MockitoExtension.class)
 class RuleRegistryTest {
@@ -246,7 +245,10 @@ class RuleRegistryTest {
         registry.addRule(testRule);
 
         MatcherAssert.assertThat(
-                registry.getRules(new ServiceRef(URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"), "com.example.App")),
+                registry.getRules(
+                        new ServiceRef(
+                                URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"),
+                                "com.example.App")),
                 Matchers.equalTo(Set.of(testRule)));
     }
 
@@ -263,7 +265,10 @@ class RuleRegistryTest {
         registry.addRule(archiverRule);
 
         MatcherAssert.assertThat(
-                registry.getRules(new ServiceRef(URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"), "com.example.App")),
+                registry.getRules(
+                        new ServiceRef(
+                                URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"),
+                                "com.example.App")),
                 Matchers.equalTo(Set.of()));
     }
 

--- a/src/test/java/io/cryostat/rules/RuleRegistryTest.java
+++ b/src/test/java/io/cryostat/rules/RuleRegistryTest.java
@@ -40,6 +40,7 @@ package io.cryostat.rules;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
@@ -48,14 +49,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.sys.FileSystem;
-import io.cryostat.platform.ServiceRef;
-import io.cryostat.rules.RuleRegistry.RuleEvent;
-import io.cryostat.util.events.Event;
-
 import com.google.gson.Gson;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -66,6 +61,13 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.RuleRegistry.RuleEvent;
+import io.cryostat.util.events.Event;
 
 @ExtendWith(MockitoExtension.class)
 class RuleRegistryTest {
@@ -244,7 +246,7 @@ class RuleRegistryTest {
         registry.addRule(testRule);
 
         MatcherAssert.assertThat(
-                registry.getRules(new ServiceRef(null, "com.example.App")),
+                registry.getRules(new ServiceRef(URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"), "com.example.App")),
                 Matchers.equalTo(Set.of(testRule)));
     }
 
@@ -261,7 +263,7 @@ class RuleRegistryTest {
         registry.addRule(archiverRule);
 
         MatcherAssert.assertThat(
-                registry.getRules(new ServiceRef(null, "com.example.App")),
+                registry.getRules(new ServiceRef(URI.create("service:jmx:rmi:///jndi/rmi://app:9091/jmxrmi"), "com.example.App")),
                 Matchers.equalTo(Set.of()));
     }
 


### PR DESCRIPTION
Fixes #699

From various readings, it seems that the obj.metadata field is always present, but the labels and annotations properties may not always be (but "should"). Here I add guards within the ServiceRef methods to treat null labels/annotations as if they are empty Maps to avoid NPEs in cases where platform implementations may return nulls to us.

https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/
https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata