### PR TITLE
fix(graphQL): Restrict GraphiQL availability to dev mode

### DIFF
--- a/devserver.sh
+++ b/devserver.sh
@@ -109,4 +109,5 @@ MAVEN_OPTS="${flags[@]}" \
     CRYOSTAT_CONFIG_PATH="${work_dir}/conf" \
     CRYOSTAT_TEMPLATE_PATH="${work_dir}/templates" \
     CRYOSTAT_PROBE_TEMPLATE_PATH="${work_dir}/probes" \
+    CRYOSTAT_WEB_ENV_DEV_MODE=true \
     "${MVN}" -Dcryostat.minimal=true -DskipTests=true vertx:run

--- a/devserver.sh
+++ b/devserver.sh
@@ -109,5 +109,5 @@ MAVEN_OPTS="${flags[@]}" \
     CRYOSTAT_CONFIG_PATH="${work_dir}/conf" \
     CRYOSTAT_TEMPLATE_PATH="${work_dir}/templates" \
     CRYOSTAT_PROBE_TEMPLATE_PATH="${work_dir}/probes" \
-    CRYOSTAT_WEB_ENV_DEV_MODE=true \
+    CRYOSTAT_DEV_MODE=true \
     "${MVN}" -Dcryostat.minimal=true -DskipTests=true vertx:run

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -69,6 +69,7 @@ public final class Variables {
     public static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
     public static final String ENABLE_CORS_ENV = "CRYOSTAT_CORS_ORIGIN";
     public static final String HTTP_REQUEST_TIMEOUT = "CRYOSTAT_HTTP_REQUEST_TIMEOUT";
+    public static final String WEB_ENV_DEV_MODE = "CRYOSTAT_WEB_ENV_DEV_MODE";
 
     // JMX connections configuration
     public static final String TARGET_CACHE_SIZE = "CRYOSTAT_TARGET_CACHE_SIZE";

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -69,7 +69,7 @@ public final class Variables {
     public static final String MAX_CONNECTIONS_ENV_VAR = "CRYOSTAT_MAX_WS_CONNECTIONS";
     public static final String ENABLE_CORS_ENV = "CRYOSTAT_CORS_ORIGIN";
     public static final String HTTP_REQUEST_TIMEOUT = "CRYOSTAT_HTTP_REQUEST_TIMEOUT";
-    public static final String WEB_ENV_DEV_MODE = "CRYOSTAT_WEB_ENV_DEV_MODE";
+    public static final String DEV_MODE = "CRYOSTAT_DEV_MODE";
 
     // JMX connections configuration
     public static final String TARGET_CACHE_SIZE = "CRYOSTAT_TARGET_CACHE_SIZE";

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphiQLGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphiQLGetHandler.java
@@ -41,6 +41,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.Variables;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.ApiVersion;
@@ -52,10 +54,12 @@ import io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions;
 
 class GraphiQLGetHandler implements RequestHandler {
 
+    private final Environment env;
     private final GraphiQLHandler handler;
 
     @Inject
-    GraphiQLGetHandler() {
+    GraphiQLGetHandler(Environment env) {
+        this.env = env;
         this.handler =
                 GraphiQLHandler.create(
                         new GraphiQLHandlerOptions()
@@ -80,9 +84,7 @@ class GraphiQLGetHandler implements RequestHandler {
 
     @Override
     public boolean isAvailable() {
-        // FIXME this should only be available in dev mode
-        // ex. "VERTXWEB_ENVIRONMENT=dev"
-        return true;
+        return this.env.hasEnv(Variables.WEB_ENV_DEV_MODE);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphiQLGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphiQLGetHandler.java
@@ -84,7 +84,7 @@ class GraphiQLGetHandler implements RequestHandler {
 
     @Override
     public boolean isAvailable() {
-        return this.env.hasEnv(Variables.WEB_ENV_DEV_MODE);
+        return this.env.hasEnv(Variables.DEV_MODE);
     }
 
     @Override


### PR DESCRIPTION
Fixes #819 

The GraphiQL web page is only available at `https://localhost:8181/api/beta/graphiql/` when running cryostat with `CRYOSTAT_DEV_MODE=true`.