### PR TITLE
feat(credentials): Always persist to disk

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1726,8 +1726,7 @@ The handler-specific descriptions below describe how each handler populates the
     Creates stored credentials for a given target. These are used for automated
     rules processing - if a Target JVM requires JMX authentication, Cryostat
     will use stored credentials when attempting to open JMX connections to the
-    target. These are retained in Cryostat's memory only and not persisted to
-    disk.
+    target.
 
     ##### request
     `POST /api/v2/targets/:targetId/credentials`

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -94,27 +94,18 @@ public class CredentialsManager {
     }
 
     public boolean addCredentials(String targetId, Credentials credentials) throws IOException {
-        return addCredentials(targetId, credentials, false);
-    }
-
-    // FIXME `persist` should not be a parameter here but rather a Strategy selected by ex. env var,
-    // with corresponding backing storage either in-memory or on-disk (with in-memory cache?)
-    public boolean addCredentials(String targetId, Credentials credentials, boolean persist)
-            throws IOException {
         boolean replaced = credentialsMap.containsKey(targetId);
         credentialsMap.put(targetId, credentials);
-        if (persist) {
-            Path destination = getPersistedPath(targetId);
-            fs.writeString(
-                    destination,
-                    gson.toJson(new StoredCredentials(targetId, credentials)),
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.TRUNCATE_EXISTING);
-            fs.setPosixFilePermissions(
-                    destination,
-                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
-        }
+        Path destination = getPersistedPath(targetId);
+        fs.writeString(
+                destination,
+                gson.toJson(new StoredCredentials(targetId, credentials)),
+                StandardOpenOption.WRITE,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+        fs.setPosixFilePermissions(
+                destination,
+                Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
         return replaced;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -50,6 +50,7 @@ import javax.security.sasl.SaslException;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -70,9 +71,12 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
     public static final String JMX_AUTHORIZATION_HEADER = "X-JMX-Authorization";
 
     protected final AuthManager auth;
+    protected final CredentialsManager credentialsManager;
 
-    protected AbstractAuthenticatedRequestHandler(AuthManager auth) {
+    protected AbstractAuthenticatedRequestHandler(
+            AuthManager auth, CredentialsManager credentialsManager) {
         this.auth = auth;
+        this.credentialsManager = credentialsManager;
     }
 
     public abstract void handleAuthenticated(RoutingContext ctx) throws Exception;
@@ -114,8 +118,7 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
 
     protected ConnectionDescriptor getConnectionDescriptorFromContext(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
-        // TODO inject the CredentialsManager here to check for stored credentials
-        Credentials credentials = null;
+        Credentials credentials = credentialsManager.getCredentials(targetId);
         if (ctx.request().headers().contains(JMX_AUTHORIZATION_HEADER)) {
             String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -53,6 +53,7 @@ import javax.security.sasl.SaslException;
 import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -74,11 +75,13 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
 
     protected final AuthManager auth;
     protected final CredentialsManager credentialsManager;
+    protected final Logger logger;
 
     protected AbstractAuthenticatedRequestHandler(
-            AuthManager auth, CredentialsManager credentialsManager) {
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
         this.auth = auth;
         this.credentialsManager = credentialsManager;
+        this.logger = logger;
     }
 
     public abstract void handleAuthenticated(RoutingContext ctx) throws Exception;
@@ -194,8 +197,8 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
                     if (credentialsManager.getCredentials(id) != null) {
                         try {
                             credentialsManager.removeCredentials(id);
-                        } catch (IOException unused) {
-                            // handleConnectionException already throws an HTTPStatusException
+                        } catch (IOException ioe) {
+                            logger.error(ioe);
                         }
                     }
                 });

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateUploadBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateUploadBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ public class ProbeTemplateUploadBodyHandler extends AbstractAuthenticatedRequest
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    ProbeTemplateUploadBodyHandler(AuthManager auth) {
-        super(auth);
+    ProbeTemplateUploadBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateUploadBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateUploadBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ public class ProbeTemplateUploadBodyHandler extends AbstractAuthenticatedRequest
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    ProbeTemplateUploadBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    ProbeTemplateUploadBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,9 @@ class RecordingMetadataLabelsPostBodyHandler extends AbstractAuthenticatedReques
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    RecordingMetadataLabelsPostBodyHandler(AuthManager auth) {
-        super(auth);
+    RecordingMetadataLabelsPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -57,8 +58,8 @@ class RecordingMetadataLabelsPostBodyHandler extends AbstractAuthenticatedReques
 
     @Inject
     RecordingMetadataLabelsPostBodyHandler(
-            AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -57,8 +58,8 @@ class TargetRecordingMetadataLabelsPostBodyHandler extends AbstractAuthenticated
 
     @Inject
     TargetRecordingMetadataLabelsPostBodyHandler(
-            AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,9 @@ class TargetRecordingMetadataLabelsPostBodyHandler extends AbstractAuthenticated
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetRecordingMetadataLabelsPostBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetRecordingMetadataLabelsPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/AuthPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/AuthPostHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
@@ -54,8 +55,8 @@ import io.vertx.ext.web.RoutingContext;
 class AuthPostHandler extends AbstractAuthenticatedRequestHandler {
 
     @Inject
-    AuthPostHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    AuthPostHandler(AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/AuthPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/AuthPostHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
@@ -53,8 +54,8 @@ import io.vertx.ext.web.RoutingContext;
 class AuthPostHandler extends AbstractAuthenticatedRequestHandler {
 
     @Inject
-    AuthPostHandler(AuthManager auth) {
-        super(auth);
+    AuthPostHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -60,8 +61,11 @@ public class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler 
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
-    RecordingDeleteHandler(AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth);
+    RecordingDeleteHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth, credentialsManager);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -64,8 +65,9 @@ public class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler 
     RecordingDeleteHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
-            RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, credentialsManager);
+            RecordingArchiveHelper recordingArchiveHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -66,8 +67,9 @@ class RecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     RecordingGetHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
-            RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, credentialsManager);
+            RecordingArchiveHelper recordingArchiveHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -62,8 +63,11 @@ class RecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
-    RecordingGetHandler(AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth);
+    RecordingGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth, credentialsManager);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
@@ -80,11 +81,12 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     RecordingUploadPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth);
+        super(auth, credentialsManager);
         this.env = env;
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -51,6 +51,7 @@ import javax.inject.Named;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -85,8 +86,9 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
-            RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, credentialsManager);
+            RecordingArchiveHelper recordingArchiveHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.env = env;
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -64,8 +65,11 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
 
     @Inject
     RecordingsGetHandler(
-            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper, Gson gson) {
-        super(auth);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingArchiveHelper recordingArchiveHelper,
+            Gson gson) {
+        super(auth, credentialsManager);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -68,8 +69,9 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             RecordingArchiveHelper recordingArchiveHelper,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostBodyHandler.java
@@ -47,6 +47,7 @@ import javax.inject.Named;
 
 import io.cryostat.MainModule;
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -66,8 +67,9 @@ class RecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
-            FileSystem fs) {
-        super(auth, credentialsManager);
+            FileSystem fs,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         Path fileUploads = recordingsPath.resolve("file-uploads");
         this.bodyHandler = BodyHandler.create(fileUploads.toAbsolutePath().toString());
         try {

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostBodyHandler.java
@@ -46,6 +46,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -63,9 +64,10 @@ class RecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     RecordingsPostBodyHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             @Named(MainModule.RECORDINGS_PATH) Path recordingsPath,
             FileSystem fs) {
-        super(auth);
+        super(auth, credentialsManager);
         Path fileUploads = recordingsPath.resolve("file-uploads");
         this.bodyHandler = BodyHandler.create(fileUploads.toAbsolutePath().toString());
         try {

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -60,6 +60,7 @@ import org.openjdk.jmc.flightrecorder.internal.FlightRecordingLoader;
 import org.openjdk.jmc.flightrecorder.internal.InvalidJfrFileException;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.NotificationFactory;
@@ -102,6 +103,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     RecordingsPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             HttpServer httpServer,
             FileSystem fs,
             @Named(MainModule.RECORDINGS_PATH) Path savedRecordingsPath,
@@ -109,7 +111,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
             NotificationFactory notificationFactory,
             Provider<WebServer> webServer,
             Logger logger) {
-        super(auth);
+        super(auth, credentialsManager);
         this.vertx = httpServer.getVertx();
         this.fs = fs;
         this.savedRecordingsPath = savedRecordingsPath;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -111,7 +111,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
             NotificationFactory notificationFactory,
             Provider<WebServer> webServer,
             Logger logger) {
-        super(auth, credentialsManager);
+        super(auth, credentialsManager, logger);
         this.vertx = httpServer.getVertx();
         this.fs = fs;
         this.savedRecordingsPath = savedRecordingsPath;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
@@ -78,7 +78,7 @@ class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds,
             Logger logger) {
-        super(auth, credentialsManager);
+        super(auth, credentialsManager, logger);
         this.reportService = reportService;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportGenerationException;
@@ -72,11 +73,12 @@ class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     ReportGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             ReportService reportService,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds,
             Logger logger) {
-        super(auth);
+        super(auth, credentialsManager);
         this.reportService = reportService;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandler.java
@@ -48,6 +48,7 @@ import javax.inject.Inject;
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.jmc.serialization.SerializableEventTypeInfo;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -71,8 +72,9 @@ class TargetEventsGetHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.connectionManager = connectionManager;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandler.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.SerializableEventTypeInfo;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -66,8 +67,12 @@ class TargetEventsGetHandler extends AbstractAuthenticatedRequestHandler {
     private final Gson gson;
 
     @Inject
-    TargetEventsGetHandler(AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
-        super(auth);
+    TargetEventsGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager connectionManager,
+            Gson gson) {
+        super(auth, credentialsManager);
         this.connectionManager = connectionManager;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
@@ -61,8 +62,11 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
     private final RecordingTargetHelper recordingTargetHelper;
 
     @Inject
-    TargetRecordingDeleteHandler(AuthManager auth, RecordingTargetHelper recordingTargetHelper) {
-        super(auth);
+    TargetRecordingDeleteHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingTargetHelper recordingTargetHelper) {
+        super(auth, credentialsManager);
         this.recordingTargetHelper = recordingTargetHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
@@ -65,8 +66,9 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
     TargetRecordingDeleteHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
-            RecordingTargetHelper recordingTargetHelper) {
-        super(auth, credentialsManager);
+            RecordingTargetHelper recordingTargetHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.recordingTargetHelper = recordingTargetHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
@@ -72,8 +73,9 @@ class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             TargetConnectionManager targetConnectionManager,
-            RecordingTargetHelper recordingTargetHelper) {
-        super(auth, credentialsManager);
+            RecordingTargetHelper recordingTargetHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
@@ -69,9 +70,10 @@ class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     TargetRecordingGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper) {
-        super(auth);
+        super(auth, credentialsManager);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandler.java
@@ -50,6 +50,7 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
@@ -76,8 +77,9 @@ class TargetRecordingOptionsGetHandler extends AbstractAuthenticatedRequestHandl
             CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.connectionManager = connectionManager;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;
         this.gson = gson;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandler.java
@@ -49,6 +49,7 @@ import org.openjdk.jmc.common.unit.IOptionDescriptor;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
@@ -72,10 +73,11 @@ class TargetRecordingOptionsGetHandler extends AbstractAuthenticatedRequestHandl
     @Inject
     TargetRecordingOptionsGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             Gson gson) {
-        super(auth);
+        super(auth, credentialsManager);
         this.connectionManager = connectionManager;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;
         this.gson = gson;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,9 @@ class TargetRecordingOptionsPatchBodyHandler extends AbstractAuthenticatedReques
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetRecordingOptionsPatchBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetRecordingOptionsPatchBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -57,8 +58,8 @@ class TargetRecordingOptionsPatchBodyHandler extends AbstractAuthenticatedReques
 
     @Inject
     TargetRecordingOptionsPatchBodyHandler(
-            AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
@@ -51,6 +51,7 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.RecordingOptionsCustomizer;
 import io.cryostat.core.RecordingOptionsCustomizer.OptionKey;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
@@ -82,8 +83,9 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
             RecordingOptionsCustomizer customizer,
             TargetConnectionManager connectionManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.customizer = customizer;
         this.connectionManager = connectionManager;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
@@ -48,6 +48,7 @@ import javax.inject.Inject;
 
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.RecordingOptionsCustomizer;
 import io.cryostat.core.RecordingOptionsCustomizer.OptionKey;
 import io.cryostat.net.AuthManager;
@@ -77,11 +78,12 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
     @Inject
     TargetRecordingOptionsPatchHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             RecordingOptionsCustomizer customizer,
             TargetConnectionManager connectionManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             Gson gson) {
-        super(auth);
+        super(auth, credentialsManager);
         this.customizer = customizer;
         this.connectionManager = connectionManager;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class TargetRecordingPatchBodyHandler extends AbstractAuthenticatedRequestHandle
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetRecordingPatchBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    TargetRecordingPatchBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class TargetRecordingPatchBodyHandler extends AbstractAuthenticatedRequestHandle
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetRecordingPatchBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetRecordingPatchBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -64,8 +65,9 @@ public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHan
             AuthManager auth,
             CredentialsManager credentialsManager,
             TargetRecordingPatchSave patchSave,
-            TargetRecordingPatchStop patchStop) {
-        super(auth, credentialsManager);
+            TargetRecordingPatchStop patchStop,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.patchSave = patchSave;
         this.patchStop = patchStop;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -61,9 +62,10 @@ public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHan
     @Inject
     TargetRecordingPatchHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetRecordingPatchSave patchSave,
             TargetRecordingPatchStop patchStop) {
-        super(auth);
+        super(auth, credentialsManager);
         this.patchSave = patchSave;
         this.patchStop = patchStop;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -53,6 +53,7 @@ import javax.inject.Named;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -92,8 +93,9 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             TargetConnectionManager targetConnectionManager,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
-            FileSystem fs) {
-        super(auth, credentialsManager);
+            FileSystem fs,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.env = env;
         this.targetConnectionManager = targetConnectionManager;
         this.httpTimeoutSeconds = httpTimeoutSeconds;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
@@ -86,12 +87,13 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
     @Inject
     TargetRecordingUploadPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Environment env,
             TargetConnectionManager targetConnectionManager,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
             FileSystem fs) {
-        super(auth);
+        super(auth, credentialsManager);
         this.env = env;
         this.targetConnectionManager = targetConnectionManager;
         this.httpTimeoutSeconds = httpTimeoutSeconds;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
@@ -48,6 +48,7 @@ import javax.inject.Provider;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor.Metadata;
 import io.cryostat.net.AuthManager;
@@ -78,8 +79,9 @@ class TargetRecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
             TargetConnectionManager connectionManager,
             Provider<WebServer> webServerProvider,
             RecordingMetadataManager recordingMetadataManager,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.connectionManager = connectionManager;
         this.webServerProvider = webServerProvider;
         this.recordingMetadataManager = recordingMetadataManager;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
@@ -47,6 +47,7 @@ import javax.inject.Provider;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor.Metadata;
 import io.cryostat.net.AuthManager;
@@ -73,11 +74,12 @@ class TargetRecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     TargetRecordingsGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
             Provider<WebServer> webServerProvider,
             RecordingMetadataManager recordingMetadataManager,
             Gson gson) {
-        super(auth);
+        super(auth, credentialsManager);
         this.connectionManager = connectionManager;
         this.webServerProvider = webServerProvider;
         this.recordingMetadataManager = recordingMetadataManager;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class TargetRecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandle
     private final BodyHandler bodyHandler;
 
     @Inject
-    TargetRecordingsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    TargetRecordingsPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
         this.bodyHandler = BodyHandler.create(true).setHandleFileUploads(false);
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class TargetRecordingsPostBodyHandler extends AbstractAuthenticatedRequestHandle
     private final BodyHandler bodyHandler;
 
     @Inject
-    TargetRecordingsPostBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetRecordingsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
         this.bodyHandler = BodyHandler.create(true).setHandleFileUploads(false);
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -54,6 +54,7 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -100,8 +101,9 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             Provider<WebServer> webServerProvider,
             RecordingMetadataManager recordingMetadataManager,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -53,6 +53,7 @@ import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -93,13 +94,14 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
     @Inject
     TargetRecordingsPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             Provider<WebServer> webServerProvider,
             RecordingMetadataManager recordingMetadataManager,
             Gson gson) {
-        super(auth);
+        super(auth, credentialsManager);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -78,7 +78,7 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds,
             Logger logger) {
-        super(auth, credentialsManager);
+        super(auth, credentialsManager, logger);
         this.reportService = reportService;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
         this.logger = logger;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -72,11 +73,12 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     TargetReportGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             ReportService reportService,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds,
             Logger logger) {
-        super(auth);
+        super(auth, credentialsManager);
         this.reportService = reportService;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
         this.logger = logger;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -62,8 +63,11 @@ class TargetSnapshotPostHandler extends AbstractAuthenticatedRequestHandler {
     private final RecordingTargetHelper recordingTargetHelper;
 
     @Inject
-    TargetSnapshotPostHandler(AuthManager auth, RecordingTargetHelper recordingTargetHelper) {
-        super(auth);
+    TargetSnapshotPostHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingTargetHelper recordingTargetHelper) {
+        super(auth, credentialsManager);
         this.recordingTargetHelper = recordingTargetHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -66,8 +67,9 @@ class TargetSnapshotPostHandler extends AbstractAuthenticatedRequestHandler {
     TargetSnapshotPostHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
-            RecordingTargetHelper recordingTargetHelper) {
-        super(auth, credentialsManager);
+            RecordingTargetHelper recordingTargetHelper,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.recordingTargetHelper = recordingTargetHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -60,8 +61,11 @@ class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
     private final TargetConnectionManager targetConnectionManager;
 
     @Inject
-    TargetTemplateGetHandler(AuthManager auth, TargetConnectionManager targetConnectionManager) {
-        super(auth);
+    TargetTemplateGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager targetConnectionManager) {
+        super(auth, credentialsManager);
         this.targetConnectionManager = targetConnectionManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -64,8 +65,9 @@ class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
     TargetTemplateGetHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
-            TargetConnectionManager targetConnectionManager) {
-        super(auth, credentialsManager);
+            TargetConnectionManager targetConnectionManager,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.targetConnectionManager = targetConnectionManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
@@ -76,8 +77,9 @@ class TargetTemplatesGetHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.connectionManager = connectionManager;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandler.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
@@ -72,8 +73,11 @@ class TargetTemplatesGetHandler extends AbstractAuthenticatedRequestHandler {
 
     @Inject
     TargetTemplatesGetHandler(
-            AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
-        super(auth);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager connectionManager,
+            Gson gson) {
+        super(auth, credentialsManager);
         this.connectionManager = connectionManager;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetsGetHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -60,8 +61,12 @@ class TargetsGetHandler extends AbstractAuthenticatedRequestHandler {
     private final Gson gson;
 
     @Inject
-    TargetsGetHandler(AuthManager auth, PlatformClient platformClient, Gson gson) {
-        super(auth);
+    TargetsGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            PlatformClient platformClient,
+            Gson gson) {
+        super(auth, credentialsManager);
         this.platformClient = platformClient;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetsGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -65,8 +66,9 @@ class TargetsGetHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             PlatformClient platformClient,
-            Gson gson) {
-        super(auth, credentialsManager);
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.platformClient = platformClient;
         this.gson = gson;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.LocalStorageTemplateService;
 import io.cryostat.core.templates.MutableTemplateService.InvalidEventTemplateException;
 import io.cryostat.core.templates.Template;
@@ -68,9 +69,10 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     TemplateDeleteHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             LocalStorageTemplateService templateService,
             NotificationFactory notificationFactory) {
-        super(auth);
+        super(auth, credentialsManager);
         this.templateService = templateService;
         this.notificationFactory = notificationFactory;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.LocalStorageTemplateService;
 import io.cryostat.core.templates.MutableTemplateService.InvalidEventTemplateException;
 import io.cryostat.core.templates.Template;
@@ -71,8 +72,9 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
             AuthManager auth,
             CredentialsManager credentialsManager,
             LocalStorageTemplateService templateService,
-            NotificationFactory notificationFactory) {
-        super(auth, credentialsManager);
+            NotificationFactory notificationFactory,
+            Logger logger) {
+        super(auth, credentialsManager, logger);
         this.templateService = templateService;
         this.notificationFactory = notificationFactory;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class TemplatesPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    TemplatesPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    TemplatesPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class TemplatesPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    TemplatesPostBodyHandler(AuthManager auth) {
-        super(auth);
+    TemplatesPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
@@ -82,7 +82,7 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
             FileSystem fs,
             NotificationFactory notificationFactory,
             Logger logger) {
-        super(auth, credentialsManager);
+        super(auth, credentialsManager, logger);
         this.notificationFactory = notificationFactory;
         this.templateService = templateService;
         this.fs = fs;

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.core.templates.LocalStorageTemplateService;
@@ -76,11 +77,12 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
     @Inject
     TemplatesPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             LocalStorageTemplateService templateService,
             FileSystem fs,
             NotificationFactory notificationFactory,
             Logger logger) {
-        super(auth);
+        super(auth, credentialsManager);
         this.notificationFactory = notificationFactory;
         this.templateService = templateService;
         this.fs = fs;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class AuthTokenPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    AuthTokenPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    AuthTokenPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class AuthTokenPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    AuthTokenPostBodyHandler(AuthManager auth) {
-        super(auth);
+    AuthTokenPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class CertificatePostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    CertificatePostBodyHandler(AuthManager auth) {
-        super(auth);
+    CertificatePostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class CertificatePostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 
     @Inject
-    CertificatePostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    CertificatePostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,8 @@ class RulesPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    RulesPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    RulesPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class RulesPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    RulesPostBodyHandler(AuthManager auth) {
-        super(auth);
+    RulesPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class TargetCredentialsPostBodyHandler extends AbstractAuthenticatedRequestHandl
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetCredentialsPostBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetCredentialsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,9 @@ class TargetCredentialsPostBodyHandler extends AbstractAuthenticatedRequestHandl
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetCredentialsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    TargetCredentialsPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -115,7 +115,6 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
         String targetId = params.getPathParams().get("targetId");
         String username = params.getFormAttributes().get("username");
         String password = params.getFormAttributes().get("password");
-        boolean persist = Boolean.valueOf(params.getFormAttributes().get("persist"));
 
         if (StringUtils.isAnyBlank(username, password)) {
             StringBuilder sb = new StringBuilder();
@@ -130,8 +129,7 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
         }
 
         try {
-            this.credentialsManager.addCredentials(
-                    targetId, new Credentials(username, password), persist);
+            this.credentialsManager.addCredentials(targetId, new Credentials(username, password));
         } catch (IOException e) {
             throw new ApiException(500, "IOException occurred while persisting credentials", e);
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -56,8 +57,8 @@ class TargetsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
-        super(auth, credentialsManager);
+    TargetsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostBodyHandler.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
@@ -55,8 +56,8 @@ class TargetsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
 
     @Inject
-    TargetsPostBodyHandler(AuthManager auth) {
-        super(auth);
+    TargetsPostBodyHandler(AuthManager auth, CredentialsManager credentialsManager) {
+        super(auth, credentialsManager);
     }
 
     @Override

--- a/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
@@ -80,11 +81,12 @@ class AbstractAuthenticatedRequestHandlerTest {
     RequestHandler handler;
     @Mock RoutingContext ctx;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock HttpServerResponse resp;
 
     @BeforeEach
     void setup() {
-        this.handler = new AuthenticatedHandler(auth);
+        this.handler = new AuthenticatedHandler(auth, credentialsManager);
         Mockito.lenient().when(ctx.response()).thenReturn(resp);
         Mockito.lenient()
                 .when(
@@ -193,7 +195,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         @Test
         void shouldPropagateIfHandlerThrowsHttpStatusException() {
             Exception expectedException = new HttpStatusException(200);
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -203,7 +205,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         @Test
         void shouldThrow500IfConnectionFails() {
             Exception expectedException = new ConnectionException("");
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -215,7 +217,7 @@ class AbstractAuthenticatedRequestHandlerTest {
             Exception cause = new SecurityException();
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             Mockito.when(ctx.response()).thenReturn(resp);
 
@@ -230,7 +232,7 @@ class AbstractAuthenticatedRequestHandlerTest {
             Exception cause = new ConnectIOException("SSL trust");
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -243,7 +245,7 @@ class AbstractAuthenticatedRequestHandlerTest {
             Exception cause = new UnknownHostException("localhostt");
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -254,7 +256,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         @Test
         void shouldThrow500IfHandlerThrowsUnexpectedly() {
             Exception expectedException = new NullPointerException();
-            handler = new ThrowingAuthenticatedHandler(auth, expectedException);
+            handler = new ThrowingAuthenticatedHandler(auth, credentialsManager, expectedException);
 
             HttpStatusException ex =
                     Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
@@ -271,7 +273,7 @@ class AbstractAuthenticatedRequestHandlerTest {
 
         @BeforeEach
         void setup3() {
-            handler = new ConnectionDescriptorHandler(auth);
+            handler = new ConnectionDescriptorHandler(auth, credentialsManager);
             Mockito.when(ctx.request()).thenReturn(req);
             when(req.headers()).thenReturn(headers);
             when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
@@ -419,8 +421,8 @@ class AbstractAuthenticatedRequestHandlerTest {
     }
 
     static class AuthenticatedHandler extends AbstractAuthenticatedRequestHandler {
-        AuthenticatedHandler(AuthManager auth) {
-            super(auth);
+        AuthenticatedHandler(AuthManager auth, CredentialsManager credentialsManager) {
+            super(auth, credentialsManager);
         }
 
         @Override
@@ -450,8 +452,9 @@ class AbstractAuthenticatedRequestHandlerTest {
     static class ThrowingAuthenticatedHandler extends AuthenticatedHandler {
         private final Exception thrown;
 
-        ThrowingAuthenticatedHandler(AuthManager auth, Exception thrown) {
-            super(auth);
+        ThrowingAuthenticatedHandler(
+                AuthManager auth, CredentialsManager credentialsManager, Exception thrown) {
+            super(auth, credentialsManager);
             this.thrown = thrown;
         }
 
@@ -464,8 +467,8 @@ class AbstractAuthenticatedRequestHandlerTest {
     static class ConnectionDescriptorHandler extends AuthenticatedHandler {
         ConnectionDescriptor desc;
 
-        ConnectionDescriptorHandler(AuthManager auth) {
-            super(auth);
+        ConnectionDescriptorHandler(AuthManager auth, CredentialsManager credentialsManager) {
+            super(auth, credentialsManager);
         }
 
         @Override

--- a/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.when;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.AuthenticationScheme;
 import io.cryostat.net.web.WebServer;
@@ -68,10 +69,11 @@ class AuthPostHandlerTest {
 
     AuthPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
 
     @BeforeEach
     void setup() {
-        this.handler = new AuthPostHandler(auth);
+        this.handler = new AuthPostHandler(auth, credentialsManager);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.AuthenticationScheme;
 import io.cryostat.net.web.WebServer;
@@ -70,10 +71,11 @@ class AuthPostHandlerTest {
     AuthPostHandler handler;
     @Mock AuthManager auth;
     @Mock CredentialsManager credentialsManager;
+    @Mock Logger logger;
 
     @BeforeEach
     void setup() {
-        this.handler = new AuthPostHandler(auth, credentialsManager);
+        this.handler = new AuthPostHandler(auth, credentialsManager, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
@@ -66,6 +67,7 @@ class RecordingDeleteHandlerTest {
 
     RecordingDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
     @Mock RoutingContext ctx;
@@ -73,7 +75,7 @@ class RecordingDeleteHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingDeleteHandler(auth, recordingArchiveHelper);
+        this.handler = new RecordingDeleteHandler(auth, credentialsManager, recordingArchiveHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
@@ -69,13 +70,16 @@ class RecordingDeleteHandlerTest {
     @Mock AuthManager auth;
     @Mock CredentialsManager credentialsManager;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
+    @Mock Logger logger;
 
     @Mock RoutingContext ctx;
     @Mock HttpServerResponse resp;
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingDeleteHandler(auth, credentialsManager, recordingArchiveHelper);
+        this.handler =
+                new RecordingDeleteHandler(
+                        auth, credentialsManager, recordingArchiveHelper, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -72,6 +73,7 @@ class RecordingGetHandlerTest {
     @Mock AuthManager authManager;
     @Mock CredentialsManager credentialsManager;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
+    @Mock Logger logger;
 
     @Mock RoutingContext ctx;
     @Mock HttpServerResponse resp;
@@ -79,7 +81,8 @@ class RecordingGetHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new RecordingGetHandler(authManager, credentialsManager, recordingArchiveHelper);
+                new RecordingGetHandler(
+                        authManager, credentialsManager, recordingArchiveHelper, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -69,6 +70,7 @@ class RecordingGetHandlerTest {
 
     RecordingGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
     @Mock RoutingContext ctx;
@@ -76,7 +78,8 @@ class RecordingGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingGetHandler(authManager, recordingArchiveHelper);
+        this.handler =
+                new RecordingGetHandler(authManager, credentialsManager, recordingArchiveHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -79,6 +80,7 @@ class RecordingUploadPostHandlerTest {
 
     RecordingUploadPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Environment env;
     @Mock WebClient webClient;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
@@ -90,7 +92,8 @@ class RecordingUploadPostHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new RecordingUploadPostHandler(auth, env, 30, webClient, recordingArchiveHelper);
+                new RecordingUploadPostHandler(
+                        auth, credentialsManager, env, 30, webClient, recordingArchiveHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -84,6 +85,7 @@ class RecordingUploadPostHandlerTest {
     @Mock Environment env;
     @Mock WebClient webClient;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
+    @Mock Logger logger;
 
     @Mock RoutingContext ctx;
 
@@ -93,7 +95,13 @@ class RecordingUploadPostHandlerTest {
     void setup() {
         this.handler =
                 new RecordingUploadPostHandler(
-                        auth, credentialsManager, env, 30, webClient, recordingArchiveHelper);
+                        auth,
+                        credentialsManager,
+                        env,
+                        30,
+                        webClient,
+                        recordingArchiveHelper,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -71,6 +72,7 @@ class RecordingsGetHandlerTest {
 
     RecordingsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
@@ -80,7 +82,8 @@ class RecordingsGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingsGetHandler(auth, recordingArchiveHelper, gson);
+        this.handler =
+                new RecordingsGetHandler(auth, credentialsManager, recordingArchiveHelper, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
@@ -83,7 +83,8 @@ class RecordingsGetHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new RecordingsGetHandler(auth, credentialsManager, recordingArchiveHelper, gson);
+                new RecordingsGetHandler(
+                        auth, credentialsManager, recordingArchiveHelper, gson, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.Notification;
@@ -91,6 +92,7 @@ class RecordingsPostHandlerTest {
 
     RecordingsPostHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock HttpServer httpServer;
     @Mock Vertx vertx;
     @Mock FileSystem cryoFs;
@@ -119,6 +121,7 @@ class RecordingsPostHandlerTest {
         this.handler =
                 new RecordingsPostHandler(
                         authManager,
+                        credentialsManager,
                         httpServer,
                         cryoFs,
                         recordingsPath,

--- a/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -72,12 +73,14 @@ class ReportGetHandlerTest {
 
     ReportGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock ReportService reportService;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() {
-        this.handler = new ReportGetHandler(authManager, reportService, 30, logger);
+        this.handler =
+                new ReportGetHandler(authManager, credentialsManager, reportService, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandlerTest.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.jmc.serialization.SerializableEventTypeInfo;
@@ -79,13 +80,15 @@ class TargetEventsGetHandlerTest {
 
     TargetEventsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager connectionManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetEventsGetHandler(auth, connectionManager, gson);
+        this.handler =
+                new TargetEventsGetHandler(auth, credentialsManager, connectionManager, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetEventsGetHandlerTest.java
@@ -88,7 +88,8 @@ class TargetEventsGetHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetEventsGetHandler(auth, credentialsManager, connectionManager, gson);
+                new TargetEventsGetHandler(
+                        auth, credentialsManager, connectionManager, gson, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -69,6 +70,7 @@ class TargetRecordingDeleteHandlerTest {
 
     TargetRecordingDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
     @Mock NotificationFactory notificationFactory;
     @Mock RoutingContext ctx;
@@ -77,7 +79,8 @@ class TargetRecordingDeleteHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetRecordingDeleteHandler(auth, recordingTargetHelper);
+        this.handler =
+                new TargetRecordingDeleteHandler(auth, credentialsManager, recordingTargetHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -72,6 +73,7 @@ class TargetRecordingDeleteHandlerTest {
     @Mock AuthManager auth;
     @Mock CredentialsManager credentialsManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
+    @Mock Logger logger;
     @Mock NotificationFactory notificationFactory;
     @Mock RoutingContext ctx;
     @Mock HttpServerRequest req;
@@ -80,7 +82,8 @@ class TargetRecordingDeleteHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetRecordingDeleteHandler(auth, credentialsManager, recordingTargetHelper);
+                new TargetRecordingDeleteHandler(
+                        auth, credentialsManager, recordingTargetHelper, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
@@ -82,6 +83,7 @@ class TargetRecordingGetHandlerTest {
 
     TargetRecordingGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
     @Mock Optional<InputStream> stream;
@@ -94,7 +96,10 @@ class TargetRecordingGetHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingGetHandler(
-                        authManager, targetConnectionManager, recordingTargetHelper);
+                        authManager,
+                        credentialsManager,
+                        targetConnectionManager,
+                        recordingTargetHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
@@ -99,7 +99,8 @@ class TargetRecordingGetHandlerTest {
                         authManager,
                         credentialsManager,
                         targetConnectionManager,
-                        recordingTargetHelper);
+                        recordingTargetHelper,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandlerTest.java
@@ -96,7 +96,8 @@ class TargetRecordingOptionsGetHandlerTest {
                         credentialsManager,
                         targetConnectionManager,
                         recordingOptionsBuilderFactory,
-                        gson);
+                        gson,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsGetHandlerTest.java
@@ -45,6 +45,7 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
@@ -78,6 +79,7 @@ class TargetRecordingOptionsGetHandlerTest {
 
     TargetRecordingOptionsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
     @Mock RecordingOptionsBuilder builder;
@@ -90,7 +92,11 @@ class TargetRecordingOptionsGetHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingOptionsGetHandler(
-                        auth, targetConnectionManager, recordingOptionsBuilderFactory, gson);
+                        auth,
+                        credentialsManager,
+                        targetConnectionManager,
+                        recordingOptionsBuilderFactory,
+                        gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.RecordingOptionsCustomizer;
 import io.cryostat.core.RecordingOptionsCustomizer.OptionKey;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -89,6 +90,7 @@ class TargetRecordingOptionsPatchHandlerTest {
     @Mock IConstrainedMap<String> recordingOptions;
     @Mock JFRConnection jfrConnection;
     @Mock Gson gson;
+    @Mock Logger logger;
 
     @BeforeEach
     void setup() {
@@ -99,7 +101,8 @@ class TargetRecordingOptionsPatchHandlerTest {
                         customizer,
                         connectionManager,
                         recordingOptionsBuilderFactory,
-                        gson);
+                        gson,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
@@ -45,6 +45,7 @@ import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.RecordingOptionsCustomizer;
 import io.cryostat.core.RecordingOptionsCustomizer.OptionKey;
 import io.cryostat.core.net.JFRConnection;
@@ -80,6 +81,7 @@ class TargetRecordingOptionsPatchHandlerTest {
 
     TargetRecordingOptionsPatchHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingOptionsCustomizer customizer;
     @Mock TargetConnectionManager connectionManager;
     @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
@@ -92,7 +94,12 @@ class TargetRecordingOptionsPatchHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingOptionsPatchHandler(
-                        auth, customizer, connectionManager, recordingOptionsBuilderFactory, gson);
+                        auth,
+                        credentialsManager,
+                        customizer,
+                        connectionManager,
+                        recordingOptionsBuilderFactory,
+                        gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
@@ -76,12 +77,13 @@ class TargetRecordingPatchHandlerTest {
     @Mock HttpServerRequest req;
     @Mock HttpServerResponse resp;
     @Mock ConnectionDescriptor connectionDescriptor;
+    @Mock Logger logger;
 
     @BeforeEach
     void setup() {
         this.handler =
                 new TargetRecordingPatchHandler(
-                        authManager, credentialsManager, patchSave, patchStop);
+                        authManager, credentialsManager, patchSave, patchStop, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
@@ -40,6 +40,7 @@ package io.cryostat.net.web.http.api.v1;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
@@ -68,6 +69,7 @@ class TargetRecordingPatchHandlerTest {
 
     TargetRecordingPatchHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetRecordingPatchSave patchSave;
     @Mock TargetRecordingPatchStop patchStop;
     @Mock RoutingContext ctx;
@@ -77,7 +79,9 @@ class TargetRecordingPatchHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetRecordingPatchHandler(authManager, patchSave, patchStop);
+        this.handler =
+                new TargetRecordingPatchHandler(
+                        authManager, credentialsManager, patchSave, patchStop);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -95,6 +96,7 @@ class TargetRecordingUploadPostHandlerTest {
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock WebClient webClient;
     @Mock FileSystem fs;
+    @Mock Logger logger;
 
     @Mock RoutingContext ctx;
     @Mock HttpServerRequest req;
@@ -107,7 +109,14 @@ class TargetRecordingUploadPostHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingUploadPostHandler(
-                        auth, credentialsManager, env, targetConnectionManager, 30, webClient, fs);
+                        auth,
+                        credentialsManager,
+                        env,
+                        targetConnectionManager,
+                        30,
+                        webClient,
+                        fs,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -89,6 +90,7 @@ class TargetRecordingUploadPostHandlerTest {
 
     TargetRecordingUploadPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Environment env;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock WebClient webClient;
@@ -105,7 +107,7 @@ class TargetRecordingUploadPostHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingUploadPostHandler(
-                        auth, env, targetConnectionManager, 30, webClient, fs);
+                        auth, credentialsManager, env, targetConnectionManager, 30, webClient, fs);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
@@ -99,7 +99,8 @@ class TargetRecordingsGetHandlerTest {
                         connectionManager,
                         () -> webServer,
                         recordingMetadataManager,
-                        gson);
+                        gson,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
@@ -47,6 +47,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -82,6 +83,7 @@ class TargetRecordingsGetHandlerTest {
 
     TargetRecordingsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager connectionManager;
     @Mock WebServer webServer;
     @Mock RecordingMetadataManager recordingMetadataManager;
@@ -92,7 +94,12 @@ class TargetRecordingsGetHandlerTest {
     void setup() {
         this.handler =
                 new TargetRecordingsGetHandler(
-                        auth, connectionManager, () -> webServer, recordingMetadataManager, gson);
+                        auth,
+                        credentialsManager,
+                        connectionManager,
+                        () -> webServer,
+                        recordingMetadataManager,
+                        gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -118,7 +118,8 @@ class TargetRecordingsPostHandlerTest {
                         recordingOptionsBuilderFactory,
                         () -> webServer,
                         recordingMetadataManager,
-                        gson);
+                        gson,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -51,6 +51,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.TemplateService;
@@ -90,6 +91,7 @@ class TargetRecordingsPostHandlerTest {
 
     TargetRecordingsPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
     @Mock RecordingOptionsBuilderFactory recordingOptionsBuilderFactory;
@@ -110,6 +112,7 @@ class TargetRecordingsPostHandlerTest {
         this.handler =
                 new TargetRecordingsPostHandler(
                         auth,
+                        credentialsManager,
                         targetConnectionManager,
                         recordingTargetHelper,
                         recordingOptionsBuilderFactory,

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -77,12 +78,15 @@ class TargetReportGetHandlerTest {
 
     TargetReportGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock ReportService reportService;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetReportGetHandler(authManager, reportService, 30, logger);
+        this.handler =
+                new TargetReportGetHandler(
+                        authManager, credentialsManager, reportService, 30, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -68,11 +69,13 @@ class TargetSnapshotPostHandlerTest {
 
     TargetSnapshotPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetSnapshotPostHandler(auth, recordingTargetHelper);
+        this.handler =
+                new TargetSnapshotPostHandler(auth, credentialsManager, recordingTargetHelper);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -71,11 +72,13 @@ class TargetSnapshotPostHandlerTest {
     @Mock AuthManager auth;
     @Mock CredentialsManager credentialsManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
+    @Mock Logger logger;
 
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetSnapshotPostHandler(auth, credentialsManager, recordingTargetHelper);
+                new TargetSnapshotPostHandler(
+                        auth, credentialsManager, recordingTargetHelper, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.FlightRecorderException;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.TemplateService;
 import io.cryostat.core.templates.TemplateType;
@@ -80,11 +81,13 @@ class TargetTemplateGetHandlerTest {
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock JFRConnection conn;
     @Mock TemplateService templateService;
+    @Mock Logger logger;
 
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetTemplateGetHandler(auth, credentialsManager, targetConnectionManager);
+                new TargetTemplateGetHandler(
+                        auth, credentialsManager, targetConnectionManager, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
@@ -40,6 +40,7 @@ package io.cryostat.net.web.http.api.v1;
 import java.util.Optional;
 import java.util.Set;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.TemplateService;
@@ -75,13 +76,15 @@ class TargetTemplateGetHandlerTest {
 
     TargetTemplateGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock JFRConnection conn;
     @Mock TemplateService templateService;
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetTemplateGetHandler(auth, targetConnectionManager);
+        this.handler =
+                new TargetTemplateGetHandler(auth, credentialsManager, targetConnectionManager);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.Template;
@@ -75,13 +76,15 @@ class TargetTemplatesGetHandlerTest {
 
     TargetTemplatesGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager connectionManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetTemplatesGetHandler(auth, connectionManager, gson);
+        this.handler =
+                new TargetTemplatesGetHandler(auth, credentialsManager, connectionManager, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplatesGetHandlerTest.java
@@ -84,7 +84,8 @@ class TargetTemplatesGetHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetTemplatesGetHandler(auth, credentialsManager, connectionManager, gson);
+                new TargetTemplatesGetHandler(
+                        auth, credentialsManager, connectionManager, gson, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
@@ -84,7 +84,8 @@ class TargetsGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetsGetHandler(auth, credentialsManager, platformClient, gson);
+        this.handler =
+                new TargetsGetHandler(auth, credentialsManager, platformClient, gson, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetsGetHandlerTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.net.AuthManager;
@@ -75,6 +76,7 @@ class TargetsGetHandlerTest {
 
     TargetsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock PlatformClient platformClient;
     @Mock Logger logger;
     @Mock JFRConnectionToolkit connectionToolkit;
@@ -82,7 +84,7 @@ class TargetsGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetsGetHandler(auth, platformClient, gson);
+        this.handler = new TargetsGetHandler(auth, credentialsManager, platformClient, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.LocalStorageTemplateService;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
@@ -76,6 +77,7 @@ class TemplateDeleteHandlerTest {
     @Mock CredentialsManager credentialsManager;
     @Mock LocalStorageTemplateService templateService;
     @Mock NotificationFactory notificationFactory;
+    @Mock Logger logger;
     @Mock Notification notification;
     @Mock Notification.Builder notificationBuilder;
 
@@ -95,7 +97,7 @@ class TemplateDeleteHandlerTest {
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new TemplateDeleteHandler(
-                        auth, credentialsManager, templateService, notificationFactory);
+                        auth, credentialsManager, templateService, notificationFactory, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.LocalStorageTemplateService;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
@@ -72,6 +73,7 @@ class TemplateDeleteHandlerTest {
 
     TemplateDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalStorageTemplateService templateService;
     @Mock NotificationFactory notificationFactory;
     @Mock Notification notification;
@@ -91,7 +93,9 @@ class TemplateDeleteHandlerTest {
                 .thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
-        this.handler = new TemplateDeleteHandler(auth, templateService, notificationFactory);
+        this.handler =
+                new TemplateDeleteHandler(
+                        auth, credentialsManager, templateService, notificationFactory);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.core.templates.LocalStorageTemplateService;
@@ -77,6 +78,7 @@ class TemplatesPostHandlerTest {
 
     TemplatesPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalStorageTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -99,7 +101,8 @@ class TemplatesPostHandlerTest {
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
-                new TemplatesPostHandler(auth, templateService, fs, notificationFactory, logger);
+                new TemplatesPostHandler(
+                        auth, credentialsManager, templateService, fs, notificationFactory, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -221,7 +221,7 @@ class TargetCredentialsPostHandlerTest {
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
             MatcherAssert.assertThat(response.getBody(), Matchers.nullValue());
             Mockito.verify(credentialsManager)
-                    .addCredentials(targetId, new Credentials(username, password), false);
+                    .addCredentials(targetId, new Credentials(username, password));
         }
 
         @Test
@@ -233,9 +233,7 @@ class TargetCredentialsPostHandlerTest {
             form.set("password", "abc123");
             Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
 
-            Mockito.when(
-                            credentialsManager.addCredentials(
-                                    Mockito.anyString(), Mockito.any(), Mockito.anyBoolean()))
+            Mockito.when(credentialsManager.addCredentials(Mockito.anyString(), Mockito.any()))
                     .thenThrow(IOException.class);
 
             ApiException ex =


### PR DESCRIPTION
Fixes #565 

Note: Most of the additions were caused by injecting the `CredentialsManager` into the `AbstractAuthenticatedRequestHandler`