### PR TITLE
fix(notifications): emit detailed recording info

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -40,6 +40,9 @@ package io.cryostat.net.web.http.api.v1;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.SocketException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
@@ -50,6 +53,7 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.internal.FlightRecordingLoader;
@@ -62,9 +66,11 @@ import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.rules.ArchivedRecordingInfo;
 
 import com.google.gson.Gson;
 import io.vertx.core.AsyncResult;
@@ -87,8 +93,9 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     private final FileSystem fs;
     private final Path savedRecordingsPath;
     private final Gson gson;
-    private final Logger logger;
     private final NotificationFactory notificationFactory;
+    private final Provider<WebServer> webServer;
+    private final Logger logger;
 
     private static final String NOTIFICATION_CATEGORY = "RecordingSaved";
 
@@ -99,15 +106,17 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
             FileSystem fs,
             @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
             Gson gson,
-            Logger logger,
-            NotificationFactory notificationFactory) {
+            NotificationFactory notificationFactory,
+            Provider<WebServer> webServer,
+            Logger logger) {
         super(auth);
         this.vertx = httpServer.getVertx();
         this.fs = fs;
         this.savedRecordingsPath = savedRecordingsPath;
         this.gson = gson;
-        this.logger = logger;
         this.notificationFactory = notificationFactory;
+        this.webServer = webServer;
+        this.logger = logger;
     }
 
     @Override
@@ -206,19 +215,39 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                                         return;
                                     }
 
+                                    String fsName = res2.result();
                                     ctx.response()
                                             .putHeader(
                                                     HttpHeaders.CONTENT_TYPE,
                                                     HttpMimeType.JSON.mime())
-                                            .end(gson.toJson(Map.of("name", res2.result())));
+                                            .end(gson.toJson(Map.of("name", fsName)));
 
-                                    notificationFactory
-                                            .createBuilder()
-                                            .metaCategory(NOTIFICATION_CATEGORY)
-                                            .metaType(HttpMimeType.JSON)
-                                            .message(Map.of("recording", res2.result()))
-                                            .build()
-                                            .send();
+                                    try {
+                                        notificationFactory
+                                                .createBuilder()
+                                                .metaCategory(NOTIFICATION_CATEGORY)
+                                                .metaType(HttpMimeType.JSON)
+                                                .message(
+                                                        Map.of(
+                                                                "recording",
+                                                                new ArchivedRecordingInfo(
+                                                                        "archive",
+                                                                        fsName,
+                                                                        webServer
+                                                                                .get()
+                                                                                .getArchivedDownloadURL(
+                                                                                        fsName),
+                                                                        webServer
+                                                                                .get()
+                                                                                .getArchivedReportURL(
+                                                                                        fsName))))
+                                                .build()
+                                                .send();
+                                    } catch (UnknownHostException
+                                            | SocketException
+                                            | URISyntaxException e) {
+                                        logger.error(e);
+                                    }
                                 }));
     }
 
@@ -259,6 +288,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                 });
     }
 
+    // FIXME refactor into RecordingArchiveHelper
     private void saveRecording(
             String subdirectoryName,
             String basename,

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -97,7 +97,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     private final Provider<WebServer> webServer;
     private final Logger logger;
 
-    private static final String NOTIFICATION_CATEGORY = "RecordingSaved";
+    private static final String NOTIFICATION_CATEGORY = "ArchivedRecordingCreated";
 
     @Inject
     RecordingsPostHandler(

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -61,7 +61,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
 
-    private static final String RECORDING_DELETION_NOTIFICATION_CATEGORY = "RecordingDeleted";
+    private static final String RECORDING_DELETION_NOTIFICATION_CATEGORY = "ActiveRecordingDeleted";
 
     private final RecordingTargetHelper recordingTargetHelper;
     private final NotificationFactory notificationFactory;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
@@ -64,7 +64,10 @@ class TargetRecordingPatchSave {
 
         try {
             String saveName =
-                    recordingArchiveHelper.saveRecording(connectionDescriptor, recordingName).get();
+                    recordingArchiveHelper
+                            .saveRecording(connectionDescriptor, recordingName)
+                            .get()
+                            .getName();
             ctx.response().end(saveName);
         } catch (ExecutionException e) {
             if (ExceptionUtils.getRootCause(e) instanceof RecordingNotFoundException) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -144,17 +144,8 @@ public class RecordingArchiveHelper {
                             },
                             false);
             Path parentPath = savePath.getParent();
-            if (parentPath == null) {
-                throw new IOException(
-                        String.format(
-                                "Filesystem parent for %s could not be determined", recordingName));
-            }
             Path filenamePath = savePath.getFileName();
-            if (filenamePath == null) {
-                throw new IOException(
-                        String.format(
-                                "Filesystem path for %s could not be determined", recordingName));
-            }
+            validateSavePath(recordingName, parentPath, filenamePath);
             String filename = filenamePath.toString();
             ArchivedRecordingInfo archivedRecordingInfo =
                     new ArchivedRecordingInfo(
@@ -190,17 +181,8 @@ public class RecordingArchiveHelper {
             Path archivedRecording = getRecordingPath(recordingName).get();
             fs.deleteIfExists(archivedRecording);
             Path parentPath = archivedRecording.getParent();
-            if (parentPath == null) {
-                throw new IOException(
-                        String.format(
-                                "Filesystem parent for %s could not be determined", recordingName));
-            }
             Path filenamePath = archivedRecording.getFileName();
-            if (filenamePath == null) {
-                throw new IOException(
-                        String.format(
-                                "Filesystem path for %s could not be determined", recordingName));
-            }
+            validateSavePath(recordingName, filenamePath, filenamePath);
             String filename = filenamePath.toString();
             ArchivedRecordingInfo archivedRecordingInfo =
                     new ArchivedRecordingInfo(
@@ -223,6 +205,19 @@ public class RecordingArchiveHelper {
         }
 
         return future;
+    }
+
+    private void validateSavePath(String recordingName, Path parentPath, Path filenamePath)
+            throws IOException {
+        if (parentPath == null) {
+            throw new IOException(
+                    String.format(
+                            "Filesystem parent for %s could not be determined", recordingName));
+        }
+        if (filenamePath == null) {
+            throw new IOException(
+                    String.format("Filesystem path for %s could not be determined", recordingName));
+        }
     }
 
     public boolean deleteReport(String recordingName) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -143,10 +143,22 @@ public class RecordingArchiveHelper {
                                 }
                             },
                             false);
-            String filename = savePath.getFileName().toString();
+            Path parentPath = savePath.getParent();
+            if (parentPath == null) {
+                throw new IOException(
+                        String.format(
+                                "Filesystem parent for %s could not be determined", recordingName));
+            }
+            Path filenamePath = savePath.getFileName();
+            if (filenamePath == null) {
+                throw new IOException(
+                        String.format(
+                                "Filesystem path for %s could not be determined", recordingName));
+            }
+            String filename = filenamePath.toString();
             ArchivedRecordingInfo archivedRecordingInfo =
                     new ArchivedRecordingInfo(
-                            savePath.getParent().toString(),
+                            parentPath.toString(),
                             filename,
                             webServerProvider.get().getArchivedDownloadURL(filename),
                             webServerProvider.get().getArchivedReportURL(filename));
@@ -177,10 +189,22 @@ public class RecordingArchiveHelper {
         try {
             Path archivedRecording = getRecordingPath(recordingName).get();
             fs.deleteIfExists(archivedRecording);
-            String filename = archivedRecording.getFileName().toString();
+            Path parentPath = archivedRecording.getParent();
+            if (parentPath == null) {
+                throw new IOException(
+                        String.format(
+                                "Filesystem parent for %s could not be determined", recordingName));
+            }
+            Path filenamePath = archivedRecording.getFileName();
+            if (filenamePath == null) {
+                throw new IOException(
+                        String.format(
+                                "Filesystem path for %s could not be determined", recordingName));
+            }
+            String filename = filenamePath.toString();
             ArchivedRecordingInfo archivedRecordingInfo =
                     new ArchivedRecordingInfo(
-                            archivedRecording.getParent().toString(),
+                            parentPath.toString(),
                             filename,
                             webServerProvider.get().getArchivedDownloadURL(filename),
                             webServerProvider.get().getArchivedReportURL(filename));

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -295,7 +295,7 @@ public class RecordingArchiveHelper {
         return null;
     }
 
-    public String writeRecordingToDestination(
+    String writeRecordingToDestination(
             JFRConnection connection, IRecordingDescriptor descriptor)
             throws IOException, URISyntaxException, FlightRecorderException, Exception {
         URI serviceUri = URIUtil.convert(connection.getJMXURL());

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -231,8 +231,8 @@ public class RecordingArchiveHelper {
                                             try {
                                                 return new ArchivedRecordingInfo(
                                                         subdirectory,
-                                                        webServer.getArchivedDownloadURL(file),
                                                         file,
+                                                        webServer.getArchivedDownloadURL(file),
                                                         webServer.getArchivedReportURL(file));
                                             } catch (SocketException
                                                     | UnknownHostException

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -95,8 +95,8 @@ public class RecordingArchiveHelper {
     private final NotificationFactory notificationFactory;
     private final Base32 base32;
 
-    private static final String SAVE_NOTIFICATION_CATEGORY = "RecordingArchived";
-    private static final String DELETE_NOTIFICATION_CATEGORY = "RecordingDeleted";
+    private static final String SAVE_NOTIFICATION_CATEGORY = "ActiveRecordingSaved";
+    private static final String DELETE_NOTIFICATION_CATEGORY = "ArchivedRecordingDeleted";
 
     RecordingArchiveHelper(
             FileSystem fs,

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -77,7 +77,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public class RecordingTargetHelper {
 
-    private static final String CREATE_NOTIFICATION_CATEGORY = "RecordingCreated";
+    private static final String CREATE_NOTIFICATION_CATEGORY = "ActiveRecordingCreated";
     private static final String STOP_NOTIFICATION_CATEGORY = "RecordingStopped";
     private static final long TIMESTAMP_DRIFT_SAFEGUARD = 3_000L;
 

--- a/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
+++ b/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
@@ -47,10 +47,10 @@ public class ArchivedRecordingInfo {
     private final String reportUrl;
 
     public ArchivedRecordingInfo(
-            String encodedServiceUri, String downloadUrl, String name, String reportUrl) {
+            String encodedServiceUri, String name, String downloadUrl, String reportUrl) {
         this.encodedServiceUri = encodedServiceUri;
-        this.downloadUrl = downloadUrl;
         this.name = name;
+        this.downloadUrl = downloadUrl;
         this.reportUrl = reportUrl;
     }
 
@@ -58,12 +58,12 @@ public class ArchivedRecordingInfo {
         return this.encodedServiceUri;
     }
 
-    public String getDownloadUrl() {
-        return this.downloadUrl;
-    }
-
     public String getName() {
         return this.name;
+    }
+
+    public String getDownloadUrl() {
+        return this.downloadUrl;
     }
 
     public String getReportUrl() {
@@ -85,8 +85,8 @@ public class ArchivedRecordingInfo {
         return new EqualsBuilder()
                 .append(encodedServiceUri, ari.encodedServiceUri)
                 .append(name, ari.name)
-                .append(reportUrl, ari.reportUrl)
                 .append(downloadUrl, ari.downloadUrl)
+                .append(reportUrl, ari.reportUrl)
                 .isEquals();
     }
 
@@ -95,8 +95,8 @@ public class ArchivedRecordingInfo {
         return new HashCodeBuilder()
                 .append(encodedServiceUri)
                 .append(name)
-                .append(reportUrl)
                 .append(downloadUrl)
+                .append(reportUrl)
                 .hashCode();
     }
 }

--- a/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
+++ b/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
@@ -41,6 +41,19 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class ArchivedRecordingInfo {
+    @Override
+    public String toString() {
+        return "ArchivedRecordingInfo [downloadUrl="
+                + downloadUrl
+                + ", encodedServiceUri="
+                + encodedServiceUri
+                + ", name="
+                + name
+                + ", reportUrl="
+                + reportUrl
+                + "]";
+    }
+
     private final transient String encodedServiceUri;
     private final String downloadUrl;
     private final String name;

--- a/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
+++ b/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
@@ -41,18 +41,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class ArchivedRecordingInfo {
-    @Override
-    public String toString() {
-        return "ArchivedRecordingInfo [downloadUrl="
-                + downloadUrl
-                + ", encodedServiceUri="
-                + encodedServiceUri
-                + ", name="
-                + name
-                + ", reportUrl="
-                + reportUrl
-                + "]";
-    }
 
     private final transient String encodedServiceUri;
     private final String downloadUrl;

--- a/src/main/java/io/cryostat/rules/PeriodicArchiver.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiver.java
@@ -150,9 +150,9 @@ class PeriodicArchiver implements Runnable {
         ConnectionDescriptor connectionDescriptor =
                 new ConnectionDescriptor(serviceRef, credentialsManager.getCredentials(serviceRef));
 
-        String saveName =
+        ArchivedRecordingInfo archivedRecordingInfo =
                 recordingArchiveHelper.saveRecording(connectionDescriptor, recordingName).get();
-        previousRecordings.add(saveName);
+        previousRecordings.add(archivedRecordingInfo.getName());
     }
 
     private void pruneArchive(String recordingName) throws Exception {

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.net.web.http.api.v1;
 
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -46,6 +45,7 @@ import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
+import io.cryostat.rules.ArchivedRecordingInfo;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
@@ -99,7 +99,7 @@ class RecordingDeleteHandlerTest {
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
 
-        CompletableFuture<Path> future = Mockito.mock(CompletableFuture.class);
+        CompletableFuture<ArchivedRecordingInfo> future = Mockito.mock(CompletableFuture.class);
         Mockito.when(recordingArchiveHelper.deleteRecording(Mockito.any())).thenReturn(future);
         ExecutionException e = Mockito.mock(ExecutionException.class);
         Mockito.when(future.get()).thenThrow(e);
@@ -126,7 +126,7 @@ class RecordingDeleteHandlerTest {
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
-        CompletableFuture<Path> future = Mockito.mock(CompletableFuture.class);
+        CompletableFuture<ArchivedRecordingInfo> future = Mockito.mock(CompletableFuture.class);
         Mockito.when(recordingArchiveHelper.deleteRecording(recordingName)).thenReturn(future);
 
         handler.handle(ctx);

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
@@ -131,8 +131,8 @@ class RecordingsGetHandlerTest {
                 List.of(
                         new ArchivedRecordingInfo(
                                 "encodedServiceUriFoo",
-                                "/some/path/download/recordingFoo",
                                 "recordingFoo",
+                                "/some/path/download/recordingFoo",
                                 "/some/path/archive/recordingFoo")));
         Mockito.when(recordingArchiveHelper.getRecordings()).thenReturn(listFuture);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -301,7 +301,7 @@ class RecordingsPostHandlerTest {
                         "/some/report/path/" + filename);
         ArgumentCaptor<Map<String, Object>> messageCaptor = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingSaved");
+        Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingCreated");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(messageCaptor.capture());
         Mockito.verify(notificationBuilder).build();

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
@@ -137,7 +137,7 @@ class TargetRecordingDeleteHandlerTest {
         handler.handleAuthenticated(ctx);
 
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingDeleted");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingDeleted");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder)
                 .message(Map.of("recording", "someRecording", "target", "someTarget"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSaveTest.java
@@ -53,6 +53,7 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.recordings.EmptyRecordingException;
 import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.rules.ArchivedRecordingInfo;
 
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
@@ -97,8 +98,10 @@ class TargetRecordingPatchSaveTest {
         Instant now = Instant.now();
         String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
 
-        CompletableFuture<String> future = new CompletableFuture<>();
-        future.complete("some-Alias-2_someRecording_" + timestamp + ".jfr");
+        CompletableFuture<ArchivedRecordingInfo> future = new CompletableFuture<>();
+        ArchivedRecordingInfo info = Mockito.mock(ArchivedRecordingInfo.class);
+        Mockito.when(info.getName()).thenReturn("some-Alias-2_someRecording_" + timestamp + ".jfr");
+        future.complete(info);
         Mockito.when(recordingArchiveHelper.saveRecording(Mockito.any(), Mockito.any()))
                 .thenReturn(future);
 

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -250,7 +250,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
@@ -329,7 +329,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder)
                 .message(
@@ -418,7 +418,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
@@ -495,7 +495,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
@@ -578,7 +578,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
@@ -712,7 +712,7 @@ class RecordingArchiveHelperTest {
         MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingSaved");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
@@ -770,7 +770,7 @@ class RecordingArchiveHelperTest {
 
         Mockito.verify(fs, Mockito.times(2)).deleteIfExists(Mockito.any());
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingDeleted");
+        Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingDeleted");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder).message(messageCaptor.capture());
         Mockito.verify(notificationBuilder).build();

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -823,13 +823,13 @@ class RecordingArchiveHelperTest {
                 List.of(
                         new ArchivedRecordingInfo(
                                 "encodedServiceUriA",
-                                "/some/path/download/recordingA",
                                 "recordingA",
+                                "/some/path/download/recordingA",
                                 "/some/path/archive/recordingA"),
                         new ArchivedRecordingInfo(
                                 "encodedServiceUri123",
-                                "/some/path/download/123recording",
                                 "123recording",
+                                "/some/path/download/123recording",
                                 "/some/path/archive/123recording"));
         MatcherAssert.assertThat(result, Matchers.equalTo(expected));
     }

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -233,26 +233,26 @@ class RecordingArchiveHelperTest {
                 .thenReturn(specificRecordingsPath);
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String savedName = "some-hostname-local_someRecording_" + timestamp + ".jfr";
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
 
-        String saveName =
+        ArchivedRecordingInfo info =
                 recordingArchiveHelper
                         .saveRecording(new ConnectionDescriptor(targetId), recordingName)
                         .get();
 
-        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        MatcherAssert.assertThat(
-                saveName, Matchers.equalTo("some-Alias-2_someRecording_" + timestamp + ".jfr"));
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-        Mockito.verify(notificationBuilder)
-                .message(
-                        Map.of(
-                                "recording",
-                                "some-Alias-2_someRecording_" + timestamp + ".jfr",
-                                "target",
-                                targetId));
+        Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
         Mockito.verify(notification).send();
     }
@@ -308,19 +308,25 @@ class RecordingArchiveHelperTest {
                 .thenReturn(specificRecordingsPath);
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
-
-        String saveName =
-                recordingArchiveHelper
-                        .saveRecording(new ConnectionDescriptor(serviceRef1), recordingName)
-                        .get();
-
         String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        String recordingName =
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        String savedName =
                 URLEncoder.encode(alias.replaceAll("[\\._]+", "-"), StandardCharsets.UTF_8)
                         + "_someRecording_"
                         + timestamp
                         + ".jfr";
-        MatcherAssert.assertThat(saveName, Matchers.equalTo(recordingName));
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
+
+        ArchivedRecordingInfo info =
+                recordingArchiveHelper
+                        .saveRecording(new ConnectionDescriptor(serviceRef1), recordingName)
+                        .get();
+
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
@@ -329,7 +335,7 @@ class RecordingArchiveHelperTest {
                 .message(
                         Map.of(
                                 "recording",
-                                recordingName,
+                                info,
                                 "target",
                                 serviceRef1.getServiceUri().toString()));
         Mockito.verify(notificationBuilder).build();
@@ -395,27 +401,26 @@ class RecordingArchiveHelperTest {
                 .thenReturn(specificRecordingsPath);
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String savedName = "some-hostname-local_someRecording_" + timestamp + ".jfr";
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
 
-        String saveName =
+        ArchivedRecordingInfo info =
                 recordingArchiveHelper
                         .saveRecording(new ConnectionDescriptor(targetId), recordingName)
                         .get();
 
-        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        MatcherAssert.assertThat(
-                saveName,
-                Matchers.equalTo("some-hostname-local_someRecording_" + timestamp + ".jfr"));
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-        Mockito.verify(notificationBuilder)
-                .message(
-                        Map.of(
-                                "recording",
-                                "some-hostname-local_someRecording_" + timestamp + ".jfr",
-                                "target",
-                                targetId));
+        Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
         Mockito.verify(notification).send();
     }
@@ -471,29 +476,28 @@ class RecordingArchiveHelperTest {
         Path specificRecordingsPath = Mockito.mock(Path.class);
         Mockito.when(archivedRecordingsPath.resolve(Mockito.anyString()))
                 .thenReturn(specificRecordingsPath);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String savedName = "some-hostname-local_someRecording_" + timestamp + ".jfr";
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
 
-        String saveName =
+        ArchivedRecordingInfo info =
                 recordingArchiveHelper
                         .saveRecording(new ConnectionDescriptor(targetId), recordingName)
                         .get();
 
-        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        MatcherAssert.assertThat(
-                saveName,
-                Matchers.equalTo("some-hostname-local_someRecording_" + timestamp + ".jfr"));
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-        Mockito.verify(notificationBuilder)
-                .message(
-                        Map.of(
-                                "recording",
-                                "some-hostname-local_someRecording_" + timestamp + ".jfr",
-                                "target",
-                                targetId));
+        Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
         Mockito.verify(notification).send();
     }
@@ -557,26 +561,26 @@ class RecordingArchiveHelperTest {
                 .thenReturn(specificRecordingsPath);
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String savedName = "some-hostname-local_someRecording_" + timestamp + ".jfr";
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
 
-        String saveName =
+        ArchivedRecordingInfo info =
                 recordingArchiveHelper
                         .saveRecording(new ConnectionDescriptor(targetId), recordingName)
                         .get();
 
-        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        MatcherAssert.assertThat(
-                saveName, Matchers.equalTo("some-Alias-2_someRecording_" + timestamp + ".jfr"));
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-        Mockito.verify(notificationBuilder)
-                .message(
-                        Map.of(
-                                "recording",
-                                "some-Alias-2_someRecording_" + timestamp + ".jfr",
-                                "target",
-                                targetId));
+        Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
         Mockito.verify(notification).send();
     }
@@ -691,26 +695,26 @@ class RecordingArchiveHelperTest {
                 .thenReturn(specificRecordingsPath);
         Path destination = Mockito.mock(Path.class);
         Mockito.when(specificRecordingsPath.resolve(Mockito.anyString())).thenReturn(destination);
+        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
+        String savedName = "some-hostname-local_someRecording_" + timestamp + ".jfr";
+        Path filenamePath = Mockito.mock(Path.class);
+        Path parentPath = Mockito.mock(Path.class);
+        Mockito.when(destination.getParent()).thenReturn(parentPath);
+        Mockito.when(parentPath.toString()).thenReturn("/some/storage/");
+        Mockito.when(filenamePath.toString()).thenReturn(savedName);
+        Mockito.when(destination.getFileName()).thenReturn(filenamePath);
 
-        String saveName =
+        ArchivedRecordingInfo info =
                 recordingArchiveHelper
                         .saveRecording(new ConnectionDescriptor(targetId), recordingName)
                         .get();
 
-        String timestamp = now.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]+", "");
-        MatcherAssert.assertThat(
-                saveName, Matchers.equalTo("some-Alias-2_someRecording_" + timestamp + ".1.jfr"));
+        MatcherAssert.assertThat(info.getName(), Matchers.equalTo(savedName));
         Mockito.verify(fs).copy(Mockito.isA(BufferedInputStream.class), Mockito.eq(destination));
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("RecordingArchived");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-        Mockito.verify(notificationBuilder)
-                .message(
-                        Map.of(
-                                "recording",
-                                "some-Alias-2_someRecording_" + timestamp + ".1.jfr",
-                                "target",
-                                targetId));
+        Mockito.verify(notificationBuilder).message(Map.of("recording", info, "target", targetId));
         Mockito.verify(notificationBuilder).build();
         Mockito.verify(notification).send();
     }

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -492,7 +492,7 @@ public class RecordingTargetHelperTest {
                 false, connectionDescriptor, recordingOptions, templateName, templateType);
 
         Mockito.verify(notificationFactory).createBuilder();
-        Mockito.verify(notificationBuilder).metaCategory("RecordingCreated");
+        Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingCreated");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
         Mockito.verify(notificationBuilder)
                 .message(Map.of("recording", recordingName, "target", targetId));

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -38,7 +38,6 @@
 package io.cryostat.rules;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -168,10 +167,9 @@ class PeriodicArchiverTest {
         Mockito.when(recordingArchiveHelper.saveRecording(Mockito.any(), Mockito.anyString()))
                 .thenReturn(stringFuture);
 
-        CompletableFuture<Path> pathFuture = new CompletableFuture<>();
-        pathFuture.complete(Path.of("/some/path"));
-        Mockito.when(recordingArchiveHelper.deleteRecording(Mockito.anyString()))
-                .thenReturn(pathFuture);
+        CompletableFuture<ArchivedRecordingInfo> infoFuture = new CompletableFuture<>();
+        infoFuture.complete(Mockito.mock(ArchivedRecordingInfo.class));
+        Mockito.when(recordingArchiveHelper.deleteRecording(Mockito.any())).thenReturn(infoFuture);
 
         // get the archiver into a state where it has reached its limit of preserved recordings
         for (int i = 0; i < rule.getPreservedArchives(); i++) {
@@ -183,8 +181,7 @@ class PeriodicArchiverTest {
         Mockito.verify(credentialsManager, Mockito.times(3)).getCredentials(serviceRef);
         Mockito.verify(recordingArchiveHelper, Mockito.times(3))
                 .saveRecording(Mockito.any(), Mockito.anyString());
-        Mockito.verify(recordingArchiveHelper, Mockito.times(1))
-                .deleteRecording(Mockito.anyString());
+        Mockito.verify(recordingArchiveHelper, Mockito.times(1)).deleteRecording(Mockito.any());
     }
 
     @Test

--- a/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
+++ b/src/test/java/io/cryostat/rules/PeriodicArchiverTest.java
@@ -201,23 +201,23 @@ class PeriodicArchiverTest {
                 List.of(
                         new ArchivedRecordingInfo(
                                 encodedServiceUri,
-                                "/some/path/download/recordingFoo",
                                 "targetFoo_recordingFoo_20210101T202547Z.jfr",
+                                "/some/path/download/recordingFoo",
                                 "/some/path/archive/recordingFoo"),
                         new ArchivedRecordingInfo(
                                 "encodedServiceUriA",
-                                "/some/path/download/recordingA",
                                 "targetA_recordingA_20190801T202547Z.jfr",
+                                "/some/path/download/recordingA",
                                 "/some/path/archive/recordingA"),
                         new ArchivedRecordingInfo(
                                 "encodedServiceUri123",
-                                "/some/path/download/123recording",
                                 "target123_123recording_20211107T202547Z.jfr",
+                                "/some/path/download/123recording",
                                 "/some/path/archive/123recording"),
                         new ArchivedRecordingInfo(
                                 encodedServiceUri,
-                                String.format("/some/path/download/%s", rule.getRecordingName()),
                                 matchingFileName,
+                                String.format("/some/path/download/%s", rule.getRecordingName()),
                                 String.format("/some/path/archive/%s", rule.getRecordingName()))));
         Mockito.when(recordingArchiveHelper.getRecordings()).thenReturn(listFuture);
 

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -274,7 +274,9 @@ class RuleProcessorTest {
         Mockito.when(registry.getRules(serviceRef)).thenReturn(Set.of(rule));
 
         Mockito.when(recordingArchiveHelper.saveRecording(Mockito.any(), Mockito.any()))
-                .thenReturn(CompletableFuture.completedFuture("unusedPath"));
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                Mockito.mock(ArchivedRecordingInfo.class)));
 
         processor.accept(tde);
 


### PR DESCRIPTION
When an recording is archived, an archived recording is deleted, or a recording is re-uploaded into the archive, emit a notification containing an `ArchivedRecordingInfo` object (name, downloadUrl, reportUrl) instead of only the archived recording name.

Related to https://github.com/cryostatio/cryostat-web/issues/344
Depends on https://github.com/cryostatio/cryostat-web/pull/366