### PR TITLE
fix(graphql): override nodetype tostrings for display

### DIFF
--- a/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
@@ -40,7 +40,6 @@ package io.cryostat.platform.discovery;
 import java.util.Collections;
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -48,7 +47,6 @@ public abstract class AbstractNode implements Comparable<AbstractNode> {
 
     protected final String name;
 
-    @SerializedName("kind")
     protected final NodeType nodeType;
 
     protected final Map<String, String> labels;

--- a/src/main/java/io/cryostat/platform/discovery/BaseNodeType.java
+++ b/src/main/java/io/cryostat/platform/discovery/BaseNodeType.java
@@ -55,4 +55,9 @@ public enum BaseNodeType implements NodeType {
     public String getKind() {
         return kind;
     }
+
+    @Override
+    public String toString() {
+        return getKind();
+    }
 }

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -148,5 +148,10 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
         public String getKind() {
             return "CustomTarget";
         }
+
+        @Override
+        public String toString() {
+            return getKind();
+        }
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -136,5 +136,10 @@ public class DefaultPlatformClient extends AbstractPlatformClient
         public String getKind() {
             return "JVM";
         }
+
+        @Override
+        public String toString() {
+            return getKind();
+        }
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -405,6 +405,7 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
             this.getFn = getFn;
         }
 
+        @Override
         public String getKind() {
             return kubernetesKind;
         }
@@ -424,6 +425,11 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
                 }
             }
             return null;
+        }
+
+        @Override
+        public String toString() {
+            return getKind();
         }
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -126,5 +126,10 @@ class KubeEnvPlatformClient extends AbstractPlatformClient {
         public String getKind() {
             return kind;
         }
+
+        @Override
+        public String toString() {
+            return getKind();
+        }
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -59,7 +59,6 @@ import dagger.Lazy;
 
 class KubeEnvPlatformClient extends AbstractPlatformClient {
 
-    public static final KubernetesNodeType NODE_TYPE = new KubernetesNodeType();
     private static final Pattern SERVICE_ENV_PATTERN =
             Pattern.compile("([\\S]+)_PORT_([\\d]+)_TCP_ADDR");
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
@@ -89,7 +88,7 @@ class KubeEnvPlatformClient extends AbstractPlatformClient {
         EnvironmentNode root = new EnvironmentNode("KubernetesEnv", BaseNodeType.REALM);
         List<ServiceRef> targets = listDiscoverableServices();
         for (ServiceRef target : targets) {
-            TargetNode targetNode = new TargetNode(NODE_TYPE, target);
+            TargetNode targetNode = new TargetNode(KubernetesNodeType.SERVICE, target);
             root.addChildNode(targetNode);
         }
         return root;
@@ -113,18 +112,19 @@ class KubeEnvPlatformClient extends AbstractPlatformClient {
         }
     }
 
-    public static class KubernetesNodeType implements NodeType {
+    public enum KubernetesNodeType implements NodeType {
+        SERVICE("Service"),
+        ;
 
-        public static final String KIND = "KubernetesEnv";
+        private final String kind;
 
-        @Override
-        public String getKind() {
-            return KIND;
+        KubernetesNodeType(String kind) {
+            this.kind = kind;
         }
 
         @Override
-        public int ordinal() {
-            return 0;
+        public String getKind() {
+            return kind;
         }
     }
 }

--- a/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
@@ -187,14 +187,18 @@ class KubeEnvPlatformClientTest {
                             Matchers.hasProperty(
                                     "name", Matchers.equalTo(serv1.getServiceUri().toString())),
                             Matchers.hasProperty(
-                                    "nodeType", Matchers.equalTo(KubeEnvPlatformClient.NODE_TYPE)),
+                                    "nodeType",
+                                    Matchers.equalTo(
+                                            KubeEnvPlatformClient.KubernetesNodeType.SERVICE)),
                             Matchers.hasProperty("target", Matchers.equalTo(serv1)));
             Matcher<AbstractNode> sr2Matcher =
                     Matchers.allOf(
                             Matchers.hasProperty(
                                     "name", Matchers.equalTo(serv2.getServiceUri().toString())),
                             Matchers.hasProperty(
-                                    "nodeType", Matchers.equalTo(KubeEnvPlatformClient.NODE_TYPE)),
+                                    "nodeType",
+                                    Matchers.equalTo(
+                                            KubeEnvPlatformClient.KubernetesNodeType.SERVICE)),
                             Matchers.hasProperty("target", Matchers.equalTo(serv2)));
             MatcherAssert.assertThat(
                     realmNode.getChildren(), Matchers.hasItems(sr1Matcher, sr2Matcher));

--- a/src/test/java/itest/DiscoveryIT.java
+++ b/src/test/java/itest/DiscoveryIT.java
@@ -125,7 +125,7 @@ class DiscoveryIT extends ExternalTargetsTest {
         List<Node> realms = rootNode.children;
         MatcherAssert.assertThat(
                 realms,
-                Matchers.everyItem(Matchers.hasProperty("kind", Matchers.equalTo("Realm"))));
+                Matchers.everyItem(Matchers.hasProperty("nodeType", Matchers.equalTo("Realm"))));
         MatcherAssert.assertThat(
                 realms,
                 Matchers.allOf(
@@ -151,7 +151,7 @@ class DiscoveryIT extends ExternalTargetsTest {
         MatcherAssert.assertThat(jdp.target, Matchers.nullValue());
         MatcherAssert.assertThat(
                 jdp.children,
-                Matchers.everyItem(Matchers.hasProperty("kind", Matchers.equalTo("JVM"))));
+                Matchers.everyItem(Matchers.hasProperty("nodeType", Matchers.equalTo("JVM"))));
 
         // There should be 2 JDP JVMs and both should be targets without further children
         List<Node> jvms = jdp.children;
@@ -242,7 +242,7 @@ class DiscoveryIT extends ExternalTargetsTest {
 
     public static class Node {
         String name;
-        String kind;
+        String nodeType;
         List<Node> children;
         Map<String, String> labels;
         Target target;
@@ -251,8 +251,8 @@ class DiscoveryIT extends ExternalTargetsTest {
             return name;
         }
 
-        public String getKind() {
-            return kind;
+        public String getNodeType() {
+            return nodeType;
         }
 
         public List<Node> getChildren() {


### PR DESCRIPTION
Fixes #853

I found this simple workaround for the way that GraphQL treats enum values. Rather than creating some duplication within our internal GraphQL module that re-encodes all of the NodeType enums to their Kind strings, I simply add an override on the `toString()` method for all of the NodeType implementations that simply returns the `Kind`. GraphQL uses `toString()` to serialize the `nodeType` enum field, which displays the enum member's name by default, so this override is simple and effective and doesn't duplicate definitions.

To test:
Query `http :8181/api/beta/graphql query=@graphql/root-node-query.graphql`
Query `http :8181/api/v2.1/discovery`

Compare the results of the `kind`/`nodeType` fields of nodes, before and after this patch. Before you should see ex. `REALM`/`Realm`, whereas after they will both agree on `Realm`.