### PR TITLE
feat(websocket): Add keepalive server ping

### DIFF
--- a/src/main/java/io/cryostat/messaging/MessagingModule.java
+++ b/src/main/java/io/cryostat/messaging/MessagingModule.java
@@ -63,6 +63,7 @@ public abstract class MessagingModule {
 
     static final String WS_MAX_CONNECTIONS = "WS_MAX_CONNECTIONS";
     static final String LIMBO_PRUNER = "LIMBO_PRUNER";
+    static final String KEEPALIVE_PINGER = "KEEPALIVE_PINGER";
 
     static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
     static final int MIN_CONNECTIONS = 1;
@@ -78,6 +79,7 @@ public abstract class MessagingModule {
             NotificationFactory notificationFactory,
             @Named(WS_MAX_CONNECTIONS) int maxConnections,
             @Named(LIMBO_PRUNER) ScheduledExecutorService limboPruner,
+            @Named(KEEPALIVE_PINGER) ScheduledExecutorService keepalivePinger,
             Clock clock,
             Logger logger,
             Gson gson) {
@@ -88,6 +90,7 @@ public abstract class MessagingModule {
                 notificationFactory,
                 maxConnections,
                 limboPruner,
+                keepalivePinger,
                 clock,
                 logger,
                 gson);
@@ -120,6 +123,12 @@ public abstract class MessagingModule {
     @Provides
     @Named(LIMBO_PRUNER)
     static ScheduledExecutorService provideLimboPruner() {
+        return Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @Provides
+    @Named(KEEPALIVE_PINGER)
+    static ScheduledExecutorService provideKeepalivePinger() {
         return Executors.newSingleThreadScheduledExecutor();
     }
 }

--- a/src/main/java/io/cryostat/messaging/WsClient.java
+++ b/src/main/java/io/cryostat/messaging/WsClient.java
@@ -41,6 +41,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Clock;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.net.SocketAddress;
 import jdk.jfr.Category;
@@ -101,6 +102,10 @@ class WsClient implements AutoCloseable {
 
     SocketAddress getRemoteAddress() {
         return sws.remoteAddress();
+    }
+
+    void ping() {
+        sws.writePing(Buffer.buffer("ping"));
     }
 
     @Override

--- a/src/test/java/io/cryostat/messaging/MessagingServerTest.java
+++ b/src/test/java/io/cryostat/messaging/MessagingServerTest.java
@@ -81,6 +81,7 @@ class MessagingServerTest {
     Gson gson = MainModule.provideGson(logger);
     @Mock ServerWebSocket sws;
     @Mock ScheduledExecutorService limboPruner;
+    @Mock ScheduledExecutorService keepalivePinger;
     @Mock Clock clock;
     @Mock NotificationFactory notificationFactory;
     @Mock Notification notification;
@@ -122,6 +123,7 @@ class MessagingServerTest {
                         notificationFactory,
                         2,
                         limboPruner,
+                        keepalivePinger,
                         clock,
                         logger,
                         gson);

--- a/src/test/java/io/cryostat/messaging/MessagingServerTest.java
+++ b/src/test/java/io/cryostat/messaging/MessagingServerTest.java
@@ -61,7 +61,6 @@ import io.cryostat.net.web.http.HttpMimeType;
 
 import com.google.gson.Gson;
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.net.SocketAddress;
 import org.junit.jupiter.api.BeforeEach;
@@ -281,7 +280,7 @@ class MessagingServerTest {
     }
 
     @Test
-    void shouldPingAcceptedClients() throws SocketException, UnknownHostException, InterruptedException {
+    void shouldPingAcceptedClients() throws SocketException, UnknownHostException {
         server.start();
 
         ArgumentCaptor<Handler> websocketHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
@@ -297,7 +296,12 @@ class MessagingServerTest {
         verify(authAction).onSuccess(authSuccessCaptor.capture());
         authSuccessCaptor.getValue().run();
 
-        verify(keepalivePinger).scheduleAtFixedRate(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(TimeUnit.class));
+        verify(keepalivePinger)
+                .scheduleAtFixedRate(
+                        Mockito.any(),
+                        Mockito.anyLong(),
+                        Mockito.anyLong(),
+                        Mockito.any(TimeUnit.class));
     }
 
     @Test


### PR DESCRIPTION
Related #757 

The server will ping accepted WebSocket clients every 5 seconds to prevent an idle timeout disconnection. The client will automatically respond with a pong as per [WebSocketBase docs](https://vertx.io/docs/apidocs/io/vertx/core/http/WebSocketBase.html#writePing-io.vertx.core.buffer.Buffer-io.vertx.core.Handler-)

> Once we have an upstream release that includes application-level keepalive then the downstream configuration for increasing the timeout can be removed.

After this PR is merged, I'll add another PR to remove the extended timeout annotations in [config.md](https://github.com/cryostatio/cryostat-operator/blob/main/docs/config.md#network-options) which will close #757.