### PR TITLE
chore(fs): Set Posix file permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   <com.google.dagger.version>2.34.1</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.8.0</io.cryostat.core.version>
+  <io.cryostat.core.version>2.9.0</io.cryostat.core.version>
 
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
   <org.apache.commons.codec.version>1.15</org.apache.commons.codec.version>

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -39,11 +39,9 @@ package io.cryostat.configuration;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -113,13 +111,9 @@ public class CredentialsManager {
                     StandardOpenOption.WRITE,
                     StandardOpenOption.CREATE,
                     StandardOpenOption.TRUNCATE_EXISTING);
-            // TODO do we need to secure these file contents further than simply applying owner-only
-            // permissions? Is it possible for other containers or processes to read target
-            // credentials
-            // in the mounted volume?
-            fs.setPosixFilePermissions(destination,
-                    Set.of(PosixFilePermission.OWNER_READ,
-                            PosixFilePermission.OWNER_WRITE));
+            fs.setPosixFilePermissions(
+                    destination,
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
         }
         return replaced;
     }


### PR DESCRIPTION
Depends on https://github.com/cryostatio/cryostat-core/pull/126
Depends on https://github.com/cryostatio/cryostat-core/pull/127
Fixes #566 

> // TODO do we need to secure these file contents further than simply applying owner-only
// permissions? Is it possible for other containers or processes to read target
// credentials
// in the mounted volume?

I'm not sure if it's possible for a process to read a credentials file from a different process. 
Here's what I could find related to this TODO:

This Kubernetes doc talks about `fsGroup`, but it seems related to accessing all the contents of a volume instead of specific files.
[Security Contexts for Pods and Containers - OpenShift Docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)

> The OpenShift Container Platform shared storage plug-ins mount volumes such that the POSIX permissions on the mount match the permissions on the target storage. For example, if the target storage’s owner ID is 1234 and its group ID is 5678, then the mount on the host node and in the container will have those same IDs. Therefore, the container’s main process must match one or both of those IDs in order to access the volume.
[Volume Security - OpenShift Docs](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/pod_security_context.html)