### PR TITLE
fix(reports): convey remote report generation status codes to client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   <com.google.dagger.version>2.34.1</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.4.0</io.cryostat.core.version>
+  <io.cryostat.core.version>2.6.0</io.cryostat.core.version>
 
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.15</org.apache.commons.codec.version>

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -67,6 +67,7 @@ public final class Variables {
     public static final String WEBSERVER_ALLOW_UNTRUSTED_SSL = "CRYOSTAT_ALLOW_UNTRUSTED_SSL";
     public static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
     public static final String ENABLE_CORS_ENV = "CRYOSTAT_CORS_ORIGIN";
+    public static final String HTTP_REQUEST_TIMEOUT = "CRYOSTAT_HTTP_REQUEST_TIMEOUT";
 
     // JMX connections configuration
     public static final String TARGET_CACHE_SIZE = "CRYOSTAT_TARGET_CACHE_SIZE";

--- a/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
@@ -105,7 +105,9 @@ class RemoteReportGenerator extends AbstractReportGeneratorService {
                             }
                             if (!HttpStatusCodeIdentifier.isSuccessCode(ar.result().statusCode())) {
                                 f.completeExceptionally(
-                                        new ReportGenerationException(ar.result().statusMessage()));
+                                        new ReportGenerationException(
+                                                ar.result().statusCode(),
+                                                ar.result().statusMessage()));
                                 return;
                             }
                             var body = ar.result().bodyAsBuffer();

--- a/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/RemoteReportGenerator.java
@@ -42,7 +42,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
-import javax.inject.Provider;
 
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
@@ -67,13 +66,12 @@ class RemoteReportGenerator extends AbstractReportGeneratorService {
     RemoteReportGenerator(
             TargetConnectionManager targetConnectionManager,
             FileSystem fs,
-            Provider<Path> tempFileProvider,
             Vertx vertx,
             WebClient http,
             Environment env,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS) long generationTimeoutSeconds,
             Logger logger) {
-        super(targetConnectionManager, fs, tempFileProvider, logger);
+        super(targetConnectionManager, fs, logger);
         this.vertx = vertx;
         this.http = http;
         this.env = env;

--- a/src/main/java/io/cryostat/net/reports/ReportGenerationException.java
+++ b/src/main/java/io/cryostat/net/reports/ReportGenerationException.java
@@ -39,11 +39,23 @@ package io.cryostat.net.reports;
 
 public class ReportGenerationException extends Exception {
 
+    private final int status;
+
     public ReportGenerationException(String message) {
-        super(message);
+        this(500, message);
     }
 
     public ReportGenerationException(String message, Throwable cause) {
         super(message, cause);
+        this.status = 500;
+    }
+
+    public ReportGenerationException(int status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public int getStatusCode() {
+        return status;
     }
 }

--- a/src/main/java/io/cryostat/net/reports/ReportsModule.java
+++ b/src/main/java/io/cryostat/net/reports/ReportsModule.java
@@ -37,9 +37,6 @@
  */
 package io.cryostat.net.reports;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Set;
 
 import javax.inject.Named;
@@ -134,25 +131,8 @@ public abstract class ReportsModule {
             Environment env,
             @Named(REPORT_GENERATION_TIMEOUT_SECONDS) long generationTimeoutSeconds,
             Logger logger) {
-        // TODO extract this so it's reusable and not duplicated
-        Provider<Path> tempFileProvider =
-                () -> {
-                    try {
-                        return Files.createTempFile(null, null);
-                    } catch (IOException e) {
-                        logger.error(e);
-                        throw new RuntimeException(e);
-                    }
-                };
         return new RemoteReportGenerator(
-                targetConnectionManager,
-                fs,
-                tempFileProvider,
-                vertx,
-                http,
-                env,
-                generationTimeoutSeconds,
-                logger);
+                targetConnectionManager, fs, vertx, http, env, generationTimeoutSeconds, logger);
     }
 
     @Provides
@@ -164,22 +144,12 @@ public abstract class ReportsModule {
             Provider<JavaProcess.Builder> javaProcessBuilder,
             @Named(REPORT_GENERATION_TIMEOUT_SECONDS) long generationTimeoutSeconds,
             Logger logger) {
-        Provider<Path> tempFileProvider =
-                () -> {
-                    try {
-                        return Files.createTempFile(null, null);
-                    } catch (IOException e) {
-                        logger.error(e);
-                        throw new RuntimeException(e);
-                    }
-                };
         return new SubprocessReportGenerator(
                 env,
                 fs,
                 targetConnectionManager,
                 reportTransformers,
                 javaProcessBuilder,
-                tempFileProvider,
                 generationTimeoutSeconds,
                 logger);
     }

--- a/src/main/java/io/cryostat/net/reports/ReportsModule.java
+++ b/src/main/java/io/cryostat/net/reports/ReportsModule.java
@@ -52,6 +52,7 @@ import io.cryostat.core.reports.ReportTransformer;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.web.http.HttpModule;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.util.JavaProcess;
 
@@ -71,10 +72,9 @@ public abstract class ReportsModule {
 
     @Provides
     @Named(REPORT_GENERATION_TIMEOUT_SECONDS)
-    static long provideReportGenerationTimeoutSeconds() {
-        // TODO make this configurable via env var? It is also related to the max HTTP response
-        // timeout that clients expect, and which usually defaults to 30 seconds
-        return 29;
+    static long provideReportGenerationTimeoutSeconds(
+            @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeout) {
+        return httpTimeout;
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
@@ -83,10 +83,9 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
             TargetConnectionManager targetConnectionManager,
             Set<ReportTransformer> reportTransformers,
             Provider<JavaProcess.Builder> javaProcessBuilderProvider,
-            Provider<Path> tempFileProvider,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS) long generationTimeoutSeconds,
             Logger logger) {
-        super(targetConnectionManager, fs, tempFileProvider, logger);
+        super(targetConnectionManager, fs, logger);
         this.env = env;
         this.reportTransformers = reportTransformers;
         this.javaProcessBuilderProvider = javaProcessBuilderProvider;

--- a/src/main/java/io/cryostat/net/web/WebModule.java
+++ b/src/main/java/io/cryostat/net/web/WebModule.java
@@ -38,7 +38,6 @@
 package io.cryostat.net.web;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -78,7 +77,7 @@ public abstract class WebModule {
     @Named(WEBSERVER_TEMP_DIR_PATH)
     static Path provideWebServerTempDirPath(FileSystem fs) {
         try {
-            return Files.createTempDirectory("cryostat").toAbsolutePath();
+            return fs.createTempDirectory("cryostat").toAbsolutePath();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/src/main/java/io/cryostat/net/web/http/HttpModule.java
+++ b/src/main/java/io/cryostat/net/web/http/HttpModule.java
@@ -37,12 +37,17 @@
  */
 package io.cryostat.net.web.http;
 
+import javax.inject.Named;
+
+import io.cryostat.configuration.Variables;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.net.web.http.api.beta.HttpApiBetaModule;
 import io.cryostat.net.web.http.api.v1.HttpApiV1Module;
 import io.cryostat.net.web.http.api.v2.HttpApiV2Module;
 import io.cryostat.net.web.http.generic.HttpGenericModule;
 
 import dagger.Module;
+import dagger.Provides;
 
 @Module(
         includes = {
@@ -51,4 +56,13 @@ import dagger.Module;
             HttpApiV1Module.class,
             HttpApiV2Module.class,
         })
-public abstract class HttpModule {}
+public abstract class HttpModule {
+
+    public static final String HTTP_REQUEST_TIMEOUT_SECONDS = "HTTP_REQUEST_TIMEOUT_SECONDS";
+
+    @Provides
+    @Named(HTTP_REQUEST_TIMEOUT_SECONDS)
+    static long provideReportGenerationTimeoutSeconds(Environment env) {
+        return Integer.valueOf(env.getEnv(Variables.HTTP_REQUEST_TIMEOUT, "29"));
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/HttpModule.java
+++ b/src/main/java/io/cryostat/net/web/http/HttpModule.java
@@ -63,6 +63,6 @@ public abstract class HttpModule {
     @Provides
     @Named(HTTP_REQUEST_TIMEOUT_SECONDS)
     static long provideReportGenerationTimeoutSeconds(Environment env) {
-        return Integer.valueOf(env.getEnv(Variables.HTTP_REQUEST_TIMEOUT, "29"));
+        return Long.parseLong(env.getEnv(Variables.HTTP_REQUEST_TIMEOUT, "29"));
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
@@ -49,6 +49,7 @@ import javax.inject.Named;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
+import io.cryostat.net.reports.ReportGenerationException;
 import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.reports.ReportsModule;
 import io.cryostat.net.security.ResourceAction;
@@ -126,6 +127,11 @@ class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
                     .putHeader(HttpHeaders.CONTENT_LENGTH, Long.toString(report.toFile().length()));
             ctx.response().sendFile(report.toAbsolutePath().toString());
         } catch (ExecutionException | CompletionException ee) {
+            if (ExceptionUtils.getRootCause(ee) instanceof ReportGenerationException) {
+                ReportGenerationException rge =
+                        (ReportGenerationException) ExceptionUtils.getRootCause(ee);
+                throw new HttpStatusException(rge.getStatusCode(), ee.getMessage());
+            }
             if (ExceptionUtils.getRootCause(ee) instanceof RecordingNotFoundException) {
                 throw new HttpStatusException(404, ee);
             }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -40,7 +40,6 @@ package io.cryostat.net.web.http.api.v1;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.EnumSet;
@@ -214,8 +213,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
                 .map(
                         descriptor -> {
                             try {
-                                // FIXME extract createTempFile wrapper into FileSystem
-                                Path tempFile = Files.createTempFile(null, null);
+                                Path tempFile = fs.createTempFile(null, null);
                                 try (InputStream stream =
                                         connection.getService().openStream(descriptor, false)) {
                                     fs.copy(stream, tempFile, StandardCopyOption.REPLACE_EXISTING);

--- a/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
+++ b/src/test/java/io/cryostat/net/reports/ActiveRecordingReportCacheTest.java
@@ -76,7 +76,6 @@ class ActiveRecordingReportCacheTest {
     @Mock Path destinationFile;
     @Mock JavaProcess.Builder javaProcessBuilder;
     Provider<JavaProcess.Builder> javaProcessBuilderProvider = () -> javaProcessBuilder;
-    Provider<Path> tempFileProvider = () -> destinationFile;
     final String REPORT_DOC = "<html><body><p>This is a report</p></body></html>";
 
     @BeforeEach

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -93,8 +93,10 @@ class SubprocessReportGeneratorTest {
                 new ConnectionDescriptor("fooHost:1234", new Credentials("someUser", "somePass"));
         recordingDescriptor = new RecordingDescriptor(connectionDescriptor, "testRecording");
 
-        tempFileProvider = Mockito.mock(Provider.class);
-        Mockito.lenient().when(tempFileProvider.get()).thenReturn(tempFile1).thenReturn(tempFile2);
+        Mockito.lenient()
+                .when(fs.createTempFile(null, null))
+                .thenReturn(tempFile1)
+                .thenReturn(tempFile2);
         Mockito.lenient().when(tempFile1.toAbsolutePath()).thenReturn(tempFile1);
         Mockito.lenient().when(tempFile1.toString()).thenReturn("/tmp/file1.tmp");
         Mockito.lenient().when(tempFile2.toAbsolutePath()).thenReturn(tempFile2);
@@ -128,7 +130,6 @@ class SubprocessReportGeneratorTest {
                         targetConnectionManager,
                         Set.of(new TestReportTransformer()),
                         () -> javaProcessBuilder,
-                        tempFileProvider,
                         30,
                         logger);
     }

--- a/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/net/reports/SubprocessReportGeneratorTest.java
@@ -46,8 +46,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Provider;
-
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.core.reports.ReportTransformer;
@@ -84,7 +82,6 @@ class SubprocessReportGeneratorTest {
     @Mock Path recordingFile;
     @Mock Path tempFile1;
     @Mock Path tempFile2;
-    @Mock Provider<Path> tempFileProvider;
     SubprocessReportGenerator generator;
 
     @BeforeEach
@@ -279,7 +276,7 @@ class SubprocessReportGeneratorTest {
                         new Answer<Path>() {
                             @Override
                             public Path answer(InvocationOnMock invocation) throws Throwable {
-                                return tempFileProvider.get();
+                                return fs.createTempFile(null, null);
                             }
                         });
 
@@ -300,7 +297,7 @@ class SubprocessReportGeneratorTest {
                         new Answer<Path>() {
                             @Override
                             public Path answer(InvocationOnMock invocation) throws Throwable {
-                                return tempFileProvider.get();
+                                return fs.createTempFile(null, null);
                             }
                         });
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -89,7 +89,8 @@ class RecordingUploadPostHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingUploadPostHandler(auth, env, webClient, recordingArchiveHelper);
+        this.handler =
+                new RecordingUploadPostHandler(auth, env, 30, webClient, recordingArchiveHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.web.http.api.v1;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -193,6 +194,9 @@ class TargetRecordingUploadPostHandlerTest {
 
     @Test
     void shouldDoUpload() throws Exception {
+        Path tempFile = Mockito.mock(Path.class);
+        Mockito.when(fs.createTempFile(null, null)).thenReturn(tempFile);
+
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(
@@ -259,6 +263,9 @@ class TargetRecordingUploadPostHandlerTest {
 
     @Test
     void shouldHandleInvalidResponseStatusCode() throws Exception {
+        Path tempFile = Mockito.mock(Path.class);
+        Mockito.when(fs.createTempFile(null, null)).thenReturn(tempFile);
+
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(
@@ -328,6 +335,9 @@ class TargetRecordingUploadPostHandlerTest {
 
     @Test
     void shouldHandleNullStatusMessage() throws Exception {
+        Path tempFile = Mockito.mock(Path.class);
+        Mockito.when(fs.createTempFile(null, null)).thenReturn(tempFile);
+
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(
@@ -397,6 +407,9 @@ class TargetRecordingUploadPostHandlerTest {
 
     @Test
     void shouldHandleNullResponseBody() throws Exception {
+        Path tempFile = Mockito.mock(Path.class);
+        Mockito.when(fs.createTempFile(null, null)).thenReturn(tempFile);
+
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -104,7 +104,7 @@ class TargetRecordingUploadPostHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingUploadPostHandler(
-                        auth, env, targetConnectionManager, webClient, fs);
+                        auth, env, targetConnectionManager, 30, webClient, fs);
     }
 
     @Test


### PR DESCRIPTION
Fixes #795
Fixes #567
Depends on https://github.com/cryostatio/cryostat-core/issues/113

Easy way to test: modify `smoketest.sh` similarly to the `-reports` `run.sh` (https://github.com/cryostatio/cryostat-reports/blob/3237998ca88710a5537b13d0bd4f742caf8b32d4/run.sh#L33). Add `-Dio.cryostat.reports.memory-factor=${MEMORY_FACTOR}` or `-Dio.cryostat.reports.timeout=${TIMEOUT}` to the `smoketest.sh` `JAVA_OPTIONS` for the report generator container with `${MEMORY_FACTOR}`/`${TIMEOUT}` replaced with some reduced value to induce a 413/504 response from the report sidecar. Then make a report request through the Cryostat HTTP API as usual (`GET /api/v1/recordings/foo` or `GET /api/v1/targets/foo/reports/bar`).