### PR TITLE
feat(reports): sidecar container report generation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,10 +39,6 @@ if [ -z "$CRYOSTAT_AUTH_MANAGER" ]; then
     CRYOSTAT_AUTH_MANAGER="io.cryostat.net.NoopAuthManager"
 fi
 
-if [ -z "$CRYOSTAT_REPORT_GENERATOR" ]; then
-    CRYOSTAT_REPORT_GENERATOR="subprocess"
-fi
-
 if [ -z "$CRYOSTAT_REPORT_GENERATION_MAX_HEAP" ]; then
     CRYOSTAT_REPORT_GENERATION_MAX_HEAP="200"
 fi

--- a/run.sh
+++ b/run.sh
@@ -39,6 +39,10 @@ if [ -z "$CRYOSTAT_AUTH_MANAGER" ]; then
     CRYOSTAT_AUTH_MANAGER="io.cryostat.net.NoopAuthManager"
 fi
 
+if [ -z "$CRYOSTAT_REPORT_GENERATOR" ]; then
+    CRYOSTAT_REPORT_GENERATOR="subprocess"
+fi
+
 if [ -z "$CRYOSTAT_REPORT_GENERATION_MAX_HEAP" ]; then
     CRYOSTAT_REPORT_GENERATION_MAX_HEAP="200"
 fi
@@ -98,9 +102,11 @@ podman run \
     --mount type=bind,source="$(dirname $0)/templates",destination=/opt/cryostat.d/templates.d,relabel=shared \
     --mount type=bind,source="$(dirname $0)/truststore",destination=/truststore,relabel=shared \
     --mount type=tmpfs,target=/opt/cryostat.d/probes.d \
+    -e CRYOSTAT_REPORT_GENERATOR=$CRYOSTAT_REPORT_GENERATOR \
     -e CRYOSTAT_PLATFORM=$CRYOSTAT_PLATFORM \
     -e CRYOSTAT_DISABLE_SSL=$CRYOSTAT_DISABLE_SSL \
     -e CRYOSTAT_DISABLE_JMX_AUTH=$CRYOSTAT_DISABLE_JMX_AUTH \
+    -e CRYOSTAT_ALLOW_UNTRUSTED_SSL=$CRYOSTAT_ALLOW_UNTRUSTED_SSL \
     -e CRYOSTAT_RJMX_USER=$CRYOSTAT_RJMX_USER \
     -e CRYOSTAT_RJMX_PASS=$CRYOSTAT_RJMX_PASS \
     -e CRYOSTAT_RJMX_PORT=$CRYOSTAT_RJMX_PORT \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -79,13 +79,14 @@ function runGrafana() {
 }
 
 function runReportGenerator() {
+    local RJMX_PORT=10000
     podman run \
         --name reports \
         --pod cryostat \
         --cpus 1 \
         --memory 512M \
         --restart on-failure \
-        --env JAVA_OPTIONS="-XX:ActiveProcessorCount=1 -XX:+UseSerialGC -Dorg.openjdk.jmc.flightrecorder.parser.singlethreaded=true" \
+        --env JAVA_OPTIONS="-XX:ActiveProcessorCount=1 -XX:+UseSerialGC -Dorg.openjdk.jmc.flightrecorder.parser.singlethreaded=true -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.rmi.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false" \
         --env QUARKUS_HTTP_PORT=10001 \
         --rm -d quay.io/cryostat/cryostat-reports:latest
 }
@@ -112,6 +113,7 @@ function createPod() {
         --publish 8082:8082 \
         --publish 9990:9990 \
         --publish 9991:9991 \
+        --publish 10000:10000 \
         --publish 10001:10001
     # 8081: vertx-fib-demo
     # 9093: vertx-fib-demo-1 RJMX
@@ -121,8 +123,9 @@ function createPod() {
     # 9999: quarkus-test HTTP
     # 8082: Wildfly HTTP
     # 9990: Wildfly Admin Console
-    # 9990: Wildfly RJMX
-    # 10001: cryostat-reports
+    # 9991: Wildfly RJMX
+    # 10000: cryostat-reports RJMX
+    # 10001: cryostat-reports HTTP
 }
 
 function destroyPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -86,7 +86,7 @@ function runReportGenerator() {
         --memory 512M \
         --restart on-failure \
         --env QUARKUS_HTTP_PORT=10001 \
-        --rm -d quay.io/andrewazores/cryostat-reports:1.0.0-SNAPSHOT
+        --rm -d quay.io/cryostatio/cryostat-reports:1.0.0-SNAPSHOT
 }
 
 function createPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -85,8 +85,9 @@ function runReportGenerator() {
         --cpus 1 \
         --memory 512M \
         --restart on-failure \
+        --env JAVA_OPTIONS="-XX:ActiveProcessorCount=1 -XX:+UseSerialGC -Dorg.openjdk.jmc.flightrecorder.parser.singlethreaded=true" \
         --env QUARKUS_HTTP_PORT=10001 \
-        --rm -d quay.io/cryostat/cryostat-reports:1.0.0-SNAPSHOT
+        --rm -d quay.io/cryostat/cryostat-reports:latest
 }
 
 function createPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -87,6 +87,7 @@ function runReportGenerator() {
         --pod cryostat \
         --cpus 1 \
         --memory 512M \
+        --restart on-failure \
         --env QUARKUS_HTTP_PORT=10001 \
         --rm -d quay.io/andrewazores/cryostat-reports:1.0.0-SNAPSHOT
 }

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -85,6 +85,8 @@ function runReportGenerator() {
     podman run \
         --name reports \
         --pod cryostat \
+        --cpus 1 \
+        --memory 512M \
         --env QUARKUS_HTTP_PORT=10001 \
         --rm -d quay.io/andrewazores/cryostat-reports:1.0.0-SNAPSHOT
 }

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -16,7 +16,7 @@ function runCryostat() {
         CRYOSTAT_RJMX_USER=smoketest \
         CRYOSTAT_RJMX_PASS=smoketest \
         CRYOSTAT_ALLOW_UNTRUSTED_SSL=true \
-        CRYOSTAT_REPORT_GENERATOR=$CRYOSTAT_REPORT_GENERATOR \
+        CRYOSTAT_REPORT_GENERATOR="http://0.0.0.0:10001" \
         exec "$DIR/run.sh"
 }
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -86,7 +86,7 @@ function runReportGenerator() {
         --memory 512M \
         --restart on-failure \
         --env QUARKUS_HTTP_PORT=10001 \
-        --rm -d quay.io/cryostatio/cryostat-reports:1.0.0-SNAPSHOT
+        --rm -d quay.io/cryostat/cryostat-reports:1.0.0-SNAPSHOT
 }
 
 function createPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -4,6 +4,9 @@ set -x
 set -e
 
 function runCryostat() {
+    if [ -z "$CRYOSTAT_REPORT_GENERATOR" ]; then
+        CRYOSTAT_REPORT_GENERATOR=subprocess
+    fi
     local DIR="$(dirname "$(readlink -f "$0")")"
     local host="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
     local datasourcePort="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"
@@ -13,7 +16,7 @@ function runCryostat() {
         CRYOSTAT_RJMX_USER=smoketest \
         CRYOSTAT_RJMX_PASS=smoketest \
         CRYOSTAT_ALLOW_UNTRUSTED_SSL=true \
-        CRYOSTAT_REPORT_GENERATOR="http://0.0.0.0:10001" \
+        CRYOSTAT_REPORT_GENERATOR=$CRYOSTAT_REPORT_GENERATOR \
         exec "$DIR/run.sh"
 }
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -4,9 +4,6 @@ set -x
 set -e
 
 function runCryostat() {
-    if [ -z "$CRYOSTAT_REPORT_GENERATOR" ]; then
-        CRYOSTAT_REPORT_GENERATOR=subprocess
-    fi
     local DIR="$(dirname "$(readlink -f "$0")")"
     local host="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
     local datasourcePort="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -13,7 +13,7 @@ function runCryostat() {
         CRYOSTAT_RJMX_USER=smoketest \
         CRYOSTAT_RJMX_PASS=smoketest \
         CRYOSTAT_ALLOW_UNTRUSTED_SSL=true \
-        CRYOSTAT_REPORT_GENERATOR="http://0.0.0.0:10001" \
+        CRYOSTAT_REPORT_GENERATOR="http://${host}:10001" \
         exec "$DIR/run.sh"
 }
 

--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -46,6 +46,7 @@ import javax.inject.Singleton;
 import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.configuration.ConfigurationModule;
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.tui.ClientWriter;
@@ -144,7 +145,7 @@ public abstract class MainModule {
     @Singleton
     @Named(RECORDINGS_PATH)
     static Path provideSavedRecordingsPath(Logger logger, Environment env) {
-        String archivePath = env.getEnv("CRYOSTAT_ARCHIVE_PATH", "/flightrecordings");
+        String archivePath = env.getEnv(Variables.ARCHIVE_PATH, "/flightrecordings");
         logger.info("Local save path for flight recordings set as {}", archivePath);
         return Paths.get(archivePath);
     }

--- a/src/main/java/io/cryostat/configuration/ConfigurationModule.java
+++ b/src/main/java/io/cryostat/configuration/ConfigurationModule.java
@@ -67,7 +67,7 @@ public abstract class ConfigurationModule {
     @Singleton
     @Named(CONFIGURATION_PATH)
     static Path provideConfigurationPath(Logger logger, Environment env) {
-        String path = env.getEnv("CRYOSTAT_CONFIG_PATH", "/opt/cryostat.d/conf.d");
+        String path = env.getEnv(Variables.CONFIG_PATH, "/opt/cryostat.d/conf.d");
         logger.info(String.format("Local config path set as %s", path));
         return Paths.get(path);
     }

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.configuration;
+
+public final class Variables {
+    private Variables() {}
+
+    public static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
+    public static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
+    public static final String REPORT_GENERATOR_ENV = "CRYOSTAT_REPORT_GENERATOR";
+}

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -40,7 +40,39 @@ package io.cryostat.configuration;
 public final class Variables {
     private Variables() {}
 
+    // jfr-datasource, cryostat-grafana-dashboard
     public static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
     public static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
+
+    // report generation
     public static final String REPORT_GENERATOR_ENV = "CRYOSTAT_REPORT_GENERATOR";
+    public static final String SUBPROCESS_MAX_HEAP_ENV = "CRYOSTAT_REPORT_GENERATION_MAX_HEAP";
+
+    // SSL configuration
+    public static final String DISABLE_SSL = "CRYOSTAT_DISABLE_SSL";
+    public static final String KEYSTORE_PATH_ENV = "KEYSTORE_PATH";
+    public static final String KEYSTORE_PASS_ENV = "KEYSTORE_PASS";
+    public static final String KEY_PATH_ENV = "KEY_PATH";
+    public static final String CERT_PATH_ENV = "CERT_PATH";
+
+    // platform configuration
+    public static final String PLATFORM_STRATEGY_ENV_VAR = "CRYOSTAT_PLATFORM";
+    public static final String AUTH_MANAGER_ENV_VAR = "CRYOSTAT_AUTH_MANAGER";
+
+    // webserver configuration
+    public static final String WEBSERVER_HOST = "CRYOSTAT_WEB_HOST";
+    public static final String WEBSERVER_PORT = "CRYOSTAT_WEB_PORT";
+    public static final String WEBSERVER_PORT_EXT = "CRYOSTAT_EXT_WEB_PORT";
+    public static final String WEBSERVER_SSL_PROXIED = "CRYOSTAT_SSL_PROXIED";
+    public static final String WEBSERVER_ALLOW_UNTRUSTED_SSL = "CRYOSTAT_ALLOW_UNTRUSTED_SSL";
+    public static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
+    public static final String ENABLE_CORS_ENV = "CRYOSTAT_CORS_ORIGIN";
+
+    // JMX connections configuration
+    public static final String TARGET_CACHE_SIZE = "CRYOSTAT_TARGET_CACHE_SIZE";
+    public static final String TARGET_CACHE_TTL = "CRYOSTAT_TARGET_CACHE_TTL";
+
+    // paths configuration
+    public static final String ARCHIVE_PATH = "CRYOSTAT_ARCHIVE_PATH";
+    public static final String CONFIG_PATH = "CRYOSTAT_CONFIG_PATH";
 }

--- a/src/main/java/io/cryostat/messaging/MessagingModule.java
+++ b/src/main/java/io/cryostat/messaging/MessagingModule.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Clock;
 import io.cryostat.core.sys.Environment;
@@ -64,8 +65,6 @@ public abstract class MessagingModule {
     static final String WS_MAX_CONNECTIONS = "WS_MAX_CONNECTIONS";
     static final String LIMBO_PRUNER = "LIMBO_PRUNER";
     static final String KEEPALIVE_PINGER = "KEEPALIVE_PINGER";
-
-    static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
     static final int MIN_CONNECTIONS = 1;
     static final int MAX_CONNECTIONS = 64;
     static final int DEFAULT_MAX_CONNECTIONS = 2;
@@ -103,7 +102,7 @@ public abstract class MessagingModule {
             int maxConn =
                     Integer.parseInt(
                             env.getEnv(
-                                    MAX_CONNECTIONS_ENV_VAR,
+                                    Variables.MAX_CONNECTIONS_ENV_VAR,
                                     String.valueOf(DEFAULT_MAX_CONNECTIONS)));
             if (maxConn > MAX_CONNECTIONS) {
                 logger.info("Requested maximum WebSocket connections {} is too large.", maxConn);

--- a/src/main/java/io/cryostat/net/NetworkConfiguration.java
+++ b/src/main/java/io/cryostat/net/NetworkConfiguration.java
@@ -40,6 +40,7 @@ package io.cryostat.net;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 
 public class NetworkConfiguration {
@@ -53,7 +54,7 @@ public class NetworkConfiguration {
     }
 
     public String getWebServerHost() throws SocketException, UnknownHostException {
-        return env.getEnv("CRYOSTAT_WEB_HOST", resolver.getHostAddress());
+        return env.getEnv(Variables.WEBSERVER_HOST, resolver.getHostAddress());
     }
 
     public int getDefaultWebServerPort() {
@@ -62,19 +63,20 @@ public class NetworkConfiguration {
 
     public int getInternalWebServerPort() {
         return Integer.parseInt(
-                env.getEnv("CRYOSTAT_WEB_PORT", String.valueOf(getDefaultWebServerPort())));
+                env.getEnv(Variables.WEBSERVER_PORT, String.valueOf(getDefaultWebServerPort())));
     }
 
     public int getExternalWebServerPort() {
         return Integer.parseInt(
-                env.getEnv("CRYOSTAT_EXT_WEB_PORT", String.valueOf(getInternalWebServerPort())));
+                env.getEnv(
+                        Variables.WEBSERVER_PORT_EXT, String.valueOf(getInternalWebServerPort())));
     }
 
     public boolean isSslProxied() {
-        return env.hasEnv("CRYOSTAT_SSL_PROXIED");
+        return env.hasEnv(Variables.WEBSERVER_SSL_PROXIED);
     }
 
     public boolean isUntrustedSslAllowed() {
-        return env.hasEnv("CRYOSTAT_ALLOW_UNTRUSTED_SSL");
+        return env.hasEnv(Variables.WEBSERVER_ALLOW_UNTRUSTED_SSL);
     }
 }

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -47,6 +47,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.cryostat.configuration.ConfigurationModule;
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
@@ -77,9 +78,6 @@ import io.vertx.ext.web.client.WebClientOptions;
         })
 public abstract class NetworkModule {
 
-    static final String TARGET_CACHE_SIZE = "CRYOSTAT_TARGET_CACHE_SIZE";
-    static final String TARGET_CACHE_TTL = "CRYOSTAT_TARGET_CACHE_TTL";
-
     @Provides
     @Singleton
     static HttpServer provideHttpServer(
@@ -101,15 +99,15 @@ public abstract class NetworkModule {
     }
 
     @Provides
-    @Named(TARGET_CACHE_SIZE)
+    @Named(Variables.TARGET_CACHE_SIZE)
     static int provideMaxTargetConnections(Environment env) {
-        return Integer.parseInt(env.getEnv(TARGET_CACHE_SIZE, "-1"));
+        return Integer.parseInt(env.getEnv(Variables.TARGET_CACHE_SIZE, "-1"));
     }
 
     @Provides
-    @Named(TARGET_CACHE_TTL)
+    @Named(Variables.TARGET_CACHE_TTL)
     static Duration provideMaxTargetTTL(Environment env) {
-        return Duration.ofSeconds(Integer.parseInt(env.getEnv(TARGET_CACHE_TTL, "10")));
+        return Duration.ofSeconds(Integer.parseInt(env.getEnv(Variables.TARGET_CACHE_TTL, "10")));
     }
 
     @Provides
@@ -117,8 +115,8 @@ public abstract class NetworkModule {
     static TargetConnectionManager provideTargetConnectionManager(
             Lazy<JFRConnectionToolkit> connectionToolkit,
             PlatformClient platformClient,
-            @Named(TARGET_CACHE_TTL) Duration maxTargetTtl,
-            @Named(TARGET_CACHE_SIZE) int maxTargetConnections,
+            @Named(Variables.TARGET_CACHE_TTL) Duration maxTargetTtl,
+            @Named(Variables.TARGET_CACHE_SIZE) int maxTargetConnections,
             Logger logger) {
         return new TargetConnectionManager(
                 connectionToolkit,

--- a/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
+++ b/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.reports;
 
 import java.io.BufferedOutputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,8 +56,6 @@ import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.reports.SubprocessReportGenerator.ExitStatus;
-import io.cryostat.net.reports.SubprocessReportGenerator.ReportGenerationException;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -131,6 +130,6 @@ abstract class AbstractReportGeneratorService implements ReportGeneratorService 
                 return path;
             }
         }
-        throw new ReportGenerationException(ExitStatus.NO_SUCH_RECORDING);
+        throw new FileNotFoundException(recordingName);
     }
 }

--- a/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
+++ b/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
@@ -38,7 +38,6 @@
 package io.cryostat.net.reports;
 
 import java.io.BufferedOutputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +55,7 @@ import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.recordings.RecordingNotFoundException;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -130,6 +130,6 @@ abstract class AbstractReportGeneratorService implements ReportGeneratorService 
                 return path;
             }
         }
-        throw new FileNotFoundException(recordingName);
+        throw new RecordingNotFoundException(cd.getTargetId(), recordingName);
     }
 }

--- a/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
+++ b/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.reports;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Provider;
+
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.reports.SubprocessReportGenerator.ExitStatus;
+import io.cryostat.net.reports.SubprocessReportGenerator.ReportGenerationException;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+abstract class AbstractReportGeneratorService implements ReportGeneratorService {
+
+    static final int READ_BUFFER_SIZE = 64 * 1024; // 64 KB
+
+    protected final TargetConnectionManager targetConnectionManager;
+    protected final FileSystem fs;
+    // FIXME extract TempFileProvider to FileSystem
+    protected final Provider<Path> tempFileProvider;
+    protected final Logger logger;
+
+    protected AbstractReportGeneratorService(
+            TargetConnectionManager targetConnectionManager,
+            FileSystem fs,
+            Provider<Path> tempFileProvider,
+            Logger logger) {
+        this.targetConnectionManager = targetConnectionManager;
+        this.fs = fs;
+        this.tempFileProvider = tempFileProvider;
+        this.logger = logger;
+    }
+
+    @Override
+    public final CompletableFuture<Path> exec(RecordingDescriptor recordingDescriptor)
+            throws Exception {
+        Path recording =
+                getRecordingFromLiveTarget(
+                        recordingDescriptor.recordingName,
+                        recordingDescriptor.connectionDescriptor);
+        Path saveFile = tempFileProvider.get();
+        CompletableFuture<Path> cf = exec(recording, saveFile);
+        return cf.whenComplete(
+                (p, t) -> {
+                    try {
+                        fs.deleteIfExists(recording);
+                    } catch (IOException e) {
+                        logger.warn(e);
+                    }
+                });
+    }
+
+    Path getRecordingFromLiveTarget(String recordingName, ConnectionDescriptor cd)
+            throws Exception {
+        return this.targetConnectionManager.executeConnectedTask(
+                cd, conn -> copyRecordingToFile(conn, cd, recordingName, tempFileProvider.get()));
+    }
+
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+    Path copyRecordingToFile(
+            JFRConnection conn, ConnectionDescriptor cd, String recordingName, Path path)
+            throws Exception {
+        for (IRecordingDescriptor rec : conn.getService().getAvailableRecordings()) {
+            if (!Objects.equals(rec.getName(), recordingName)) {
+                continue;
+            }
+            try (conn;
+                    InputStream in = conn.getService().openStream(rec, false);
+                    OutputStream out =
+                            new BufferedOutputStream(new FileOutputStream(path.toFile()))) {
+                byte[] buff = new byte[READ_BUFFER_SIZE];
+                int n = 0;
+                while ((n = in.read(buff)) != -1) {
+                    out.write(buff, 0, n);
+                    if (!targetConnectionManager.markConnectionInUse(cd)) {
+                        throw new IOException(
+                                "Target connection unexpectedly closed while streaming recording");
+                    }
+                }
+                out.flush();
+                return path;
+            }
+        }
+        throw new ReportGenerationException(ExitStatus.NO_SUCH_RECORDING);
+    }
+}

--- a/src/main/java/io/cryostat/net/reports/ActiveRecordingReportCache.java
+++ b/src/main/java/io/cryostat/net/reports/ActiveRecordingReportCache.java
@@ -114,14 +114,17 @@ class ActiveRecordingReportCache {
             try {
                 saveFile = reportGeneratorServiceProvider.get().exec(recordingDescriptor).get();
                 return fs.readString(saveFile);
-            } catch (ExecutionException | CompletionException ee) {
-                logger.error(ee);
+            } catch (ExecutionException | CompletionException e) {
+                logger.error(e);
 
                 delete(recordingDescriptor.connectionDescriptor, recordingDescriptor.recordingName);
 
-                if (ee.getCause() instanceof SubprocessReportGenerator.ReportGenerationException) {
-                    SubprocessReportGenerator.ReportGenerationException generationException =
-                            (SubprocessReportGenerator.ReportGenerationException) ee.getCause();
+                if (e.getCause()
+                        instanceof SubprocessReportGenerator.SubprocessReportGenerationException) {
+                    SubprocessReportGenerator.SubprocessReportGenerationException
+                            generationException =
+                                    (SubprocessReportGenerator.SubprocessReportGenerationException)
+                                            e.getCause();
 
                     SubprocessReportGenerator.ExitStatus status = generationException.getStatus();
                     if (status == SubprocessReportGenerator.ExitStatus.OUT_OF_MEMORY) {
@@ -143,7 +146,7 @@ class ActiveRecordingReportCache {
                                 });
                     }
                 }
-                throw ee;
+                throw e;
             }
         } finally {
             if (saveFile != null) {

--- a/src/main/java/io/cryostat/net/reports/ArchivedRecordingReportCache.java
+++ b/src/main/java/io/cryostat/net/reports/ArchivedRecordingReportCache.java
@@ -53,19 +53,19 @@ import io.cryostat.recordings.RecordingArchiveHelper;
 class ArchivedRecordingReportCache {
 
     protected final FileSystem fs;
-    protected final Provider<SubprocessReportGenerator> subprocessReportGeneratorProvider;
+    protected final Provider<ReportGeneratorService> reportGeneratorServiceProvider;
     protected final ReentrantLock generationLock;
     protected final Logger logger;
     protected final RecordingArchiveHelper recordingArchiveHelper;
 
     ArchivedRecordingReportCache(
             FileSystem fs,
-            Provider<SubprocessReportGenerator> subprocessReportGeneratorProvider,
+            Provider<ReportGeneratorService> reportGeneratorServiceProvider,
             @Named(ReportsModule.REPORT_GENERATION_LOCK) ReentrantLock generationLock,
             Logger logger,
             RecordingArchiveHelper recordingArchiveHelper) {
         this.fs = fs;
-        this.subprocessReportGeneratorProvider = subprocessReportGeneratorProvider;
+        this.reportGeneratorServiceProvider = reportGeneratorServiceProvider;
         this.generationLock = generationLock;
         this.logger = logger;
         this.recordingArchiveHelper = recordingArchiveHelper;
@@ -90,7 +90,7 @@ class ArchivedRecordingReportCache {
 
             Path archivedRecording = recordingArchiveHelper.getRecordingPath(recordingName).get();
             Path saveFile =
-                    subprocessReportGeneratorProvider.get().exec(archivedRecording, dest).get();
+                    reportGeneratorServiceProvider.get().exec(archivedRecording, dest).get();
             f.complete(saveFile);
         } catch (Exception e) {
             logger.error(e);

--- a/src/main/java/io/cryostat/net/reports/RecordingDescriptor.java
+++ b/src/main/java/io/cryostat/net/reports/RecordingDescriptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.reports;
+
+import java.util.Objects;
+
+import io.cryostat.net.ConnectionDescriptor;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+class RecordingDescriptor {
+    final ConnectionDescriptor connectionDescriptor;
+    final String recordingName;
+
+    RecordingDescriptor(ConnectionDescriptor connectionDescriptor, String recordingName) {
+        this.connectionDescriptor = Objects.requireNonNull(connectionDescriptor);
+        this.recordingName = Objects.requireNonNull(recordingName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof RecordingDescriptor)) {
+            return false;
+        }
+        RecordingDescriptor rd = (RecordingDescriptor) other;
+        return new EqualsBuilder()
+                .append(connectionDescriptor, rd.connectionDescriptor)
+                .append(recordingName, rd.recordingName)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(connectionDescriptor).append(recordingName).hashCode();
+    }
+}

--- a/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
@@ -50,6 +50,7 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.multipart.MultipartForm;
@@ -75,6 +76,7 @@ class RemoteReportGenerator extends AbstractReportGeneratorService {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public CompletableFuture<Path> exec(Path recording, Path destination) {
         String reportGenerator = env.getEnv("CRYOSTAT_REPORT_GENERATOR");
         logger.info("POSTing {} to {}", recording, reportGenerator);

--- a/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Provider;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -78,7 +79,7 @@ class RemoteReportGenerator extends AbstractReportGeneratorService {
     @Override
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public CompletableFuture<Path> exec(Path recording, Path destination) {
-        String reportGenerator = env.getEnv("CRYOSTAT_REPORT_GENERATOR");
+        String reportGenerator = env.getEnv(Variables.REPORT_GENERATOR_ENV);
         logger.info("POSTing {} to {}", recording, reportGenerator);
         var form =
                 MultipartForm.create()

--- a/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.reports;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Provider;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.Environment;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.web.http.HttpMimeType;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.multipart.MultipartForm;
+
+class RemoteReportGenerator extends AbstractReportGeneratorService {
+
+    private final Vertx vertx;
+    private final WebClient http;
+    private final Environment env;
+
+    RemoteReportGenerator(
+            TargetConnectionManager targetConnectionManager,
+            FileSystem fs,
+            Provider<Path> tempFileProvider,
+            Vertx vertx,
+            WebClient http,
+            Environment env,
+            Logger logger) {
+        super(targetConnectionManager, fs, tempFileProvider, logger);
+        this.vertx = vertx;
+        this.http = http;
+        this.env = env;
+    }
+
+    @Override
+    public CompletableFuture<Path> exec(Path recording, Path destination) {
+        String reportGenerator = env.getEnv("CRYOSTAT_REPORT_GENERATOR");
+        logger.info("POSTing {} to {}", recording, reportGenerator);
+        var form =
+                MultipartForm.create()
+                        .binaryFileUpload(
+                                "file",
+                                recording.getFileName().toString(),
+                                recording.toAbsolutePath().toString(),
+                                HttpMimeType.OCTET_STREAM.mime());
+        var f = new CompletableFuture<Path>();
+        this.http
+                .postAbs(String.format("%s/report", reportGenerator))
+                .timeout(30_000L)
+                .sendMultipartForm(
+                        form,
+                        ar -> {
+                            if (ar.failed()) {
+                                f.completeExceptionally(ar.cause());
+                                return;
+                            }
+                            var body = ar.result().bodyAsBuffer();
+                            vertx.fileSystem()
+                                    .writeFile(
+                                            destination.toString(),
+                                            body,
+                                            ar2 -> {
+                                                if (ar2.failed()) {
+                                                    f.completeExceptionally(ar.cause());
+                                                    return;
+                                                }
+                                                f.complete(destination);
+                                                logger.info(
+                                                        "Report response for {} success",
+                                                        recording);
+                                            });
+                        });
+        return f;
+    }
+}

--- a/src/main/java/io/cryostat/net/reports/ReportGenerationException.java
+++ b/src/main/java/io/cryostat/net/reports/ReportGenerationException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.reports;
+
+public class ReportGenerationException extends Exception {
+
+    public ReportGenerationException(String message) {
+        super(message);
+    }
+
+    public ReportGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/cryostat/net/reports/ReportGeneratorService.java
+++ b/src/main/java/io/cryostat/net/reports/ReportGeneratorService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.reports;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+interface ReportGeneratorService {
+    CompletableFuture<Path> exec(Path in, Path out) throws Exception;
+
+    CompletableFuture<Path> exec(RecordingDescriptor rd) throws Exception;
+}

--- a/src/main/java/io/cryostat/net/reports/ReportsModule.java
+++ b/src/main/java/io/cryostat/net/reports/ReportsModule.java
@@ -41,9 +41,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
 
-import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -66,30 +64,15 @@ import io.vertx.ext.web.client.WebClient;
         })
 public abstract class ReportsModule {
 
-    static final String REPORT_GENERATION_LOCK = "REPORT_GENERATION_LOCK";
-
-    @Provides
-    @Singleton
-    @Named(REPORT_GENERATION_LOCK)
-    /** Used to ensure that only one report is generated at a time */
-    static ReentrantLock provideReportGenerationLock() {
-        return new ReentrantLock(true);
-    }
-
     @Provides
     @Singleton
     static ActiveRecordingReportCache provideActiveRecordingReportCache(
             Provider<ReportGeneratorService> reportGeneratorServiceProvider,
             FileSystem fs,
-            @Named(REPORT_GENERATION_LOCK) ReentrantLock generationLock,
             TargetConnectionManager targetConnectionManager,
             Logger logger) {
         return new ActiveRecordingReportCache(
-                reportGeneratorServiceProvider,
-                fs,
-                generationLock,
-                targetConnectionManager,
-                logger);
+                reportGeneratorServiceProvider, fs, targetConnectionManager, logger);
     }
 
     @Provides
@@ -97,11 +80,10 @@ public abstract class ReportsModule {
     static ArchivedRecordingReportCache provideArchivedRecordingReportCache(
             FileSystem fs,
             Provider<ReportGeneratorService> reportGeneratorServiceProvider,
-            @Named(REPORT_GENERATION_LOCK) ReentrantLock generationLock,
             Logger logger,
             RecordingArchiveHelper recordingArchiveHelper) {
         return new ArchivedRecordingReportCache(
-                fs, reportGeneratorServiceProvider, generationLock, logger, recordingArchiveHelper);
+                fs, reportGeneratorServiceProvider, logger, recordingArchiveHelper);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/reports/ReportsModule.java
+++ b/src/main/java/io/cryostat/net/reports/ReportsModule.java
@@ -96,10 +96,10 @@ public abstract class ReportsModule {
             Environment env,
             RemoteReportGenerator remoteGenerator,
             SubprocessReportGenerator subprocessGenerator) {
-        if (env.getEnv("CRYOSTAT_REPORT_GENERATOR", "subprocess").equals("subprocess")) {
-            return subprocessGenerator;
+        if (env.hasEnv("CRYOSTAT_REPORT_GENERATOR")) {
+            return remoteGenerator;
         }
-        return remoteGenerator;
+        return subprocessGenerator;
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/reports/ReportsModule.java
+++ b/src/main/java/io/cryostat/net/reports/ReportsModule.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.reports.ReportTransformer;
 import io.cryostat.core.sys.Environment;
@@ -96,7 +97,7 @@ public abstract class ReportsModule {
             Environment env,
             RemoteReportGenerator remoteGenerator,
             SubprocessReportGenerator subprocessGenerator) {
-        if (env.hasEnv("CRYOSTAT_REPORT_GENERATOR")) {
+        if (env.hasEnv(Variables.REPORT_GENERATOR_ENV)) {
             return remoteGenerator;
         }
         return subprocessGenerator;

--- a/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
@@ -136,12 +136,12 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
                                 throw new RecordingNotFoundException(
                                         "archives", recording.toString());
                             default:
-                                throw new ReportGenerationException(status);
+                                throw new SubprocessReportGenerationException(status);
                         }
                     } catch (InterruptedException e) {
                         logger.error(e);
                         throw new CompletionException(
-                                new ReportGenerationException(ExitStatus.TERMINATED));
+                                new SubprocessReportGenerationException(ExitStatus.TERMINATED));
                     } catch (IOException
                             | ReportGenerationException
                             | RecordingNotFoundException
@@ -279,13 +279,13 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
             throws Exception {
         var fs = new FileSystem();
         if (!fs.isRegularFile(recording)) {
-            throw new ReportGenerationException(ExitStatus.NO_SUCH_RECORDING);
+            throw new SubprocessReportGenerationException(ExitStatus.NO_SUCH_RECORDING);
         }
         try (InputStream stream = fs.newInputStream(recording)) {
             return new ReportGenerator(Logger.INSTANCE, transformers).generateReport(stream);
         } catch (IOException ioe) {
             ioe.printStackTrace();
-            throw new ReportGenerationException(ExitStatus.IO_EXCEPTION);
+            throw new SubprocessReportGenerationException(ExitStatus.IO_EXCEPTION);
         }
     }
 
@@ -319,10 +319,10 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
         }
     }
 
-    public static class ReportGenerationException extends Exception {
+    public static class SubprocessReportGenerationException extends ReportGenerationException {
         private final ExitStatus status;
 
-        public ReportGenerationException(ExitStatus status) {
+        public SubprocessReportGenerationException(ExitStatus status) {
             super(String.format("[%d] %s", status.code, status.message));
             this.status = status;
         }

--- a/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
@@ -111,9 +111,6 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
                 javaProcessBuilderProvider
                         .get()
                         .klazz(SubprocessReportGenerator.class)
-                        // FIXME the heap size should be determined by some heuristics if not
-                        // defined in env.
-                        // See https://github.com/cryostatio/cryostat/issues/287
                         .jvmArgs(
                                 createJvmArgs(
                                         Integer.parseInt(

--- a/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
@@ -58,6 +58,7 @@ import javax.inject.Provider;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.CryostatCore;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.reports.ReportGenerator;
@@ -69,8 +70,6 @@ import io.cryostat.recordings.RecordingNotFoundException;
 import io.cryostat.util.JavaProcess;
 
 public class SubprocessReportGenerator extends AbstractReportGeneratorService {
-
-    static final String SUBPROCESS_MAX_HEAP_ENV = "CRYOSTAT_REPORT_GENERATION_MAX_HEAP";
 
     private final Environment env;
     private final Set<ReportTransformer> reportTransformers;
@@ -117,7 +116,9 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
                         // See https://github.com/cryostatio/cryostat/issues/287
                         .jvmArgs(
                                 createJvmArgs(
-                                        Integer.parseInt(env.getEnv(SUBPROCESS_MAX_HEAP_ENV, "0"))))
+                                        Integer.parseInt(
+                                                env.getEnv(
+                                                        Variables.SUBPROCESS_MAX_HEAP_ENV, "0"))))
                         .processArgs(createProcessArgs(recording, saveFile));
         return CompletableFuture.supplyAsync(
                 () -> {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetHandler.java
@@ -114,7 +114,7 @@ class ReportGetHandler extends AbstractJwtConsumingHandler {
 
     @Override
     public boolean isOrdered() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandler.java
@@ -134,17 +134,18 @@ class TargetReportGetHandler extends AbstractJwtConsumingHandler {
         }
     }
 
+    // TODO this needs to also handle the case where sidecar report generator container responds 404
     private boolean targetRecordingNotFound(Exception rootCause) {
         if (rootCause instanceof RecordingNotFoundException) {
             return true;
         }
         boolean isReportGenerationException =
-                rootCause instanceof SubprocessReportGenerator.ReportGenerationException;
+                rootCause instanceof SubprocessReportGenerator.SubprocessReportGenerationException;
         if (!isReportGenerationException) {
             return false;
         }
-        SubprocessReportGenerator.ReportGenerationException generationException =
-                (SubprocessReportGenerator.ReportGenerationException) rootCause;
+        SubprocessReportGenerator.SubprocessReportGenerationException generationException =
+                (SubprocessReportGenerator.SubprocessReportGenerationException) rootCause;
         boolean isTargetConnectionFailure =
                 generationException.getStatus()
                         == SubprocessReportGenerator.ExitStatus.TARGET_CONNECTION_FAILURE;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandler.java
@@ -41,12 +41,15 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
+import io.cryostat.net.reports.ReportsModule;
 import io.cryostat.net.reports.SubprocessReportGenerator;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.security.jwt.AssetJwtHelper;
@@ -66,6 +69,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 class TargetReportGetHandler extends AbstractJwtConsumingHandler {
 
     protected final ReportService reportService;
+    protected final long reportGenerationTimeoutSeconds;
 
     @Inject
     TargetReportGetHandler(
@@ -73,9 +77,12 @@ class TargetReportGetHandler extends AbstractJwtConsumingHandler {
             AssetJwtHelper jwtFactory,
             Lazy<WebServer> webServer,
             ReportService reportService,
+            @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
+                    long reportGenerationTimeoutSeconds,
             Logger logger) {
         super(auth, jwtFactory, webServer, logger);
         this.reportService = reportService;
+        this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
     }
 
     @Override
@@ -122,7 +129,7 @@ class TargetReportGetHandler extends AbstractJwtConsumingHandler {
                     .end(
                             reportService
                                     .get(getConnectionDescriptorFromJwt(ctx, jwt), recordingName)
-                                    .get());
+                                    .get(reportGenerationTimeoutSeconds, TimeUnit.SECONDS));
         } catch (CompletionException | ExecutionException ee) {
 
             Exception rootCause = (Exception) ExceptionUtils.getRootCause(ee);

--- a/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -55,8 +56,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class GrafanaDashboardUrlGetHandler implements RequestHandler {
-
-    static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
 
     private final Environment env;
     private final Gson gson;
@@ -96,11 +95,15 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
 
     @Override
     public void handle(RoutingContext ctx) {
-        if (!this.env.hasEnv(GRAFANA_DASHBOARD_ENV)) {
+        if (!this.env.hasEnv(Variables.GRAFANA_DASHBOARD_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");
         }
         ctx.response()
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
-                .end(gson.toJson(Map.of("grafanaDashboardUrl", env.getEnv(GRAFANA_DASHBOARD_ENV))));
+                .end(
+                        gson.toJson(
+                                Map.of(
+                                        "grafanaDashboardUrl",
+                                        env.getEnv(Variables.GRAFANA_DASHBOARD_ENV))));
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -55,8 +56,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class GrafanaDatasourceUrlGetHandler implements RequestHandler {
-
-    static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
 
     private final Environment env;
     private final Gson gson;
@@ -96,7 +95,7 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
 
     @Override
     public void handle(RoutingContext ctx) {
-        if (!this.env.hasEnv(GRAFANA_DATASOURCE_ENV)) {
+        if (!this.env.hasEnv(Variables.GRAFANA_DATASOURCE_ENV)) {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");
         }
         ctx.response()
@@ -105,6 +104,6 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
                         gson.toJson(
                                 Map.of(
                                         "grafanaDatasourceUrl",
-                                        env.getEnv(GRAFANA_DATASOURCE_ENV))));
+                                        env.getEnv(Variables.GRAFANA_DATASOURCE_ENV))));
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -70,7 +71,6 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
 
     private final Environment env;
     private final WebClient webClient;
-    private static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
@@ -114,7 +114,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         String recordingName = ctx.pathParam("recordingName");
         try {
-            URL uploadUrl = new URL(env.getEnv(GRAFANA_DATASOURCE_ENV));
+            URL uploadUrl = new URL(env.getEnv(Variables.GRAFANA_DATASOURCE_ENV));
             boolean isValidUploadUrl =
                     new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS).isValid(uploadUrl.toString());
             if (!isValidUploadUrl) {
@@ -122,7 +122,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
                         501,
                         String.format(
                                 "$%s=%s is an invalid datasource URL",
-                                GRAFANA_DATASOURCE_ENV, uploadUrl.toString()));
+                                Variables.GRAFANA_DATASOURCE_ENV, uploadUrl.toString()));
             }
             ResponseMessage response = doPost(recordingName, uploadUrl);
             if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode)

--- a/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
@@ -110,7 +110,7 @@ class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
 
     @Override
     public boolean isOrdered() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -78,7 +79,6 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
     private final TargetConnectionManager targetConnectionManager;
     private final WebClient webClient;
     private final FileSystem fs;
-    private static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
 
     @Inject
     TargetRecordingUploadPostHandler(
@@ -122,7 +122,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
     @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         try {
-            URL uploadUrl = new URL(env.getEnv(GRAFANA_DATASOURCE_ENV));
+            URL uploadUrl = new URL(env.getEnv(Variables.GRAFANA_DATASOURCE_ENV));
             boolean isValidUploadUrl =
                     new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS).isValid(uploadUrl.toString());
             if (!isValidUploadUrl) {
@@ -130,7 +130,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
                         501,
                         String.format(
                                 "$%s=%s is an invalid datasource URL",
-                                GRAFANA_DATASOURCE_ENV, uploadUrl.toString()));
+                                Variables.GRAFANA_DATASOURCE_ENV, uploadUrl.toString()));
             }
             ResponseMessage response = doPost(ctx, uploadUrl);
             if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode)

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -44,8 +44,6 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -55,10 +53,12 @@ import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
+
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -44,6 +44,8 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -53,12 +55,10 @@ import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
-
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -127,17 +127,18 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
         }
     }
 
+    // TODO this needs to also handle the case where sidecar report generator container responds 404
     private boolean targetRecordingNotFound(Exception rootCause) {
         if (rootCause instanceof RecordingNotFoundException) {
             return true;
         }
         boolean isReportGenerationException =
-                rootCause instanceof SubprocessReportGenerator.ReportGenerationException;
+                rootCause instanceof SubprocessReportGenerator.SubprocessReportGenerationException;
         if (!isReportGenerationException) {
             return false;
         }
-        SubprocessReportGenerator.ReportGenerationException generationException =
-                (SubprocessReportGenerator.ReportGenerationException) rootCause;
+        SubprocessReportGenerator.SubprocessReportGenerationException generationException =
+                (SubprocessReportGenerator.SubprocessReportGenerationException) rootCause;
         boolean isTargetConnectionFailure =
                 generationException.getStatus()
                         == SubprocessReportGenerator.ExitStatus.TARGET_CONNECTION_FAILURE;

--- a/src/main/java/io/cryostat/net/web/http/generic/CorsEnablingHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/CorsEnablingHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
@@ -54,7 +55,6 @@ import io.vertx.ext.web.handler.CorsHandler;
 
 class CorsEnablingHandler implements RequestHandler {
     protected static final String DEV_ORIGIN = "http://localhost:9000";
-    protected static final String ENABLE_CORS_ENV = "CRYOSTAT_CORS_ORIGIN";
     protected final CorsHandler corsHandler;
     protected final Environment env;
 
@@ -88,7 +88,7 @@ class CorsEnablingHandler implements RequestHandler {
 
     @Override
     public boolean isAvailable() {
-        return this.env.hasEnv(ENABLE_CORS_ENV);
+        return this.env.hasEnv(Variables.ENABLE_CORS_ENV);
     }
 
     @Override
@@ -112,6 +112,6 @@ class CorsEnablingHandler implements RequestHandler {
     }
 
     String getOrigin() {
-        return this.env.getEnv(ENABLE_CORS_ENV, DEV_ORIGIN);
+        return this.env.getEnv(Variables.ENABLE_CORS_ENV, DEV_ORIGIN);
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
@@ -46,15 +46,17 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
 import io.cryostat.ApplicationVersion;
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.ApiVersion;
-
-import com.google.gson.Gson;
+import io.cryostat.util.HttpStatusCodeIdentifier;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -63,9 +65,6 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 
 class HealthGetHandler implements RequestHandler {
-
-    static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
-    static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
 
     private final ApplicationVersion appVersion;
     private final WebClient webClient;
@@ -116,9 +115,15 @@ class HealthGetHandler implements RequestHandler {
     public void handle(RoutingContext ctx) {
         CompletableFuture<Boolean> datasourceAvailable = new CompletableFuture<>();
         CompletableFuture<Boolean> dashboardAvailable = new CompletableFuture<>();
+        CompletableFuture<Boolean> reportsAvailable = new CompletableFuture<>();
 
-        checkUri(GRAFANA_DATASOURCE_ENV, "/", datasourceAvailable);
-        checkUri(GRAFANA_DASHBOARD_ENV, "/api/health", dashboardAvailable);
+        checkUri(Variables.GRAFANA_DATASOURCE_ENV, "/", datasourceAvailable);
+        checkUri(Variables.GRAFANA_DASHBOARD_ENV, "/api/health", dashboardAvailable);
+        if (this.env.getEnv(Variables.REPORT_GENERATOR_ENV, "subprocess").equals("subprocess")) {
+            reportsAvailable.complete(true);
+        } else {
+            checkUri(Variables.REPORT_GENERATOR_ENV, "/health", reportsAvailable);
+        }
 
         ctx.response()
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
@@ -130,7 +135,9 @@ class HealthGetHandler implements RequestHandler {
                                         "dashboardAvailable",
                                         dashboardAvailable.join(),
                                         "datasourceAvailable",
-                                        datasourceAvailable.join())));
+                                        datasourceAvailable.join(),
+                                        "reportsAvailable",
+                                        reportsAvailable.join())));
     }
 
     private void checkUri(String envName, String path, CompletableFuture<Boolean> future) {
@@ -157,7 +164,9 @@ class HealthGetHandler implements RequestHandler {
                                     future.complete(false);
                                     return;
                                 }
-                                future.complete(handler.result().statusCode() == 200);
+                                future.complete(
+                                        HttpStatusCodeIdentifier.isSuccessCode(
+                                                handler.result().statusCode()));
                             });
         } else {
             future.complete(false);

--- a/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
@@ -119,7 +119,8 @@ class HealthGetHandler implements RequestHandler {
 
         checkUri(Variables.GRAFANA_DATASOURCE_ENV, "/", datasourceAvailable);
         checkUri(Variables.GRAFANA_DASHBOARD_ENV, "/api/health", dashboardAvailable);
-        if (this.env.getEnv(Variables.REPORT_GENERATOR_ENV, "subprocess").equals("subprocess")) {
+        if (!this.env.hasEnv(Variables.REPORT_GENERATOR_ENV)) {
+            // using subprocess generation, so it is available
             reportsAvailable.complete(true);
         } else {
             checkUri(Variables.REPORT_GENERATOR_ENV, "/health", reportsAvailable);

--- a/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/HealthGetHandler.java
@@ -46,8 +46,6 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
 import io.cryostat.ApplicationVersion;
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
@@ -57,6 +55,8 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.util.HttpStatusCodeIdentifier;
+
+import com.google.gson.Gson;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;

--- a/src/main/java/io/cryostat/platform/PlatformModule.java
+++ b/src/main/java/io/cryostat/platform/PlatformModule.java
@@ -45,6 +45,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.cryostat.configuration.ConfigurationModule;
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.core.sys.Environment;
@@ -63,9 +64,6 @@ import dagger.Provides;
 
 @Module(includes = {PlatformStrategyModule.class, PlatformDiscoveryModule.class})
 public abstract class PlatformModule {
-
-    static final String PLATFORM_STRATEGY_ENV_VAR = "CRYOSTAT_PLATFORM";
-    static final String AUTH_MANAGER_ENV_VAR = "CRYOSTAT_AUTH_MANAGER";
 
     @Provides
     @Singleton
@@ -96,8 +94,8 @@ public abstract class PlatformModule {
             Set<AuthManager> authManagers,
             Logger logger) {
         final String authManagerClass;
-        if (env.hasEnv(AUTH_MANAGER_ENV_VAR)) {
-            authManagerClass = env.getEnv(AUTH_MANAGER_ENV_VAR);
+        if (env.hasEnv(Variables.AUTH_MANAGER_ENV_VAR)) {
+            authManagerClass = env.getEnv(Variables.AUTH_MANAGER_ENV_VAR);
             logger.info("Selecting configured AuthManager \"{}\"", authManagerClass);
         } else {
             authManagerClass = platformStrategy.getAuthManager().getClass().getCanonicalName();
@@ -119,8 +117,8 @@ public abstract class PlatformModule {
     static PlatformDetectionStrategy<?> providePlatformStrategy(
             Logger logger, Set<PlatformDetectionStrategy<?>> strategies, Environment env) {
         PlatformDetectionStrategy<?> strat = null;
-        if (env.hasEnv(PLATFORM_STRATEGY_ENV_VAR)) {
-            String platform = env.getEnv(PLATFORM_STRATEGY_ENV_VAR);
+        if (env.hasEnv(Variables.PLATFORM_STRATEGY_ENV_VAR)) {
+            String platform = env.getEnv(Variables.PLATFORM_STRATEGY_ENV_VAR);
             logger.info("Selecting configured PlatformDetectionStrategy \"{}\"", platform);
             for (PlatformDetectionStrategy<?> s : strategies) {
                 if (Objects.equals(platform, s.getClass().getCanonicalName())) {

--- a/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
@@ -173,7 +173,7 @@ class ActiveRecordingReportCacheTest {
         Mockito.when(subprocessReportGenerator.exec(Mockito.any(RecordingDescriptor.class)))
                 .thenThrow(
                         new CompletionException(
-                                new SubprocessReportGenerator.ReportGenerationException(
+                                new SubprocessReportGenerator.SubprocessReportGenerationException(
                                         SubprocessReportGenerator.ExitStatus.OTHER)));
         Assertions.assertThrows(
                 ExecutionException.class, () -> cache.get(connectionDescriptor, "bar").get());

--- a/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
@@ -83,7 +83,7 @@ class ActiveRecordingReportCacheTest {
     void setup() {
         this.cache =
                 new ActiveRecordingReportCache(
-                        () -> subprocessReportGenerator, fs, targetConnectionManager, logger);
+                        () -> subprocessReportGenerator, fs, targetConnectionManager, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
@@ -93,7 +93,7 @@ class ActiveRecordingReportCacheTest {
 
     @Test
     void shouldReturnTrueWhenDeletingReport() throws Exception {
-        Mockito.when(pathFuture.get()).thenReturn(destinationFile);
+        Mockito.when(pathFuture.get(Mockito.anyLong(), Mockito.any())).thenReturn(destinationFile);
         Mockito.when(subprocessReportGenerator.exec(Mockito.any(RecordingDescriptor.class)))
                 .thenReturn(pathFuture);
         Mockito.when(fs.readString(destinationFile)).thenReturn(REPORT_DOC);
@@ -108,7 +108,7 @@ class ActiveRecordingReportCacheTest {
 
     @Test
     void shouldReturnGeneratedReportResult() throws Exception {
-        Mockito.when(pathFuture.get()).thenReturn(destinationFile);
+        Mockito.when(pathFuture.get(Mockito.anyLong(), Mockito.any())).thenReturn(destinationFile);
         Mockito.when(subprocessReportGenerator.exec(Mockito.any(RecordingDescriptor.class)))
                 .thenReturn(pathFuture);
         Mockito.when(fs.readString(destinationFile)).thenReturn(REPORT_DOC);
@@ -125,7 +125,7 @@ class ActiveRecordingReportCacheTest {
 
     @Test
     void shouldReturnCachedReportResultOnSecondRequest() throws Exception {
-        Mockito.when(pathFuture.get()).thenReturn(destinationFile);
+        Mockito.when(pathFuture.get(Mockito.anyLong(), Mockito.any())).thenReturn(destinationFile);
         Mockito.when(subprocessReportGenerator.exec(Mockito.any(RecordingDescriptor.class)))
                 .thenReturn(pathFuture);
         Mockito.when(fs.readString(destinationFile)).thenReturn(REPORT_DOC);

--- a/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
@@ -38,7 +38,6 @@
 package io.cryostat.net.reports;
 
 import java.nio.file.Path;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -47,7 +46,6 @@ import java.util.concurrent.Future;
 import javax.inject.Provider;
 
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.reports.ReportTransformer;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.ConnectionDescriptor;
@@ -80,19 +78,6 @@ class ActiveRecordingReportCacheTest {
     Provider<JavaProcess.Builder> javaProcessBuilderProvider = () -> javaProcessBuilder;
     Provider<Path> tempFileProvider = () -> destinationFile;
     final String REPORT_DOC = "<html><body><p>This is a report</p></body></html>";
-
-    class TestSubprocessReportGenerator extends SubprocessReportGenerator {
-        TestSubprocessReportGenerator(FileSystem fs, Set<ReportTransformer> reportTransformers) {
-            super(
-                    ActiveRecordingReportCacheTest.this.env,
-                    ActiveRecordingReportCacheTest.this.fs,
-                    ActiveRecordingReportCacheTest.this.targetConnectionManager,
-                    reportTransformers,
-                    ActiveRecordingReportCacheTest.this.javaProcessBuilderProvider,
-                    ActiveRecordingReportCacheTest.this.tempFileProvider,
-                    ActiveRecordingReportCacheTest.this.logger);
-        }
-    }
 
     @BeforeEach
     void setup() {

--- a/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.locks.ReentrantLock;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
@@ -55,7 +54,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,7 +66,6 @@ class ArchivedRecordingReportCacheTest {
     @Mock Path destinationFile;
     @Mock FileSystem fs;
     @Mock SubprocessReportGenerator subprocessReportGenerator;
-    @Mock ReentrantLock generationLock;
     @Mock Logger logger;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
@@ -76,11 +73,7 @@ class ArchivedRecordingReportCacheTest {
     void setup() {
         this.cache =
                 new ArchivedRecordingReportCache(
-                        fs,
-                        () -> subprocessReportGenerator,
-                        generationLock,
-                        logger,
-                        recordingArchiveHelper);
+                        fs, () -> subprocessReportGenerator, logger, recordingArchiveHelper);
     }
 
     @Test
@@ -100,9 +93,6 @@ class ArchivedRecordingReportCacheTest {
         Assertions.assertThrows(ExecutionException.class, () -> cache.get(recordingName).get());
 
         Mockito.verify(fs, Mockito.atLeastOnce()).isReadable(destinationFile);
-        InOrder lockOrder = Mockito.inOrder(generationLock);
-        lockOrder.verify(generationLock).lock();
-        lockOrder.verify(generationLock).unlock();
     }
 
     @Test
@@ -128,9 +118,6 @@ class ArchivedRecordingReportCacheTest {
 
         MatcherAssert.assertThat(res.get(), Matchers.sameInstance(destinationFile));
         Mockito.verify(fs, Mockito.atLeastOnce()).isReadable(destinationFile);
-        InOrder lockOrder = Mockito.inOrder(generationLock);
-        lockOrder.verify(generationLock).lock();
-        lockOrder.verify(generationLock).unlock();
     }
 
     @Test
@@ -146,7 +133,6 @@ class ArchivedRecordingReportCacheTest {
         MatcherAssert.assertThat(res.get(), Matchers.sameInstance(destinationFile));
         Mockito.verify(fs).isReadable(destinationFile);
         Mockito.verify(fs).isRegularFile(destinationFile);
-        Mockito.verifyNoInteractions(generationLock);
     }
 
     @Test
@@ -173,8 +159,5 @@ class ArchivedRecordingReportCacheTest {
         Assertions.assertThrows(ExecutionException.class, () -> cache.get("foo").get());
 
         Mockito.verify(fs, Mockito.atLeastOnce()).isReadable(destinationFile);
-        InOrder lockOrder = Mockito.inOrder(generationLock);
-        lockOrder.verify(generationLock).lock();
-        lockOrder.verify(generationLock).unlock();
     }
 }

--- a/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
@@ -153,7 +153,7 @@ class ArchivedRecordingReportCacheTest {
                                 Mockito.any(Path.class), Mockito.any(Path.class)))
                 .thenThrow(
                         new CompletionException(
-                                new SubprocessReportGenerator.ReportGenerationException(
+                                new SubprocessReportGenerator.SubprocessReportGenerationException(
                                         SubprocessReportGenerator.ExitStatus.OUT_OF_MEMORY)));
 
         Assertions.assertThrows(ExecutionException.class, () -> cache.get("foo").get());

--- a/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
@@ -108,7 +108,7 @@ class ArchivedRecordingReportCacheTest {
                 .thenReturn(future);
         Mockito.when(future.get()).thenReturn(recording);
 
-        Mockito.when(pathFuture.get()).thenReturn(destinationFile);
+        Mockito.when(pathFuture.get(Mockito.anyLong(), Mockito.any())).thenReturn(destinationFile);
         Mockito.when(
                         subprocessReportGenerator.exec(
                                 Mockito.any(Path.class), Mockito.any(Path.class)))

--- a/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ArchivedRecordingReportCacheTest.java
@@ -73,7 +73,7 @@ class ArchivedRecordingReportCacheTest {
     void setup() {
         this.cache =
                 new ArchivedRecordingReportCache(
-                        fs, () -> subprocessReportGenerator, logger, recordingArchiveHelper);
+                        fs, () -> subprocessReportGenerator, recordingArchiveHelper, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -80,7 +80,7 @@ class SubprocessReportGeneratorTest {
     @Mock Logger logger;
     @Mock Process proc;
     ConnectionDescriptor connectionDescriptor;
-    SubprocessReportGenerator.RecordingDescriptor recordingDescriptor;
+    RecordingDescriptor recordingDescriptor;
     @Mock Path recordingFile;
     @Mock Path tempFile1;
     @Mock Path tempFile2;
@@ -91,9 +91,7 @@ class SubprocessReportGeneratorTest {
     void setup() throws Exception {
         connectionDescriptor =
                 new ConnectionDescriptor("fooHost:1234", new Credentials("someUser", "somePass"));
-        recordingDescriptor =
-                new SubprocessReportGenerator.RecordingDescriptor(
-                        connectionDescriptor, "testRecording");
+        recordingDescriptor = new RecordingDescriptor(connectionDescriptor, "testRecording");
 
         tempFileProvider = Mockito.mock(Provider.class);
         Mockito.lenient().when(tempFileProvider.get()).thenReturn(tempFile1).thenReturn(tempFile2);

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -235,7 +235,7 @@ class SubprocessReportGeneratorTest {
         Path dest = Mockito.mock(Path.class);
         Mockito.when(dest.toAbsolutePath()).thenReturn(dest);
         Mockito.when(dest.toString()).thenReturn("/dest/somefile.tmp");
-        Mockito.when(proc.waitFor(5, TimeUnit.MINUTES)).thenReturn(true);
+        Mockito.when(proc.waitFor(29, TimeUnit.SECONDS)).thenReturn(true);
 
         Assertions.assertTimeoutPreemptively(
                 Duration.ofSeconds(2),
@@ -250,7 +250,7 @@ class SubprocessReportGeneratorTest {
         Path dest = Mockito.mock(Path.class);
         Mockito.when(dest.toAbsolutePath()).thenReturn(dest);
         Mockito.when(dest.toString()).thenReturn("/dest/somefile.tmp");
-        Mockito.when(proc.waitFor(5, TimeUnit.MINUTES)).thenReturn(false);
+        Mockito.when(proc.waitFor(29, TimeUnit.SECONDS)).thenReturn(false);
         Mockito.when(proc.exitValue())
                 .thenReturn(SubprocessReportGenerator.ExitStatus.NO_SUCH_RECORDING.code);
 
@@ -270,7 +270,7 @@ class SubprocessReportGeneratorTest {
 
     @Test
     void shouldExecuteProcessAndDeleteRecordingOnCompletion() throws Exception {
-        Mockito.when(proc.waitFor(5, TimeUnit.MINUTES)).thenReturn(true);
+        Mockito.when(proc.waitFor(29, TimeUnit.SECONDS)).thenReturn(true);
         Mockito.when(proc.exitValue()).thenReturn(SubprocessReportGenerator.ExitStatus.OK.code);
 
         Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
@@ -290,7 +290,7 @@ class SubprocessReportGeneratorTest {
 
     @Test
     void shouldExecuteProcessAndDeleteRecordingOnFailure() throws Exception {
-        Mockito.when(proc.waitFor(5, TimeUnit.MINUTES)).thenReturn(true);
+        Mockito.when(proc.waitFor(29, TimeUnit.SECONDS)).thenReturn(true);
         Mockito.when(proc.exitValue())
                 .thenReturn(SubprocessReportGenerator.ExitStatus.NO_SUCH_RECORDING.code);
 

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -118,7 +118,7 @@ class SubprocessReportGeneratorTest {
         Mockito.lenient()
                 .when(
                         env.getEnv(
-                                Mockito.eq(SubprocessReportGenerator.SUBPROCESS_MAX_HEAP_ENV),
+                                Mockito.eq("CRYOSTAT_REPORT_GENERATION_MAX_HEAP"),
                                 Mockito.anyString()))
                 .thenReturn("200");
         this.generator =
@@ -201,7 +201,7 @@ class SubprocessReportGeneratorTest {
         Mockito.when(dest.toString()).thenReturn("/dest/somefile.tmp");
         Mockito.when(
                         env.getEnv(
-                                Mockito.eq(SubprocessReportGenerator.SUBPROCESS_MAX_HEAP_ENV),
+                                Mockito.eq("CRYOSTAT_REPORT_GENERATION_MAX_HEAP"),
                                 Mockito.anyString()))
                 .thenReturn("0");
 

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -129,6 +129,7 @@ class SubprocessReportGeneratorTest {
                         Set.of(new TestReportTransformer()),
                         () -> javaProcessBuilder,
                         tempFileProvider,
+                        30,
                         logger);
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
@@ -82,7 +82,7 @@ class ReportGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new ReportGetHandler(auth, jwt, () -> webServer, reports, logger);
+        this.handler = new ReportGetHandler(auth, jwt, () -> webServer, reports, 30, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
@@ -121,8 +121,8 @@ class ReportGetHandlerTest {
         }
 
         @Test
-        void shouldBeOrdered() {
-            Assertions.assertTrue(handler.isOrdered());
+        void shouldNotBeOrdered() {
+            Assertions.assertFalse(handler.isOrdered());
         }
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/TargetReportGetHandlerTest.java
@@ -80,7 +80,7 @@ class TargetReportGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetReportGetHandler(auth, jwt, () -> webServer, reports, logger);
+        this.handler = new TargetReportGetHandler(auth, jwt, () -> webServer, reports, 30, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
@@ -108,8 +108,8 @@ class ReportGetHandlerTest {
     }
 
     @Test
-    void shouldBeOrdered() {
-        Assertions.assertTrue(handler.isOrdered());
+    void shouldNotBeOrdered() {
+        Assertions.assertFalse(handler.isOrdered());
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
@@ -77,7 +77,7 @@ class ReportGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new ReportGetHandler(authManager, reportService, logger);
+        this.handler = new ReportGetHandler(authManager, reportService, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
@@ -177,7 +177,7 @@ class TargetReportGetHandlerTest {
         Future<String> content =
                 CompletableFuture.failedFuture(
                         new ExecutionException(
-                                new SubprocessReportGenerator.ReportGenerationException(
+                                new SubprocessReportGenerator.SubprocessReportGenerationException(
                                         SubprocessReportGenerator.ExitStatus
                                                 .TARGET_CONNECTION_FAILURE)));
         when(reportService.get(Mockito.any(), Mockito.anyString())).thenReturn(content);
@@ -207,7 +207,7 @@ class TargetReportGetHandlerTest {
         Future<String> content =
                 CompletableFuture.failedFuture(
                         new ExecutionException(
-                                new SubprocessReportGenerator.ReportGenerationException(
+                                new SubprocessReportGenerator.SubprocessReportGenerationException(
                                         SubprocessReportGenerator.ExitStatus.NO_SUCH_RECORDING)));
         when(reportService.get(Mockito.any(), Mockito.anyString())).thenReturn(content);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
@@ -82,7 +82,7 @@ class TargetReportGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetReportGetHandler(authManager, reportService, logger);
+        this.handler = new TargetReportGetHandler(authManager, reportService, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
@@ -71,10 +71,7 @@ class CorsEnablingHandlerTest {
 
     @BeforeEach
     void setup() {
-        Mockito.when(
-                        env.getEnv(
-                                CorsEnablingHandler.ENABLE_CORS_ENV,
-                                CorsEnablingHandler.DEV_ORIGIN))
+        Mockito.when(env.getEnv("CRYOSTAT_CORS_ORIGIN", CorsEnablingHandler.DEV_ORIGIN))
                 .thenReturn(CUSTOM_ORIGIN);
         this.handler = new CorsEnablingHandler(env);
     }
@@ -92,7 +89,7 @@ class CorsEnablingHandlerTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void availabilityShouldDependOnEnvVar(boolean available) {
-        Mockito.when(env.hasEnv(CorsEnablingHandler.ENABLE_CORS_ENV)).thenReturn(available);
+        Mockito.when(env.hasEnv("CRYOSTAT_CORS_ORIGIN")).thenReturn(available);
         MatcherAssert.assertThat(handler.isAvailable(), Matchers.equalTo(available));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/generic/CorsOptionsHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/CorsOptionsHandlerTest.java
@@ -58,10 +58,7 @@ class CorsOptionsHandlerTest {
 
     @BeforeEach
     void setup() {
-        Mockito.when(
-                        env.getEnv(
-                                CorsEnablingHandler.ENABLE_CORS_ENV,
-                                CorsEnablingHandler.DEV_ORIGIN))
+        Mockito.when(env.getEnv("CRYOSTAT_CORS_ORIGIN", CorsEnablingHandler.DEV_ORIGIN))
                 .thenReturn("http://localhost:9000");
         this.handler = new CorsOptionsHandler(env);
     }

--- a/src/test/java/io/cryostat/net/web/http/generic/HealthGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/HealthGetHandlerTest.java
@@ -129,7 +129,8 @@ class HealthGetHandlerTest {
                         Map.of(
                                 "cryostatVersion", "v1.2.3",
                                 "dashboardAvailable", false,
-                                "datasourceAvailable", false)));
+                                "datasourceAvailable", false,
+                                "reportsAvailable", true)));
     }
 
     @Test
@@ -184,7 +185,8 @@ class HealthGetHandlerTest {
                         Map.of(
                                 "cryostatVersion", "v1.2.3",
                                 "dashboardAvailable", false,
-                                "datasourceAvailable", true)));
+                                "datasourceAvailable", true,
+                                "reportsAvailable", true)));
     }
 
     @Test
@@ -239,7 +241,8 @@ class HealthGetHandlerTest {
                         Map.of(
                                 "cryostatVersion", "v1.2.3",
                                 "dashboardAvailable", true,
-                                "datasourceAvailable", false)));
+                                "datasourceAvailable", false,
+                                "reportsAvailable", true)));
     }
 
     @Test
@@ -293,6 +296,7 @@ class HealthGetHandlerTest {
                         Map.of(
                                 "cryostatVersion", "v1.2.3",
                                 "dashboardAvailable", true,
-                                "datasourceAvailable", false)));
+                                "datasourceAvailable", false,
+                                "reportsAvailable", true)));
     }
 }


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/8
Fixes #324 (no longer necessary)

This abstracts report generation to reduce the coupling of the report caches and report handlers to the SubprocessReportGenerator, and then introduces an alternate report generator implementation that performs HTTP calls out to a separate sidecar container (https://github.com/cryostatio/cryostat-reports). The user selects which report generation strategy is used by setting the environment variable `CRYOSTAT_REPORT_GENERATOR`. If this env var is unset or empty then Cryostat will default to forking a subprocess to generate the report as usual. If it is set then it is expected to be the URL to a `cryostat-reports` instance (or a loadbalanced service in front of some replicas), and Cryostat will delegate report generation off to the sidecar(s).