### PR TITLE
chore(graphql): rename mutations and a query

### DIFF
--- a/GRAPHQL.md
+++ b/GRAPHQL.md
@@ -68,13 +68,13 @@ content-type: application/json
         "alias": "org.codehaus.plexus.classworlds.launcher.Launcher",
         "annotations": {
             "cryostat": {
-                "HOST": "vengeance",
+                "HOST": "localhost",
                 "JAVA_MAIN": "org.codehaus.plexus.classworlds.launcher.Launcher",
                 "PORT": "9091"
             },
             "platform": {}
         },
-        "connectUrl": "service:jmx:rmi:///jndi/rmi://vengeance:9091/jmxrmi",
+        "connectUrl": "service:jmx:rmi:///jndi/rmi://localhost/jmxrmi",
         "labels": {}
     }
 ]
@@ -115,11 +115,11 @@ content-type: application/json
             },
             {
                 "labels": {},
-                "name": "service:jmx:rmi:///jndi/rmi://vengeance:9091/jmxrmi",
+                "name": "service:jmx:rmi:///jndi/rmi://localhost/jmxrmi",
                 "nodeType": "JVM",
                 "target": {
                     "alias": "org.codehaus.plexus.classworlds.launcher.Launcher",
-                    "serviceUri": "service:jmx:rmi:///jndi/rmi://vengeance:9091/jmxrmi"
+                    "serviceUri": "service:jmx:rmi:///jndi/rmi://localhost/jmxrmi"
                 }
             }
         ]

--- a/graphql/environment-nodes-query-1.graphql
+++ b/graphql/environment-nodes-query-1.graphql
@@ -1,7 +1,7 @@
 query {
     environmentNodes(filter: { nodeName: "JDP" }) {
         descendantTargets {
-            startRecording(recording: {
+            doStartRecording(recording: {
                 name: "foo",
                 template: "Profiling",
                 templateType: "TARGET",

--- a/graphql/environment-nodes-query-2.graphql
+++ b/graphql/environment-nodes-query-2.graphql
@@ -1,7 +1,7 @@
 query {
     environmentNodes(filter: { nodeName: "JDP" }) {
         descendantTargets {
-            startRecording(recording: {
+            doStartRecording(recording: {
                 name: "bar",
                 template: "Continuous",
                 templateType: "TARGET",

--- a/graphql/environment-nodes-query-4.graphql
+++ b/graphql/environment-nodes-query-4.graphql
@@ -7,7 +7,7 @@ query {
             }
             recordings {
                 active {
-                    archive {
+                    doArchive {
                         name
                     }
                 }

--- a/graphql/environment-nodes-query-4.graphql
+++ b/graphql/environment-nodes-query-4.graphql
@@ -1,7 +1,7 @@
 query {
     environmentNodes(filter: { nodeName: "JDP" }) {
         descendantTargets {
-            snapshot {
+            doSnapshot {
                 name
                 state
             }

--- a/graphql/environment-nodes-query-5.graphql
+++ b/graphql/environment-nodes-query-5.graphql
@@ -3,7 +3,7 @@ query {
         descendantTargets {
             recordings {
                 active {
-                    stop {
+                    doStop {
                         name
                         state
                     }

--- a/graphql/environment-nodes-query-6.graphql
+++ b/graphql/environment-nodes-query-6.graphql
@@ -3,7 +3,7 @@ query {
         descendantTargets {
             recordings {
                 active {
-                    delete {
+                    doDelete {
                         name
                         state
                     }

--- a/graphql/environment-nodes-query-7.graphql
+++ b/graphql/environment-nodes-query-7.graphql
@@ -3,7 +3,7 @@ query {
         descendantTargets {
             recordings {
                 archived {
-                    delete {
+                    doDelete {
                         name
                     }
                 }

--- a/graphql/root-node-query.graphql
+++ b/graphql/root-node-query.graphql
@@ -58,7 +58,7 @@ fragment ChildrenRecursive on EnvironmentNode {
 }
 
 {
-    discovery {
+    rootNode {
         ... TargetFields
         ... ChildrenRecursive
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
@@ -56,20 +56,20 @@ import graphql.schema.DataFetchingEnvironmentImpl;
 
 class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>> {
 
-    private final DiscoveryFetcher discoveryFetcher;
+    private final RootNodeFetcher rootNodeFetcher;
     private final EnvironmentNodeRecurseFetcher recurseFetcher;
 
     @Inject
     EnvironmentNodesFetcher(
-            DiscoveryFetcher discoveryFetcher, EnvironmentNodeRecurseFetcher recurseFetcher) {
-        this.discoveryFetcher = discoveryFetcher;
+            RootNodeFetcher rootNodeFetcher, EnvironmentNodeRecurseFetcher recurseFetcher) {
+        this.rootNodeFetcher = rootNodeFetcher;
         this.recurseFetcher = recurseFetcher;
     }
 
     @Override
     public List<EnvironmentNode> get(DataFetchingEnvironment environment) throws Exception {
         Map<String, String> filter = environment.getArgument("filter");
-        EnvironmentNode root = discoveryFetcher.get(environment);
+        EnvironmentNode root = rootNodeFetcher.get(environment);
         List<EnvironmentNode> nodes =
                 recurseFetcher.get(
                         DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -145,7 +145,7 @@ public abstract class GraphModule {
                                                 "startRecording", startRecordingOnTargetMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("TargetNode")
-                                        .dataFetcher("snapshot", snapshotOnTargetMutator))
+                                        .dataFetcher("doSnapshot", snapshotOnTargetMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
                                         .dataFetcher("archive", archiveRecordingMutator))

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -87,7 +87,7 @@ public abstract class GraphModule {
     static GraphQL provideGraphQL(
             NodeTypeResolver nodeTypeResolver,
             RecordingTypeResolver recordingTypeResolver,
-            DiscoveryFetcher discoveryFetcher,
+            RootNodeFetcher rootNodeFetcher,
             EnvironmentNodesFetcher environmentNodesFetcher,
             TargetNodesFetcher targetNodesFetcher,
             EnvironmentNodeChildrenFetcher nodeChildrenFetcher,
@@ -117,7 +117,7 @@ public abstract class GraphModule {
                                         .build())
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("Query")
-                                        .dataFetcher("discovery", discoveryFetcher))
+                                        .dataFetcher("rootNode", rootNodeFetcher))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("Query")
                                         .dataFetcher("environmentNodes", environmentNodesFetcher))
@@ -180,8 +180,8 @@ public abstract class GraphModule {
     }
 
     @Provides
-    static DiscoveryFetcher provideDiscoveryFetcher(PlatformClient client) {
-        return new DiscoveryFetcher(client);
+    static RootNodeFetcher provideRootNodeFetcher(PlatformClient client) {
+        return new RootNodeFetcher(client);
     }
 
     @Provides
@@ -226,20 +226,20 @@ public abstract class GraphModule {
     }
 
     @Provides
-    static NodeFetcher provideNodeFetcher(DiscoveryFetcher discoveryFetcher) {
-        return new NodeFetcher(discoveryFetcher);
+    static NodeFetcher provideNodeFetcher(RootNodeFetcher rootNodeFetcher) {
+        return new NodeFetcher(rootNodeFetcher);
     }
 
     @Provides
     static EnvironmentNodesFetcher provideEnvironmentNodesFetcher(
-            DiscoveryFetcher discoveryFetcher, EnvironmentNodeRecurseFetcher recurseFetcher) {
-        return new EnvironmentNodesFetcher(discoveryFetcher, recurseFetcher);
+            RootNodeFetcher rootNodeFetcher, EnvironmentNodeRecurseFetcher recurseFetcher) {
+        return new EnvironmentNodesFetcher(rootNodeFetcher, recurseFetcher);
     }
 
     @Provides
     static TargetNodesFetcher provideTargetNodesFetcher(
-            DiscoveryFetcher discoveryFetcher, TargetNodeRecurseFetcher recurseFetcher) {
-        return new TargetNodesFetcher(discoveryFetcher, recurseFetcher);
+            RootNodeFetcher rootNodeFetcher, TargetNodeRecurseFetcher recurseFetcher) {
+        return new TargetNodesFetcher(rootNodeFetcher, recurseFetcher);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -142,7 +142,7 @@ public abstract class GraphModule {
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("TargetNode")
                                         .dataFetcher(
-                                                "startRecording", startRecordingOnTargetMutator))
+                                                "doStartRecording", startRecordingOnTargetMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("TargetNode")
                                         .dataFetcher("doSnapshot", snapshotOnTargetMutator))

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -148,7 +148,7 @@ public abstract class GraphModule {
                                         .dataFetcher("doSnapshot", snapshotOnTargetMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
-                                        .dataFetcher("archive", archiveRecordingMutator))
+                                        .dataFetcher("doArchive", archiveRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
                                         .dataFetcher("stop", stopRecordingMutator))

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -151,7 +151,7 @@ public abstract class GraphModule {
                                         .dataFetcher("doArchive", archiveRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
-                                        .dataFetcher("stop", stopRecordingMutator))
+                                        .dataFetcher("doStop", stopRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
                                         .dataFetcher("delete", deleteActiveRecordingMutator))

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -154,10 +154,10 @@ public abstract class GraphModule {
                                         .dataFetcher("doStop", stopRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ActiveRecording")
-                                        .dataFetcher("delete", deleteActiveRecordingMutator))
+                                        .dataFetcher("doDelete", deleteActiveRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("ArchivedRecording")
-                                        .dataFetcher("delete", deleteArchivedRecordingMutator))
+                                        .dataFetcher("doDelete", deleteArchivedRecordingMutator))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("Node")
                                         .typeResolver(nodeTypeResolver))

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/NodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/NodeFetcher.java
@@ -50,16 +50,16 @@ import graphql.schema.DataFetchingEnvironment;
 
 class NodeFetcher implements DataFetcher<AbstractNode> {
 
-    private final DiscoveryFetcher discoveryFetcher;
+    private final RootNodeFetcher rootNodeFetcher;
 
     @Inject
-    NodeFetcher(DiscoveryFetcher discoveryFetcher) {
-        this.discoveryFetcher = discoveryFetcher;
+    NodeFetcher(RootNodeFetcher rootNodeFetcher) {
+        this.rootNodeFetcher = rootNodeFetcher;
     }
 
     @Override
     public AbstractNode get(DataFetchingEnvironment environment) throws Exception {
-        EnvironmentNode root = discoveryFetcher.get(environment);
+        EnvironmentNode root = rootNodeFetcher.get(environment);
         String name = environment.getArgument("name");
         String nodeType = environment.getArgument("nodeType");
         AbstractNode node = findNode(name, nodeType, root);

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/RootNodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/RootNodeFetcher.java
@@ -45,12 +45,12 @@ import io.cryostat.platform.discovery.EnvironmentNode;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class DiscoveryFetcher implements DataFetcher<EnvironmentNode> {
+class RootNodeFetcher implements DataFetcher<EnvironmentNode> {
 
     private final PlatformClient client;
 
     @Inject
-    DiscoveryFetcher(PlatformClient client) {
+    RootNodeFetcher(PlatformClient client) {
         this.client = client;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
@@ -49,12 +49,12 @@ import graphql.schema.DataFetchingEnvironmentImpl;
 
 class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
 
-    private final DiscoveryFetcher discoveryFetcher;
+    private final RootNodeFetcher rootNodeFetcher;
     private final TargetNodeRecurseFetcher recurseFetcher;
 
     @Inject
-    TargetNodesFetcher(DiscoveryFetcher discoveryFetcher, TargetNodeRecurseFetcher recurseFetcher) {
-        this.discoveryFetcher = discoveryFetcher;
+    TargetNodesFetcher(RootNodeFetcher rootNodefetcher, TargetNodeRecurseFetcher recurseFetcher) {
+        this.rootNodeFetcher = rootNodefetcher;
         this.recurseFetcher = recurseFetcher;
     }
 
@@ -62,7 +62,7 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
     public List<TargetNode> get(DataFetchingEnvironment environment) throws Exception {
         return recurseFetcher.get(
                 DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
-                        .source(discoveryFetcher.get(environment))
+                        .source(rootNodeFetcher.get(environment))
                         .build());
     }
 }

--- a/src/main/resources/queries.graphqls
+++ b/src/main/resources/queries.graphqls
@@ -1,5 +1,5 @@
 type Query {
-    discovery: EnvironmentNode! # TODO rename as rootNode
+    rootNode: EnvironmentNode!
     environmentNodes(filter: EnvironmentNodeFilterInput): [EnvironmentNode!]!
     targetNodes: [TargetNode!]! # TODO add filters for names, labels, annotations
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -72,7 +72,7 @@ type ActiveRecording implements Recording {
     downloadUrl: Url!
 
     doArchive: ArchivedRecording!
-    stop: ActiveRecording! # mutation
+    doStop: ActiveRecording!
     delete: ActiveRecording! # mutation
 }
 

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -73,7 +73,7 @@ type ActiveRecording implements Recording {
 
     doArchive: ArchivedRecording!
     doStop: ActiveRecording!
-    delete: ActiveRecording! # mutation
+    doDelete: ActiveRecording!
 }
 
 type ArchivedRecording implements Recording {
@@ -81,7 +81,7 @@ type ArchivedRecording implements Recording {
     reportUrl: Url!
     downloadUrl: Url!
 
-    delete: ArchivedRecording! # mutation
+    doDelete: ArchivedRecording!
 }
 
 interface Recording {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -25,7 +25,7 @@ type TargetNode implements Node {
     nodeType: NodeType!
     labels: Object!
 
-    startRecording(recording: RecordingSettings!): ActiveRecording!
+    doStartRecording(recording: RecordingSettings!): ActiveRecording!
     doSnapshot: ActiveRecording!
 }
 

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -71,7 +71,7 @@ type ActiveRecording implements Recording {
     reportUrl: Url!
     downloadUrl: Url!
 
-    archive: ArchivedRecording! # mutation
+    doArchive: ArchivedRecording!
     stop: ActiveRecording! # mutation
     delete: ActiveRecording! # mutation
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -26,7 +26,7 @@ type TargetNode implements Node {
     labels: Object!
 
     startRecording(recording: RecordingSettings!): ActiveRecording!
-    snapshot: ActiveRecording! # mutation
+    doSnapshot: ActiveRecording!
 }
 
 type EnvironmentNode implements Node {


### PR DESCRIPTION
Rename query "discovery" to "rootNode"
Rename mutations with a "do" prefix

Fixes #824
Fixes #818