### PR TITLE
fix(pom): use latest jfr-datasource and grafana-dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <cryostat.rjmxPort>9091</cryostat.rjmxPort>
   <cryostat.webPort>8181</cryostat.webPort>
   <cryostat.itest.webPort>8181</cryostat.itest.webPort>
-  <cryostat.itest.webHost>localhost</cryostat.itest.webHost>
+  <cryostat.itest.webHost>0.0.0.0</cryostat.itest.webHost>
   <cryostat.itest.podName>cryostat-itests</cryostat.itest.podName>
   <cryostat.itest.containerName>cryostat-itest</cryostat.itest.containerName>
   <cryostat.itest.grafana.port>3000</cryostat.itest.grafana.port>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <cryostat.rjmxPort>9091</cryostat.rjmxPort>
   <cryostat.webPort>8181</cryostat.webPort>
   <cryostat.itest.webPort>8181</cryostat.itest.webPort>
-  <cryostat.itest.webHost>0.0.0.0</cryostat.itest.webHost>
+  <cryostat.itest.webHost>localhost</cryostat.itest.webHost>
   <cryostat.itest.podName>cryostat-itests</cryostat.itest.podName>
   <cryostat.itest.containerName>cryostat-itest</cryostat.itest.containerName>
   <cryostat.itest.grafana.port>3000</cryostat.itest.grafana.port>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
   <cryostat.itest.containerName>cryostat-itest</cryostat.itest.containerName>
   <cryostat.itest.grafana.port>3000</cryostat.itest.grafana.port>
   <cryostat.itest.grafana.imageStream>quay.io/cryostat/cryostat-grafana-dashboard</cryostat.itest.grafana.imageStream>
-  <cryostat.itest.grafana.version>1.0.0</cryostat.itest.grafana.version>
+  <cryostat.itest.grafana.version>latest</cryostat.itest.grafana.version>
   <cryostat.itest.jfr-datasource.port>8080</cryostat.itest.jfr-datasource.port>
   <cryostat.itest.jfr-datasource.imageStream>quay.io/cryostat/jfr-datasource</cryostat.itest.jfr-datasource.imageStream>
-  <cryostat.itest.jfr-datasource.version>1.0.0</cryostat.itest.jfr-datasource.version>
+  <cryostat.itest.jfr-datasource.version>latest</cryostat.itest.jfr-datasource.version>
 
   <io.reactiverse.plugin.version>1.0.25</io.reactiverse.plugin.version>
   <org.apache.maven.plugins.compiler.version>3.8.1</org.apache.maven.plugins.compiler.version>

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ fi
 echo -e "\n\nRunning $CRYOSTAT_IMAGE ...\n\n"
 
 if [ -z "$CRYOSTAT_RJMX_PORT" ]; then
-    CRYOSTAT_RJMX_PORT=9091
+    CRYOSTAT_RJMX_PORT="$(xpath -q -e 'project/properties/cryostat.rjmxPort/text()' pom.xml)"
 fi
 
 if [ -z "$CRYOSTAT_RMI_PORT" ]; then
@@ -24,11 +24,11 @@ if [ -z "$CRYOSTAT_RMI_PORT" ]; then
 fi
 
 if [ -z "$CRYOSTAT_WEB_HOST" ]; then
-    CRYOSTAT_WEB_HOST="0.0.0.0" # listens on all interfaces and hostnames for testing purposes
+    CRYOSTAT_WEB_HOST="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
 fi
 
 if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-    CRYOSTAT_WEB_PORT=8181
+    CRYOSTAT_WEB_PORT="$(xpath -q -e 'project/properties/cryostat.itest.webPort/text()' pom.xml)"
 fi
 
 if [ -z "$CRYOSTAT_EXT_WEB_PORT" ]; then


### PR DESCRIPTION
Fixes #772

This updates the `pom.xml` versions for jfr-datasource and cryostat-grafana-dashboard used in integration testing from `1.0.0` to `latest`. Once the backport PR is opened I will change these versions from `latest` in `main` to `2.0.0` in the `v2` backport release version. Later, when `2.1.0` release is approaching and we create the upstream branch for it, then that branch should also have `latest` replaced by `2.1.0` for these two itest container versions as well.

Additionally, this PR uses `xpath` in `run.sh` and `smoketest.sh` to read `pom.xml` to determine things like the JMX and HTTP API port numbers to use by default. This is just a cleanup so that the values aren't hardcoded in multiple places, which is what leads to some places lagging behind as was the problem with the itest container versions above.