### PR TITLE
fix(grafana): add GRAFANA_DASHBOARD_EXT_URL variable

### DIFF
--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -43,6 +43,7 @@ public final class Variables {
     // jfr-datasource, cryostat-grafana-dashboard
     public static final String GRAFANA_DATASOURCE_ENV = "GRAFANA_DATASOURCE_URL";
     public static final String GRAFANA_DASHBOARD_ENV = "GRAFANA_DASHBOARD_URL";
+    public static final String GRAFANA_DASHBOARD_EXT_ENV = "GRAFANA_DASHBOARD_EXT_URL";
 
     // report generation
     public static final String REPORT_GENERATOR_ENV = "CRYOSTAT_REPORT_GENERATOR";

--- a/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
@@ -95,15 +95,17 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
 
     @Override
     public void handle(RoutingContext ctx) {
-        if (!this.env.hasEnv(Variables.GRAFANA_DASHBOARD_ENV)) {
+        String dashboardURL;
+        if (env.hasEnv(Variables.GRAFANA_DASHBOARD_EXT_ENV)) {
+            dashboardURL = env.getEnv(Variables.GRAFANA_DASHBOARD_EXT_ENV);
+        } else if (this.env.hasEnv(Variables.GRAFANA_DASHBOARD_ENV)) {
+            // Fall back to GRAFANA_DASHBOARD_URL if no external URL is provided
+            dashboardURL = env.getEnv(Variables.GRAFANA_DASHBOARD_ENV);
+        } else {
             throw new HttpStatusException(500, "Deployment has no Grafana configuration");
         }
         ctx.response()
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())
-                .end(
-                        gson.toJson(
-                                Map.of(
-                                        "grafanaDashboardUrl",
-                                        env.getEnv(Variables.GRAFANA_DASHBOARD_ENV))));
+                .end(gson.toJson(Map.of("grafanaDashboardUrl", dashboardURL)));
     }
 }


### PR DESCRIPTION
Adds a new `GRAFANA_DASHBOARD_EXT_URL` to override `GRAFANA_DASHBOARD_URL` for the GrafanaDashboardUrlGetHandler.

Fixes: #842 