### PR TITLE
fix(rules): do not create cached connections for automated rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Cryostat can be configured via the following environment variables
 
 #### Configuration for JMX Cache
 
-* `CRYOSTAT_TARGET_CACHE_MAX_CONNECTIONS`: the maximum number of JMX connections to cache. Use `-1` for an unlimited amount
-* `CRYOSTAT_TARGET_CACHE_TTL`: the time to live in seconds for cached JMX connections
+* `CRYOSTAT_TARGET_CACHE_SIZE`: the maximum number of JMX connections to cache.
+Use `-1` for an unlimited cache size (TTL expiration only). Defaults to `-1`.
+* `CRYOSTAT_TARGET_CACHE_TTL`: the time to live (in seconds) for cached JMX
+connections. Defaults to `10`.
 
 #### Configuration for Logging
 

--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,8 @@
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/opt/cryostat.d/truststore.d</argument>
               <argument>--env</argument>
+              <argument>CRYOSTAT_TARGET_CACHE_TTL=60</argument>
+              <argument>--env</argument>
               <argument>CRYOSTAT_DISABLE_JMX_AUTH=true</argument>
               <argument>--env</argument>
               <argument>CRYOSTAT_DISABLE_SSL=true</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -396,10 +396,6 @@
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/opt/cryostat.d/truststore.d</argument>
               <argument>--env</argument>
-              <argument>CRYOSTAT_TARGET_CACHE_MAX_CONNECTIONS=1</argument>
-              <argument>--env</argument>
-              <argument>CRYOSTAT_TARGET_CACHE_TTL=5</argument>
-              <argument>--env</argument>
               <argument>CRYOSTAT_DISABLE_JMX_AUTH=true</argument>
               <argument>--env</argument>
               <argument>CRYOSTAT_DISABLE_SSL=true</argument>

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -55,6 +55,7 @@ import io.cryostat.core.tui.ClientWriter;
 import io.cryostat.net.reports.ReportsModule;
 import io.cryostat.net.security.SecurityModule;
 import io.cryostat.net.web.WebModule;
+import io.cryostat.platform.PlatformClient;
 
 import com.github.benmanes.caffeine.cache.Scheduler;
 import dagger.Binds;
@@ -115,11 +116,13 @@ public abstract class NetworkModule {
     @Singleton
     static TargetConnectionManager provideTargetConnectionManager(
             Lazy<JFRConnectionToolkit> connectionToolkit,
+            PlatformClient platformClient,
             @Named(TARGET_CACHE_TTL) Duration maxTargetTtl,
             @Named(TARGET_CACHE_SIZE) int maxTargetConnections,
             Logger logger) {
         return new TargetConnectionManager(
                 connectionToolkit,
+                platformClient,
                 ForkJoinPool.commonPool(),
                 Scheduler.systemScheduler(),
                 maxTargetTtl,

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -55,7 +55,6 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import dagger.Lazy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -89,42 +88,7 @@ public class TargetConnectionManager {
                         .executor(executor)
                         .scheduler(scheduler)
                         .expireAfterAccess(ttl)
-                        .removalListener(
-                                new RemovalListener<ConnectionDescriptor, JFRConnection>() {
-                                    @Override
-                                    public void onRemoval(
-                                            ConnectionDescriptor descriptor,
-                                            JFRConnection connection,
-                                            RemovalCause cause) {
-                                        if (descriptor == null) {
-                                            logger.warn(
-                                                    "Connection eviction triggered with null descriptor");
-                                            return;
-                                        }
-                                        if (connection == null) {
-                                            logger.warn(
-                                                    "Connection eviction triggered with null connection");
-                                            return;
-                                        }
-                                        JMXConnectionClosed evt =
-                                                new JMXConnectionClosed(descriptor.getTargetId());
-                                        logger.info(
-                                                "Removing cached connection for {}",
-                                                descriptor.getTargetId());
-                                        evt.begin();
-                                        try {
-                                            connection.close();
-                                        } catch (RuntimeException e) {
-                                            evt.setExceptionThrown(true);
-                                            throw e;
-                                        } finally {
-                                            evt.end();
-                                            if (evt.shouldCommit()) {
-                                                evt.commit();
-                                            }
-                                        }
-                                    }
-                                });
+                        .removalListener(this::closeConnection);
         if (maxTargetConnections >= 0) {
             cacheBuilder = cacheBuilder.maximumSize(maxTargetConnections);
         }
@@ -133,7 +97,40 @@ public class TargetConnectionManager {
 
     public <T> T executeConnectedTask(
             ConnectionDescriptor connectionDescriptor, ConnectedTask<T> task) throws Exception {
-        return task.execute(connections.get(connectionDescriptor));
+        return executeConnectedTask(connectionDescriptor, task, true);
+    }
+
+    /**
+     * Execute a {@link ConnectedTask}, optionally caching the connection for future re-use. If
+     * useCache is true then the connection will be retrieved from cache if available, or created
+     * and stored in the cache if not. This is subject to the cache maxSize and TTL policy. If
+     * useCache is false then a connection will be taken from cache if available, otherwise a new
+     * connection will be created externally from the cache. After the task has completed the
+     * connection will be closed only if the connection was not originally retrieved from the cache,
+     * otherwise the connection is left as-is to be subject to the cache's standard eviction policy.
+     * "Interactive" use cases should prefer to call this with useCache==true (or simply call {@link
+     * #executeConnectedTask(ConnectionDescriptor cd, ConnectedTask task)} instead). Automated use
+     * cases such as Automated Rules should call this with useCache==false.
+     */
+    public <T> T executeConnectedTask(
+            ConnectionDescriptor connectionDescriptor, ConnectedTask<T> task, boolean useCache)
+            throws Exception {
+        if (useCache) {
+            return task.execute(connections.get(connectionDescriptor));
+        } else {
+            JFRConnection connection = connections.getIfPresent(connectionDescriptor);
+            boolean cached = connection != null;
+            if (!cached) {
+                connection = connect(connectionDescriptor);
+            }
+            try {
+                return task.execute(connection);
+            } finally {
+                if (!cached) {
+                    connection.close();
+                }
+            }
+        }
     }
 
     /**
@@ -151,6 +148,29 @@ public class TargetConnectionManager {
      */
     public boolean markConnectionInUse(ConnectionDescriptor connectionDescriptor) {
         return connections.getIfPresent(connectionDescriptor) != null;
+    }
+
+    private void closeConnection(
+            ConnectionDescriptor descriptor, JFRConnection connection, RemovalCause cause) {
+        try {
+            JMXConnectionClosed evt =
+                    new JMXConnectionClosed(descriptor.getTargetId(), cause.name());
+            logger.info("Removing cached connection for {}: {}", descriptor.getTargetId(), cause);
+            evt.begin();
+            try {
+                connection.close();
+            } catch (RuntimeException e) {
+                evt.setExceptionThrown(true);
+                throw e;
+            } finally {
+                evt.end();
+                if (evt.shouldCommit()) {
+                    evt.commit();
+                }
+            }
+        } catch (Exception e) {
+            logger.error(e);
+        }
     }
 
     private JFRConnection connect(ConnectionDescriptor connectionDescriptor) throws Exception {
@@ -199,7 +219,11 @@ public class TargetConnectionManager {
                     .connect(
                             url,
                             credentials.orElse(null),
-                            Collections.singletonList(() -> this.connections.invalidate(cacheKey)));
+                            Collections.singletonList(
+                                    () -> {
+                                        logger.info("Connection for {} closed", url);
+                                        this.connections.invalidate(cacheKey);
+                                    }));
         } catch (Exception e) {
             evt.setExceptionThrown(true);
             throw e;
@@ -244,10 +268,12 @@ public class TargetConnectionManager {
     public static class JMXConnectionClosed extends Event {
         String serviceUri;
         boolean exceptionThrown;
+        String reason;
 
-        JMXConnectionClosed(String serviceUri) {
+        JMXConnectionClosed(String serviceUri, String reason) {
             this.serviceUri = serviceUri;
             this.exceptionThrown = false;
+            this.reason = reason;
         }
 
         void setExceptionThrown(boolean exceptionThrown) {

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -152,6 +152,14 @@ public class TargetConnectionManager {
 
     private void closeConnection(
             ConnectionDescriptor descriptor, JFRConnection connection, RemovalCause cause) {
+        if (descriptor == null) {
+            logger.error("Connection eviction triggered with null descriptor");
+            return;
+        }
+        if (connection == null) {
+            logger.error("Connection eviction triggered with null connection");
+            return;
+        }
         try {
             JMXConnectionClosed evt =
                     new JMXConnectionClosed(descriptor.getTargetId(), cause.name());

--- a/src/main/java/io/cryostat/net/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/net/TargetConnectionManager.java
@@ -211,7 +211,7 @@ public class TargetConnectionManager {
             ConnectionDescriptor cacheKey, JMXServiceURL url, Optional<Credentials> credentials)
             throws Exception {
         JMXConnectionOpened evt = new JMXConnectionOpened(url.toString());
-        logger.info("Creating connection for {}", url.toString());
+        logger.info("Creating connection for {}", url);
         evt.begin();
         try {
             return jfrConnectionToolkit

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -120,8 +120,7 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
 
             Exception rootCause = (Exception) ExceptionUtils.getRootCause(ee);
 
-            if (rootCause instanceof RecordingNotFoundException
-                    || targetRecordingNotFound(rootCause)) {
+            if (targetRecordingNotFound(rootCause)) {
                 throw new HttpStatusException(404, ee);
             }
             throw ee;
@@ -129,11 +128,22 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
     }
 
     private boolean targetRecordingNotFound(Exception rootCause) {
-        return rootCause instanceof SubprocessReportGenerator.ReportGenerationException
-                        && (((SubprocessReportGenerator.ReportGenerationException) rootCause)
-                                        .getStatus()
-                                == SubprocessReportGenerator.ExitStatus.TARGET_CONNECTION_FAILURE)
-                || (((SubprocessReportGenerator.ReportGenerationException) rootCause).getStatus()
-                        == SubprocessReportGenerator.ExitStatus.NO_SUCH_RECORDING);
+        if (rootCause instanceof RecordingNotFoundException) {
+            return true;
+        }
+        boolean isReportGenerationException =
+                rootCause instanceof SubprocessReportGenerator.ReportGenerationException;
+        if (!isReportGenerationException) {
+            return false;
+        }
+        SubprocessReportGenerator.ReportGenerationException generationException =
+                (SubprocessReportGenerator.ReportGenerationException) rootCause;
+        boolean isTargetConnectionFailure =
+                generationException.getStatus()
+                        == SubprocessReportGenerator.ExitStatus.TARGET_CONNECTION_FAILURE;
+        boolean isNoSuchRecording =
+                generationException.getStatus()
+                        == SubprocessReportGenerator.ExitStatus.NO_SUCH_RECORDING;
+        return isTargetConnectionFailure || isNoSuchRecording;
     }
 }

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -141,7 +141,8 @@ public class RecordingArchiveHelper {
                                     throw new RecordingNotFoundException(
                                             "active recordings", recordingName);
                                 }
-                            });
+                            },
+                            false);
             future.complete(saveName);
             notificationFactory
                     .createBuilder()

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -120,7 +120,8 @@ public class RecordingTargetHelper {
                             .build()
                             .send();
                     return desc;
-                });
+                },
+                false);
     }
 
     public IRecordingDescriptor startRecording(

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -232,19 +232,17 @@ public class RuleProcessor
         targetConnectionManager.executeConnectedTask(
                 connectionDescriptor,
                 connection -> {
-                    try (connection) {
-                        IRecordingDescriptor descriptor =
-                                connection.getService().getSnapshotRecording();
-                        try {
-                            recordingArchiveHelper
-                                    .saveRecording(connectionDescriptor, descriptor.getName())
-                                    .get();
-                        } finally {
-                            connection.getService().close(descriptor);
-                        }
-
-                        return null;
+                    IRecordingDescriptor descriptor =
+                            connection.getService().getSnapshotRecording();
+                    try {
+                        recordingArchiveHelper
+                                .saveRecording(connectionDescriptor, descriptor.getName())
+                                .get();
+                    } finally {
+                        connection.getService().close(descriptor);
                     }
+
+                    return null;
                 },
                 false);
     }
@@ -255,28 +253,26 @@ public class RuleProcessor
         targetConnectionManager.executeConnectedTask(
                 connectionDescriptor,
                 connection -> {
-                    try (connection) {
-                        RecordingOptionsBuilder builder =
-                                recordingOptionsBuilderFactory
-                                        .create(connection.getService())
-                                        .name(rule.getRecordingName());
-                        if (rule.getMaxAgeSeconds() > 0) {
-                            builder = builder.maxAge(rule.getMaxAgeSeconds()).toDisk(true);
-                        }
-                        if (rule.getMaxSizeBytes() > 0) {
-                            builder = builder.maxSize(rule.getMaxSizeBytes()).toDisk(true);
-                        }
-                        Pair<String, TemplateType> template =
-                                RecordingTargetHelper.parseEventSpecifierToTemplate(
-                                        rule.getEventSpecifier());
-                        recordingTargetHelper.startRecording(
-                                true,
-                                connectionDescriptor,
-                                builder.build(),
-                                template.getLeft(),
-                                template.getRight());
-                        return null;
+                    RecordingOptionsBuilder builder =
+                            recordingOptionsBuilderFactory
+                                    .create(connection.getService())
+                                    .name(rule.getRecordingName());
+                    if (rule.getMaxAgeSeconds() > 0) {
+                        builder = builder.maxAge(rule.getMaxAgeSeconds()).toDisk(true);
                     }
+                    if (rule.getMaxSizeBytes() > 0) {
+                        builder = builder.maxSize(rule.getMaxSizeBytes()).toDisk(true);
+                    }
+                    Pair<String, TemplateType> template =
+                            RecordingTargetHelper.parseEventSpecifierToTemplate(
+                                    rule.getEventSpecifier());
+                    recordingTargetHelper.startRecording(
+                            true,
+                            connectionDescriptor,
+                            builder.build(),
+                            template.getLeft(),
+                            template.getRight());
+                    return null;
                 },
                 false);
     }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -245,7 +245,8 @@ public class RuleProcessor
 
                         return null;
                     }
-                });
+                },
+                false);
     }
 
     private void startRuleRecording(ConnectionDescriptor connectionDescriptor, Rule rule)
@@ -276,6 +277,7 @@ public class RuleProcessor
                                 template.getRight());
                         return null;
                     }
-                });
+                },
+                false);
     }
 }

--- a/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
+++ b/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
@@ -47,6 +47,7 @@ import javax.management.remote.JMXServiceURL;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.net.JFRConnectionToolkit;
+import io.cryostat.platform.PlatformClient;
 
 import com.github.benmanes.caffeine.cache.Scheduler;
 import org.hamcrest.MatcherAssert;
@@ -67,6 +68,7 @@ class TargetConnectionManagerTest {
     TargetConnectionManager mgr;
     @Mock Logger logger;
     @Mock JFRConnectionToolkit jfrConnectionToolkit;
+    @Mock PlatformClient platformClient;
     Duration TTL = Duration.ofMillis(250);
 
     @BeforeEach
@@ -74,6 +76,7 @@ class TargetConnectionManagerTest {
         this.mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        platformClient,
                         ForkJoinPool.commonPool(),
                         Scheduler.systemScheduler(),
                         TTL,
@@ -191,6 +194,7 @@ class TargetConnectionManagerTest {
         TargetConnectionManager mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        platformClient,
                         ForkJoinPool.commonPool(),
                         Scheduler.systemScheduler(),
                         Duration.ofNanos(1),
@@ -231,6 +235,7 @@ class TargetConnectionManagerTest {
         TargetConnectionManager mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        platformClient,
                         new DirectExecutor(),
                         Scheduler.disabledScheduler(),
                         Duration.ofSeconds(1),
@@ -270,6 +275,7 @@ class TargetConnectionManagerTest {
         TargetConnectionManager mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        platformClient,
                         new DirectExecutor(),
                         Scheduler.disabledScheduler(),
                         Duration.ofNanos(1),

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -144,7 +144,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -178,7 +179,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -265,7 +267,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -337,7 +340,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -420,7 +424,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -498,7 +503,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override
@@ -631,7 +637,8 @@ class RecordingArchiveHelperTest {
         Mockito.when(
                         targetConnectionManager.executeConnectedTask(
                                 Mockito.any(),
-                                Mockito.any(TargetConnectionManager.ConnectedTask.class)))
+                                Mockito.any(TargetConnectionManager.ConnectedTask.class),
+                                Mockito.anyBoolean()))
                 .thenAnswer(
                         new Answer<>() {
                             @Override

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -150,7 +150,9 @@ class RuleProcessorTest {
         IConstrainedMap<String> recordingOptions = Mockito.mock(IConstrainedMap.class);
         Mockito.when(recordingOptionsBuilder.build()).thenReturn(recordingOptions);
 
-        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
                 .thenAnswer(
                         arg0 ->
                                 ((TargetConnectionManager.ConnectedTask<Object>)
@@ -239,7 +241,9 @@ class RuleProcessorTest {
 
     @Test
     void testSuccessfulArchiverRuleActivationWithCredentials() throws Exception {
-        Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
                 .thenAnswer(
                         arg0 ->
                                 ((TargetConnectionManager.ConnectedTask<Object>)

--- a/src/test/java/itest/ReportJwtDownloadIT.java
+++ b/src/test/java/itest/ReportJwtDownloadIT.java
@@ -61,7 +61,11 @@ public class ReportJwtDownloadIT extends JwtAssetsSelfTest {
         Path assetDownload = null;
         try {
             resource = createRecording();
-            String downloadUrl = getTokenDownloadUrl(new URL(resource.getString("reportUrl")));
+            String downloadUrl =
+                    getTokenDownloadUrl(
+                            new URL(
+                                    resource.getString("reportUrl")
+                                            .replace("/api/v1/", "/api/beta/")));
             Thread.sleep(10_000L);
             assetDownload =
                     downloadFileAbs(downloadUrl, TEST_RECORDING_NAME, ".html")


### PR DESCRIPTION
fix(rules): signal connections opened by rules may be immediately closed

Related to #756

fix(pom): remove itest connection cache size config

Remove connection cache size/TTL config, which used an incorrect/outdated
cache max size env var name, to better reflect a standard Cryostat
deployment using default cache settings (unlimited size, 10s TTL)

Fixes #762

fix(rules): do not create cached connections for automated rules

Related to #756

Automated rules processing will reuse existing cached connections if
available. If none are available then a new connection will be created and
NOT cached, in order to avoid automated rules causing evictions of cached
connections for other interactive clients