### PR TITLE
feat(auth): Add OAuth logout

### DIFF
--- a/src/main/java/io/cryostat/net/AuthManager.java
+++ b/src/main/java/io/cryostat/net/AuthManager.java
@@ -37,6 +37,7 @@
  */
 package io.cryostat.net;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -56,7 +57,7 @@ public interface AuthManager {
             throws ExecutionException, InterruptedException;
 
     Optional<String> logout(Supplier<String> httpHeaderProvider)
-            throws ExecutionException, InterruptedException;
+            throws ExecutionException, InterruptedException, IOException, TokenNotFoundException;
 
     Future<Boolean> validateToken(
             Supplier<String> tokenProvider, Set<ResourceAction> resourceActions);

--- a/src/main/java/io/cryostat/net/AuthManager.java
+++ b/src/main/java/io/cryostat/net/AuthManager.java
@@ -55,7 +55,8 @@ public interface AuthManager {
             Supplier<String> headerProvider, Set<ResourceAction> resourceActions)
             throws ExecutionException, InterruptedException;
 
-    Optional<String> logout(Supplier<String> httpHeaderProvider) throws ExecutionException, InterruptedException;
+    Optional<String> logout(Supplier<String> httpHeaderProvider)
+            throws ExecutionException, InterruptedException;
 
     Future<Boolean> validateToken(
             Supplier<String> tokenProvider, Set<ResourceAction> resourceActions);

--- a/src/main/java/io/cryostat/net/AuthManager.java
+++ b/src/main/java/io/cryostat/net/AuthManager.java
@@ -64,6 +64,8 @@ public interface AuthManager {
     Future<Boolean> validateWebSocketSubProtocol(
             Supplier<String> subProtocolProvider, Set<ResourceAction> resourceActions);
 
+    Future<Boolean> logout();
+
     AuthenticatedAction doAuthenticated(
             Supplier<String> provider, Function<Supplier<String>, Future<Boolean>> validator);
 }

--- a/src/main/java/io/cryostat/net/AuthManager.java
+++ b/src/main/java/io/cryostat/net/AuthManager.java
@@ -55,7 +55,7 @@ public interface AuthManager {
             Supplier<String> headerProvider, Set<ResourceAction> resourceActions)
             throws ExecutionException, InterruptedException;
 
-    Optional<String> logout() throws ExecutionException, InterruptedException;
+    Optional<String> logout(Supplier<String> httpHeaderProvider) throws ExecutionException, InterruptedException;
 
     Future<Boolean> validateToken(
             Supplier<String> tokenProvider, Set<ResourceAction> resourceActions);

--- a/src/main/java/io/cryostat/net/BasicAuthManager.java
+++ b/src/main/java/io/cryostat/net/BasicAuthManager.java
@@ -166,7 +166,7 @@ class BasicAuthManager extends AbstractAuthManager {
     }
 
     @Override
-    public Optional<String> logout() {
+    public Optional<String> logout(Supplier<String> httpHeaderProvider) {
         return Optional.empty();
     }
 

--- a/src/main/java/io/cryostat/net/BasicAuthManager.java
+++ b/src/main/java/io/cryostat/net/BasicAuthManager.java
@@ -166,8 +166,8 @@ class BasicAuthManager extends AbstractAuthManager {
     }
 
     @Override
-    public Future<Boolean> logout() {
-        return CompletableFuture.completedFuture(true);
+    public Optional<String> logout() {
+        return Optional.empty();
     }
 
     private Pair<String, String> splitCredentials(String credentials) {

--- a/src/main/java/io/cryostat/net/BasicAuthManager.java
+++ b/src/main/java/io/cryostat/net/BasicAuthManager.java
@@ -165,6 +165,11 @@ class BasicAuthManager extends AbstractAuthManager {
         }
     }
 
+    @Override
+    public Future<Boolean> logout() {
+        return CompletableFuture.completedFuture(true);
+    }
+
     private Pair<String, String> splitCredentials(String credentials) {
         if (credentials == null) {
             return null;

--- a/src/main/java/io/cryostat/net/NoopAuthManager.java
+++ b/src/main/java/io/cryostat/net/NoopAuthManager.java
@@ -87,7 +87,7 @@ public class NoopAuthManager extends AbstractAuthManager {
     }
 
     @Override
-    public Optional<String> logout() {
+    public Optional<String> logout(Supplier<String> httpHeaderProvider) {
         return Optional.empty();
     }
 }

--- a/src/main/java/io/cryostat/net/NoopAuthManager.java
+++ b/src/main/java/io/cryostat/net/NoopAuthManager.java
@@ -87,7 +87,7 @@ public class NoopAuthManager extends AbstractAuthManager {
     }
 
     @Override
-    public Future<Boolean> logout() {
-        return CompletableFuture.completedFuture(true);
+    public Optional<String> logout() {
+        return Optional.empty();
     }
 }

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -321,7 +321,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
                     Optional.ofNullable(client.oAuthAccessTokens().delete(userOauthAccessTokens))
                             .orElseThrow(TokenNotFoundException::new);
 
-            if (!deleted) {
+            if (Boolean.FALSE.equals(deleted)) {
                 throw new TokenNotFoundException();
             }
 

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -165,7 +165,8 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
     }
 
     @Override
-    public Optional<String> logout(Supplier<String> httpHeaderProvider) throws ExecutionException, InterruptedException {
+    public Optional<String> logout(Supplier<String> httpHeaderProvider)
+            throws ExecutionException, InterruptedException {
 
         String token = getTokenFromHttpHeader(httpHeaderProvider.get());
         deleteToken(token).get();
@@ -319,10 +320,12 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
 
             List<OAuthAccessToken> userOauthAccessTokens =
                     client.oAuthAccessTokens().list().getItems().stream()
-                            .filter(t -> {
-                                return (t.getClientName().equals(serviceAccountAsOAuthClient)
-                                    && t.getUserUID().equals(uid));
-                            })
+                            .filter(
+                                    t -> {
+                                        return (t.getClientName()
+                                                        .equals(serviceAccountAsOAuthClient)
+                                                && t.getUserUID().equals(uid));
+                                    })
                             .collect(Collectors.toList());
 
             Boolean deleted =

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -166,10 +166,10 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
 
     @Override
     public Optional<String> logout(Supplier<String> httpHeaderProvider)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, IOException, TokenNotFoundException {
 
         String token = getTokenFromHttpHeader(httpHeaderProvider.get());
-        deleteToken(token).get();
+        deleteToken(token);
 
         return Optional.of(this.computeLogoutRedirectEndpoint().get());
     }
@@ -311,7 +311,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
-    private Future<Boolean> deleteToken(String token) {
+    private Boolean deleteToken(String token) throws IOException, TokenNotFoundException {
         try (OpenShiftClient client = clientProvider.apply(getServiceAccountToken())) {
             Boolean deleted =
                     Optional.ofNullable(
@@ -324,10 +324,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
                 throw new TokenNotFoundException();
             }
 
-            return CompletableFuture.completedFuture(deleted);
-        } catch (Exception e) {
-            logger.error(e);
-            return CompletableFuture.failedFuture(e);
+            return deleted;
         }
     }
 

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -311,7 +311,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
-    private Boolean deleteToken(String token) throws IOException, TokenNotFoundException {
+    private boolean deleteToken(String token) throws IOException, TokenNotFoundException {
         try (OpenShiftClient client = clientProvider.apply(getServiceAccountToken())) {
             Boolean deleted =
                     Optional.ofNullable(

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -73,6 +73,7 @@ import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewB
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.OAuthAccessToken;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
@@ -314,8 +315,16 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
     private Future<Boolean> deleteToken(String token) {
         try (OpenShiftClient client = clientProvider.apply(getServiceAccountToken())) {
             String serviceAccountAsOAuthClient = this.getServiceAccountName();
-            Future<TokenReviewStatus> fStatus = performTokenReview(token);
-            TokenReviewStatus status = fStatus.get();
+
+            // FIXME reuse performTokenReview instead of copying it here
+            TokenReview review =
+                    new TokenReviewBuilder().withNewSpec().withToken(token).endSpec().build();
+            review = client.tokenReviews().create(review);
+            TokenReviewStatus status = review.getStatus();
+            if (StringUtils.isNotBlank(status.getError())) {
+                return CompletableFuture.failedFuture(
+                        new AuthorizationErrorException(status.getError()));
+            }
             String uid = status.getUser().getUid();
 
             List<OAuthAccessToken> userOauthAccessTokens =

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;

--- a/src/main/java/io/cryostat/net/TokenNotFoundException.java
+++ b/src/main/java/io/cryostat/net/TokenNotFoundException.java
@@ -37,35 +37,8 @@
  */
 package io.cryostat.net;
 
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import io.cryostat.net.security.ResourceAction;
-
-public interface AuthManager {
-    AuthenticationScheme getScheme();
-
-    Future<UserInfo> getUserInfo(Supplier<String> httpHeaderProvider);
-
-    Optional<String> getLoginRedirectUrl(
-            Supplier<String> headerProvider, Set<ResourceAction> resourceActions)
-            throws ExecutionException, InterruptedException;
-
-    Optional<String> logout() throws ExecutionException, InterruptedException;
-
-    Future<Boolean> validateToken(
-            Supplier<String> tokenProvider, Set<ResourceAction> resourceActions);
-
-    Future<Boolean> validateHttpHeader(
-            Supplier<String> headerProvider, Set<ResourceAction> resourceActions);
-
-    Future<Boolean> validateWebSocketSubProtocol(
-            Supplier<String> subProtocolProvider, Set<ResourceAction> resourceActions);
-
-    AuthenticatedAction doAuthenticated(
-            Supplier<String> provider, Function<Supplier<String>, Future<Boolean>> validator);
+public class TokenNotFoundException extends Exception {
+    public TokenNotFoundException() {
+        super(String.format("Token not found"));
+    }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
@@ -62,6 +62,10 @@ public abstract class HttpApiV2Module {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindLogoutPostHandler(LogoutPostHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindApiGetHandler(ApiGetHandler handler);
 
     @Binds

--- a/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
@@ -97,7 +97,6 @@ class LogoutPostHandler extends AbstractV2RequestHandler<Void> {
     public IntermediateResponse<Void> handle(RequestParameters requestParams) throws Exception {
         Optional<String> logoutRedirectUrl =
                 auth.logout(() -> requestParams.getHeaders().get(HttpHeaders.AUTHORIZATION));
-
         return logoutRedirectUrl
                 .map(
                         location -> {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
@@ -48,6 +48,8 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
 import com.google.gson.Gson;
+
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 
 class LogoutPostHandler extends AbstractV2RequestHandler<Void> {
@@ -94,7 +96,7 @@ class LogoutPostHandler extends AbstractV2RequestHandler<Void> {
 
     @Override
     public IntermediateResponse<Void> handle(RequestParameters requestParams) throws Exception {
-        Optional<String> logoutRedirectUrl = auth.logout();
+        Optional<String> logoutRedirectUrl = auth.logout(() -> requestParams.getHeaders().get(HttpHeaders.AUTHORIZATION));
 
         return logoutRedirectUrl
                 .map(

--- a/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
@@ -48,7 +48,6 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
 import com.google.gson.Gson;
-
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 
@@ -96,7 +95,8 @@ class LogoutPostHandler extends AbstractV2RequestHandler<Void> {
 
     @Override
     public IntermediateResponse<Void> handle(RequestParameters requestParams) throws Exception {
-        Optional<String> logoutRedirectUrl = auth.logout(() -> requestParams.getHeaders().get(HttpHeaders.AUTHORIZATION));
+        Optional<String> logoutRedirectUrl =
+                auth.logout(() -> requestParams.getHeaders().get(HttpHeaders.AUTHORIZATION));
 
         return logoutRedirectUrl
                 .map(

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -65,7 +64,6 @@ import io.cryostat.net.security.ResourceVerb;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.authentication.TokenReview;
 import io.fabric8.kubernetes.api.model.authentication.TokenReviewBuilder;
-import io.fabric8.kubernetes.api.model.authentication.TokenReviewStatus;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReview;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewBuilder;
 import io.fabric8.kubernetes.client.Config;
@@ -445,7 +443,9 @@ class OpenShiftAuthManagerTest {
     @Test
     void shouldReturnLogoutRedirectUrl() throws Exception {
         Mockito.when(fs.readFile(Paths.get(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)))
-                .thenReturn(new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)));
+                .thenReturn(
+                        new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)),
+                        new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)));
         Mockito.when(fs.readFile(Paths.get(Config.KUBERNETES_NAMESPACE_PATH)))
                 .thenReturn(
                         new BufferedReader(new StringReader(NAMESPACE)),
@@ -512,7 +512,9 @@ class OpenShiftAuthManagerTest {
     @ValueSource(booleans = {false})
     void shouldThrowWhenTokenDeletionFailsOnLogout(Boolean deletionFailure) throws Exception {
         Mockito.when(fs.readFile(Paths.get(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)))
-                .thenReturn(new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)));
+                .thenReturn(
+                        new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)),
+                        new BufferedReader(new StringReader(SERVICE_ACCOUNT_TOKEN)));
         Mockito.when(fs.readFile(Paths.get(Config.KUBERNETES_NAMESPACE_PATH)))
                 .thenReturn(
                         new BufferedReader(new StringReader(NAMESPACE)),
@@ -692,9 +694,6 @@ class OpenShiftAuthManagerTest {
 
         @Override
         public OpenShiftClient apply(String token) {
-            if (this.token != null) {
-                throw new IllegalStateException("Token was already set!");
-            }
             this.token = token;
             return osc;
         }

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -369,11 +369,12 @@ class OpenShiftAuthManagerTest {
 
     @ParameterizedTest
     @CsvSource(value = {",", "oauth-client-id,", ", oauth-role-scope"})
-    void shouldThrowWhenEnvironmentVariablesMissing(String clientId, String roleScope)
+    void shouldThrowWhenEnvironmentVariablesMissing(String clientId, String tokenScope)
             throws Exception {
+
         Mockito.when(fs.readFile(Paths.get(Config.KUBERNETES_NAMESPACE_PATH)))
                 .thenReturn(new BufferedReader(new StringReader("namespace")));
-        Mockito.when(env.getEnv(Mockito.anyString())).thenReturn(clientId, roleScope);
+        Mockito.when(env.getEnv(Mockito.anyString())).thenReturn(clientId, tokenScope);
 
         CompletionException ee =
                 Assertions.assertThrows(

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -493,11 +493,8 @@ class OpenShiftAuthManagerTest {
         Mockito.when(tokens.withName(Mockito.anyString())).thenReturn(token);
         Mockito.when(token.delete()).thenReturn(deletionFailure);
 
-        ExecutionException ee =
-                Assertions.assertThrows(
-                        ExecutionException.class, () -> mgr.logout(() -> "Bearer myToken").get());
-        MatcherAssert.assertThat(
-                ExceptionUtils.getRootCause(ee), Matchers.instanceOf(TokenNotFoundException.class));
+        Assertions.assertThrows(
+                TokenNotFoundException.class, () -> mgr.logout(() -> "Bearer myToken").get());
     }
 
     @ParameterizedTest

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -479,7 +479,7 @@ class OpenShiftAuthManagerTest {
                 .when(req)
                 .send(Mockito.any());
 
-        String logoutRedirectUrl = mgr.logout().get();
+        String logoutRedirectUrl = mgr.logout(() -> "Bearer myToken").get();
 
         MatcherAssert.assertThat(logoutRedirectUrl, Matchers.equalTo(EXPECTED_LOGOUT_REDIRECT_URL));
     }
@@ -509,7 +509,7 @@ class OpenShiftAuthManagerTest {
         Mockito.when(nonNamespaceOperation.delete(tokens)).thenReturn(deletionFailure);
 
         ExecutionException ee =
-                Assertions.assertThrows(ExecutionException.class, () -> mgr.logout().get());
+                Assertions.assertThrows(ExecutionException.class, () -> mgr.logout(() -> "Bearer myToken").get());
         MatcherAssert.assertThat(
                 ExceptionUtils.getRootCause(ee), Matchers.instanceOf(TokenNotFoundException.class));
     }

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -63,7 +62,6 @@ import io.cryostat.net.security.ResourceVerb;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.authentication.TokenReview;
 import io.fabric8.kubernetes.api.model.authentication.TokenReviewBuilder;
-import io.fabric8.kubernetes.api.model.authentication.TokenReviewStatus;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReview;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewBuilder;
 import io.fabric8.kubernetes.client.Config;

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -509,7 +509,8 @@ class OpenShiftAuthManagerTest {
         Mockito.when(nonNamespaceOperation.delete(tokens)).thenReturn(deletionFailure);
 
         ExecutionException ee =
-                Assertions.assertThrows(ExecutionException.class, () -> mgr.logout(() -> "Bearer myToken").get());
+                Assertions.assertThrows(
+                        ExecutionException.class, () -> mgr.logout(() -> "Bearer myToken").get());
         MatcherAssert.assertThat(
                 ExceptionUtils.getRootCause(ee), Matchers.instanceOf(TokenNotFoundException.class));
     }

--- a/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/OpenShiftAuthManagerTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -62,6 +63,7 @@ import io.cryostat.net.security.ResourceVerb;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.authentication.TokenReview;
 import io.fabric8.kubernetes.api.model.authentication.TokenReviewBuilder;
+import io.fabric8.kubernetes.api.model.authentication.TokenReviewStatus;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReview;
 import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewBuilder;
 import io.fabric8.kubernetes.client.Config;
@@ -637,6 +639,9 @@ class OpenShiftAuthManagerTest {
 
         @Override
         public OpenShiftClient apply(String token) {
+            if (this.token != null) {
+                throw new IllegalStateException("Token was already set!");
+            }
             this.token = token;
             return osc;
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
@@ -47,6 +47,7 @@ import io.cryostat.net.security.ResourceAction;
 
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
@@ -76,6 +77,7 @@ public class LogoutPostHandlerTest {
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        headers.set(HttpHeaders.AUTHORIZATION, "abcd1234==");
         Mockito.lenient().when(req.headers()).thenReturn(headers);
         Mockito.lenient().when(ctx.request()).thenReturn(req);
     }
@@ -97,7 +99,7 @@ public class LogoutPostHandlerTest {
 
     @Test
     void shouldHandleLogoutWhenNoRedirectNecessary() throws Exception {
-        Mockito.when(auth.logout(() -> "Bearer myToken")).thenReturn(Optional.empty());
+        Mockito.when(auth.logout(Mockito.any())).thenReturn(Optional.empty());
 
         IntermediateResponse<Void> response = handler.handle(requestParams);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
@@ -106,7 +108,7 @@ public class LogoutPostHandlerTest {
 
     @Test
     void shouldSendLogoutRedirectUrlWhenPresent() throws Exception {
-        Mockito.when(auth.logout(() -> "Bearer myToken")).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
+        Mockito.when(auth.logout(Mockito.any())).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
 
         IntermediateResponse<Void> response = handler.handle(requestParams);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
@@ -108,7 +108,8 @@ public class LogoutPostHandlerTest {
 
     @Test
     void shouldSendLogoutRedirectUrlWhenPresent() throws Exception {
-        Mockito.when(auth.logout(Mockito.any())).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
+        Mockito.when(auth.logout(Mockito.any()))
+                .thenReturn(Optional.of("https://oauth.redirect-url/logout"));
 
         IntermediateResponse<Void> response = handler.handle(requestParams);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
@@ -97,7 +97,7 @@ public class LogoutPostHandlerTest {
 
     @Test
     void shouldHandleLogoutWhenNoRedirectNecessary() throws Exception {
-        Mockito.when(auth.logout()).thenReturn(Optional.empty());
+        Mockito.when(auth.logout(() -> "Bearer myToken")).thenReturn(Optional.empty());
 
         IntermediateResponse<Void> response = handler.handle(requestParams);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
@@ -106,7 +106,7 @@ public class LogoutPostHandlerTest {
 
     @Test
     void shouldSendLogoutRedirectUrlWhenPresent() throws Exception {
-        Mockito.when(auth.logout()).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
+        Mockito.when(auth.logout(() -> "Bearer myToken")).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
 
         IntermediateResponse<Void> response = handler.handle(requestParams);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.Optional;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class LogoutPostHandlerTest {
+
+    LogoutPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @Mock RoutingContext ctx;
+    @Mock RequestParameters requestParams;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new LogoutPostHandler(auth, gson);
+
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        Mockito.lenient().when(req.headers()).thenReturn(headers);
+        Mockito.lenient().when(ctx.request()).thenReturn(req);
+    }
+
+    @Test
+    void shouldHandlePOST() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2.1/logout"));
+    }
+
+    @Test
+    void shouldHaveExpectedRequiredPermissions() {
+        MatcherAssert.assertThat(handler.resourceActions(), Matchers.equalTo(ResourceAction.NONE));
+    }
+
+    @Test
+    void shouldHandleLogoutWhenNoRedirectNecessary() throws Exception {
+        Mockito.when(auth.logout()).thenReturn(Optional.empty());
+
+        IntermediateResponse<Void> response = handler.handle(requestParams);
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+        MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(null));
+    }
+
+    @Test
+    void shouldSendLogoutRedirectUrlWhenPresent() throws Exception {
+        Mockito.when(auth.logout()).thenReturn(Optional.of("https://oauth.redirect-url/logout"));
+
+        IntermediateResponse<Void> response = handler.handle(requestParams);
+
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(302));
+        MatcherAssert.assertThat(
+                response.getHeaders().get("X-Location"),
+                Matchers.equalTo("https://oauth.redirect-url/logout"));
+        MatcherAssert.assertThat(
+                response.getHeaders().get("access-control-expose-headers"),
+                Matchers.equalTo("Location"));
+        MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(null));
+    }
+}


### PR DESCRIPTION
Fixes #717 
Depends on https://github.com/cryostatio/cryostat-web/pull/355
Depends on https://github.com/cryostatio/cryostat-operator/pull/319
Depends on https://github.com/cryostatio/cryostat-operator/issues/320

Please see the -web PR for more information about the OAuth server logout behaviour.

This PR also updates the web client and caches the logout redirect url.