### PR TITLE
feat(recordings): set recording template in label

### DIFF
--- a/graphql/environment-nodes-query-3.graphql
+++ b/graphql/environment-nodes-query-3.graphql
@@ -7,9 +7,15 @@ query {
                 active {
                     name
                     state
+                    metadata {
+                        labels
+                    }
                 }
                 archived {
                     name
+                    metadata {
+                        labels
+                    }
                 }
             }
         }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -51,6 +51,7 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 
@@ -189,9 +190,11 @@ public abstract class GraphModule {
             TargetConnectionManager tcm,
             RecordingArchiveHelper archiveHelper,
             CredentialsManager credentialsManager,
+            RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer,
             Logger logger) {
-        return new RecordingsFetcher(tcm, archiveHelper, credentialsManager, webServer, logger);
+        return new RecordingsFetcher(
+                tcm, archiveHelper, credentialsManager, metadataManager, webServer, logger);
     }
 
     @Provides
@@ -267,9 +270,14 @@ public abstract class GraphModule {
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             CredentialsManager credentialsManager,
+            RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer) {
         return new StopRecordingMutator(
-                targetConnectionManager, recordingTargetHelper, credentialsManager, webServer);
+                targetConnectionManager,
+                recordingTargetHelper,
+                credentialsManager,
+                metadataManager,
+                webServer);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphRecordingDescriptor.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphRecordingDescriptor.java
@@ -42,15 +42,20 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 
 class GraphRecordingDescriptor extends HyperlinkedSerializableRecordingDescriptor {
 
     protected transient ServiceRef target;
 
     public GraphRecordingDescriptor(
-            ServiceRef target, IRecordingDescriptor original, String downloadUrl, String reportUrl)
+            ServiceRef target,
+            IRecordingDescriptor original,
+            String downloadUrl,
+            String reportUrl,
+            Metadata metadata)
             throws QuantityConversionException {
-        super(original, downloadUrl, reportUrl);
+        super(original, downloadUrl, reportUrl, metadata);
         this.target = target;
     }
 
@@ -58,5 +63,6 @@ class GraphRecordingDescriptor extends HyperlinkedSerializableRecordingDescripto
             throws QuantityConversionException {
         super(o, o.getDownloadUrl(), o.getReportUrl());
         this.target = target;
+        this.metadata = o.getMetadata();
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/RecordingsFetcher.java
@@ -57,6 +57,8 @@ import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -68,6 +70,7 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
     private final TargetConnectionManager tcm;
     private final RecordingArchiveHelper archiveHelper;
     private final CredentialsManager credentialsManager;
+    private final RecordingMetadataManager metadataManager;
     private final Provider<WebServer> webServer;
     private final Logger logger;
 
@@ -76,11 +79,13 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
             TargetConnectionManager tcm,
             RecordingArchiveHelper archiveHelper,
             CredentialsManager credentialsManager,
+            RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer,
             Logger logger) {
         this.tcm = tcm;
         this.archiveHelper = archiveHelper;
         this.credentialsManager = credentialsManager;
+        this.metadataManager = metadataManager;
         this.webServer = webServer;
         this.logger = logger;
     }
@@ -119,8 +124,15 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
                                                                     .get()
                                                                     .getReportURL(
                                                                             conn, r.getName());
+                                                    Metadata metadata =
+                                                            metadataManager.getMetadata(
+                                                                    targetId, r.getName());
                                                     return new GraphRecordingDescriptor(
-                                                            target, r, downloadUrl, reportUrl);
+                                                            target,
+                                                            r,
+                                                            downloadUrl,
+                                                            reportUrl,
+                                                            metadata);
                                                 } catch (QuantityConversionException
                                                         | URISyntaxException
                                                         | IOException e) {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/StopRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/StopRecordingMutator.java
@@ -47,6 +47,8 @@ import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper;
 
 import graphql.schema.DataFetcher;
@@ -57,6 +59,7 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
     private final CredentialsManager credentialsManager;
+    private final RecordingMetadataManager metadataManager;
     private final Provider<WebServer> webServer;
 
     @Inject
@@ -64,10 +67,12 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             CredentialsManager credentialsManager,
+            RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer) {
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
+        this.metadataManager = metadataManager;
         this.webServer = webServer;
     }
 
@@ -85,11 +90,13 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
                     IRecordingDescriptor desc =
                             recordingTargetHelper.stopRecording(cd, source.getName(), true);
                     WebServer ws = webServer.get();
+                    Metadata metadata = metadataManager.getMetadata(uri, desc.getName());
                     return new GraphRecordingDescriptor(
                             target,
                             desc,
                             ws.getDownloadURL(conn, desc.getName()),
-                            ws.getReportURL(conn, desc.getName()));
+                            ws.getReportURL(conn, desc.getName()),
+                            metadata);
                 },
                 true);
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandler.java
@@ -58,7 +58,6 @@ import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingMetadataManager;
-import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpHeaders;
@@ -131,12 +130,10 @@ class TargetRecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
                                                 webServer.getDownloadURL(
                                                         connection, desc.getName()),
                                                 webServer.getReportURL(connection, desc.getName()),
-                                                new Metadata(
-                                                        recordingMetadataManager.getRecordingLabels(
-                                                                getConnectionDescriptorFromContext(
-                                                                                ctx)
-                                                                        .getTargetId(),
-                                                                desc.getName()))));
+                                                recordingMetadataManager.getMetadata(
+                                                        getConnectionDescriptorFromContext(ctx)
+                                                                .getTargetId(),
+                                                        desc.getName())));
                             }
                             return list;
                         });

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -190,10 +190,10 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                     attrs.get("metadata"),
                                                     new TypeToken<Metadata>() {}.getType());
                                     recordingMetadataManager
-                                            .setRecordingLabels(
+                                            .setRecordingMetadata(
                                                     connectionDescriptor.getTargetId(),
                                                     recordingName,
-                                                    metadata.getLabels())
+                                                    metadata)
                                             .get();
                                 }
                                 Pair<String, TemplateType> template =
@@ -214,10 +214,9 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                     connection, descriptor.getName()),
                                             webServer.getReportURL(
                                                     connection, descriptor.getName()),
-                                            new Metadata(
-                                                    recordingMetadataManager.getRecordingLabels(
-                                                            connectionDescriptor.getTargetId(),
-                                                            recordingName)));
+                                            recordingMetadataManager.getMetadata(
+                                                    connectionDescriptor.getTargetId(),
+                                                    recordingName));
                                 } catch (QuantityConversionException
                                         | URISyntaxException
                                         | IOException e) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -158,9 +158,9 @@ public class RecordingArchiveHelper {
             Path parentPath = savePath.getParent();
             Path filenamePath = savePath.getFileName();
             String filename = filenamePath.toString();
-            Map<String, String> labels =
+            Metadata metadata =
                     recordingMetadataManager
-                            .copyLabelsToArchives(
+                            .copyMetadataToArchives(
                                     connectionDescriptor.getTargetId(), recordingName, filename)
                             .get();
             ArchivedRecordingInfo archivedRecordingInfo =
@@ -169,7 +169,7 @@ public class RecordingArchiveHelper {
                             filename,
                             webServerProvider.get().getArchivedDownloadURL(filename),
                             webServerProvider.get().getArchivedReportURL(filename),
-                            new Metadata(labels));
+                            metadata);
             future.complete(archivedRecordingInfo);
             notificationFactory
                     .createBuilder()
@@ -211,9 +211,8 @@ public class RecordingArchiveHelper {
                             filename,
                             webServerProvider.get().getArchivedDownloadURL(filename),
                             webServerProvider.get().getArchivedReportURL(filename),
-                            new Metadata(
-                                    recordingMetadataManager.deleteRecordingLabelsIfExists(
-                                            ARCHIVES, recordingName)));
+                            recordingMetadataManager.deleteRecordingMetadataIfExists(
+                                    ARCHIVES, recordingName));
             notificationFactory
                     .createBuilder()
                     .metaCategory(DELETE_NOTIFICATION_CATEGORY)
@@ -300,9 +299,7 @@ public class RecordingArchiveHelper {
                                             file,
                                             webServer.getArchivedDownloadURL(file),
                                             webServer.getArchivedReportURL(file),
-                                            new Metadata(
-                                                    recordingMetadataManager.getRecordingLabels(
-                                                            ARCHIVES, file)));
+                                            recordingMetadataManager.getMetadata(ARCHIVES, file));
                                 } catch (SocketException
                                         | UnknownHostException
                                         | URISyntaxException e) {
@@ -352,10 +349,8 @@ public class RecordingArchiveHelper {
                                                         file,
                                                         webServer.getArchivedDownloadURL(file),
                                                         webServer.getArchivedReportURL(file),
-                                                        new Metadata(
-                                                                recordingMetadataManager
-                                                                        .getRecordingLabels(
-                                                                                ARCHIVES, file)));
+                                                        recordingMetadataManager.getMetadata(
+                                                                ARCHIVES, file));
                                             } catch (SocketException
                                                     | UnknownHostException
                                                     | URISyntaxException e) {

--- a/src/main/java/io/cryostat/recordings/RecordingMetadataManager.java
+++ b/src/main/java/io/cryostat/recordings/RecordingMetadataManager.java
@@ -127,6 +127,10 @@ public class RecordingMetadataManager {
         return this.setRecordingLabels(RecordingArchiveHelper.ARCHIVES, recordingName, labels);
     }
 
+    public Metadata getMetadata(String targetId, String recordingName) {
+        return this.recordingLabelsMap.get(Pair.of(targetId, recordingName));
+    }
+
     public Map<String, String> getRecordingLabels(String targetId, String recordingName) {
         Objects.requireNonNull(targetId);
         Objects.requireNonNull(recordingName);

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -162,10 +162,8 @@ public class RecordingTargetHelper {
                                     desc,
                                     webServer.get().getDownloadURL(connection, desc.getName()),
                                     webServer.get().getReportURL(connection, desc.getName()),
-                                    new Metadata(
-                                            recordingMetadataManager.getRecordingLabels(
-                                                    connectionDescriptor.getTargetId(),
-                                                    recordingName)));
+                                    recordingMetadataManager.getMetadata(
+                                            connectionDescriptor.getTargetId(), recordingName));
                     notificationFactory
                             .createBuilder()
                             .metaCategory(CREATE_NOTIFICATION_CATEGORY)
@@ -268,13 +266,10 @@ public class RecordingTargetHelper {
                                                     webServer
                                                             .get()
                                                             .getReportURL(connection, d.getName()),
-                                                    new Metadata(
-                                                            recordingMetadataManager
-                                                                    .getRecordingLabels(
-                                                                            connectionDescriptor
-                                                                                    .getTargetId(),
-                                                                            recordingName)));
-                                    recordingMetadataManager.deleteRecordingLabelsIfExists(
+                                                    recordingMetadataManager.getMetadata(
+                                                            connectionDescriptor.getTargetId(),
+                                                            recordingName));
+                                    recordingMetadataManager.deleteRecordingMetadataIfExists(
                                             connectionDescriptor.getTargetId(), recordingName);
                                     notificationFactory
                                             .createBuilder()
@@ -372,18 +367,15 @@ public class RecordingTargetHelper {
                                             "The newly created Snapshot could not be found under its rename");
                                 }
 
-                                Map<String, String> labels =
-                                        Optional.ofNullable(
-                                                        recordingMetadataManager.getRecordingLabels(
-                                                                connectionDescriptor.getTargetId(),
-                                                                rename))
-                                                .orElse(Map.of());
+                                Metadata metadata =
+                                        recordingMetadataManager.getMetadata(
+                                                connectionDescriptor.getTargetId(), rename);
 
                                 return new HyperlinkedSerializableRecordingDescriptor(
                                         updatedDescriptor.get(),
                                         webServer.get().getDownloadURL(connection, rename),
                                         webServer.get().getReportURL(connection, rename),
-                                        new Metadata(labels));
+                                        metadata);
                             });
             future.complete(recordingDescriptor);
         } catch (Exception e) {

--- a/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
+++ b/src/main/java/io/cryostat/rules/ArchivedRecordingInfo.java
@@ -53,11 +53,7 @@ public class ArchivedRecordingInfo {
 
     public ArchivedRecordingInfo(
             String encodedServiceUri, String name, String downloadUrl, String reportUrl) {
-        this.encodedServiceUri = encodedServiceUri;
-        this.name = name;
-        this.downloadUrl = downloadUrl;
-        this.reportUrl = reportUrl;
-        this.metadata = new Metadata();
+        this(encodedServiceUri, name, downloadUrl, reportUrl, new Metadata());
     }
 
     public ArchivedRecordingInfo(
@@ -110,7 +106,7 @@ public class ArchivedRecordingInfo {
                 .append(name, ari.name)
                 .append(downloadUrl, ari.downloadUrl)
                 .append(reportUrl, ari.reportUrl)
-                .append(metadata.getLabels(), ari.metadata.getLabels())
+                .append(metadata, ari.metadata)
                 .isEquals();
     }
 

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -60,6 +60,7 @@ import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.rules.RuleRegistry.RuleEvent;
@@ -281,10 +282,12 @@ public class RuleProcessor
                         false);
         Map<String, String> labels =
                 new HashMap<>(
-                        metadataManager.getRecordingLabels(
-                                connectionDescriptor.getTargetId(), recording.getName()));
+                        metadataManager
+                                .getMetadata(
+                                        connectionDescriptor.getTargetId(), recording.getName())
+                                .getLabels());
         labels.put("rule", rule.getName());
-        metadataManager.setRecordingLabels(
-                connectionDescriptor.getTargetId(), recording.getName(), labels);
+        metadataManager.setRecordingMetadata(
+                connectionDescriptor.getTargetId(), recording.getName(), new Metadata(labels));
     }
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -84,6 +84,7 @@ type ActiveRecording implements Recording {
     name: String!
     reportUrl: Url!
     downloadUrl: Url!
+    metadata: RecordingMetadata!
 
     doArchive: ArchivedRecording!
     doStop: ActiveRecording!
@@ -94,6 +95,7 @@ type ArchivedRecording implements Recording {
     name: String!
     reportUrl: Url!
     downloadUrl: Url!
+    metadata: RecordingMetadata!
 
     doDelete: ArchivedRecording!
 }
@@ -102,6 +104,11 @@ interface Recording {
     name: String!
     reportUrl: Url!
     downloadUrl: Url!
+    metadata: RecordingMetadata!
+}
+
+type RecordingMetadata {
+    labels: Object!
 }
 
 input RecordingSettings {

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsGetHandlerTest.java
@@ -57,6 +57,7 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -191,6 +192,9 @@ class TargetRecordingsGetHandlerTest {
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         handler.handleAuthenticated(ctx);
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -62,6 +62,7 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 
@@ -203,6 +204,9 @@ class TargetRecordingsPostHandlerTest {
                         recordingTargetHelper.startRecording(
                                 Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(descriptor);
+
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         handler.handle(ctx);
 

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -70,6 +70,7 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.rules.ArchivedRecordingInfo;
 import io.cryostat.util.URIUtil;
 
@@ -245,9 +246,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -328,9 +329,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -421,9 +422,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -502,9 +503,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -589,9 +590,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -727,9 +728,9 @@ class RecordingArchiveHelperTest {
         Mockito.when(filenamePath.toString()).thenReturn(savedName);
         Mockito.when(destination.getFileName()).thenReturn(filenamePath);
         Mockito.when(
-                        recordingMetadataManager.copyLabelsToArchives(
+                        recordingMetadataManager.copyMetadataToArchives(
                                 Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(CompletableFuture.completedFuture(Map.of()));
+                .thenReturn(CompletableFuture.completedFuture(new Metadata()));
 
         ArchivedRecordingInfo info =
                 recordingArchiveHelper
@@ -790,6 +791,11 @@ class RecordingArchiveHelperTest {
                                 return "/some/path/download/" + name;
                             }
                         });
+
+        Mockito.when(
+                        recordingMetadataManager.deleteRecordingMetadataIfExists(
+                                Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         recordingArchiveHelper.deleteRecording(recordingName);
 
@@ -881,6 +887,9 @@ class RecordingArchiveHelperTest {
                                 return "/some/path/download/" + name;
                             }
                         });
+
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         List<ArchivedRecordingInfo> result = recordingArchiveHelper.getRecordings().get();
         List<ArchivedRecordingInfo> expected =

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -215,6 +215,9 @@ public class RecordingTargetHelperTest {
         IRecordingDescriptor descriptor = createDescriptor(recordingName);
         Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(descriptor));
 
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
+
         recordingTargetHelper.deleteRecording(connectionDescriptor, recordingName).get();
 
         Mockito.verify(service).close(descriptor);
@@ -308,6 +311,9 @@ public class RecordingTargetHelperTest {
                 .thenReturn("http://example.com/download");
         Mockito.when(webServer.getReportURL(Mockito.any(), Mockito.any()))
                 .thenReturn("http://example.com/report");
+
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         HyperlinkedSerializableRecordingDescriptor result =
                 recordingTargetHelper.createSnapshot(connectionDescriptor).get();
@@ -496,6 +502,9 @@ public class RecordingTargetHelperTest {
         Mockito.when(connection.getTemplateService()).thenReturn(templateService);
         Mockito.when(templateService.getEvents(Mockito.any(), Mockito.any()))
                 .thenReturn(Optional.of(events));
+
+        Mockito.when(recordingMetadataManager.getMetadata(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new Metadata());
 
         ScheduledFuture<Optional<IRecordingDescriptor>> scheduledFuture =
                 Mockito.mock(ScheduledFuture.class);

--- a/src/test/java/itest/RecordingMetadataIT.java
+++ b/src/test/java/itest/RecordingMetadataIT.java
@@ -169,6 +169,7 @@ public class RecordingMetadataIT extends StandardSelfTest {
             // update the recording labels
             Map<String, String> updatedLabels =
                     Map.of("KEY", "newValue", "key.2", "some.value", "key3", "1234");
+            Map<String, Map<String, String>> updatedMetadata = Map.of("labels", updatedLabels);
             CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
             webClient
                     .post(
@@ -194,7 +195,7 @@ public class RecordingMetadataIT extends StandardSelfTest {
                                                     HttpMimeType.JSON.mime(),
                                                     "status",
                                                     "OK"),
-                                    "data", Map.of("result", updatedLabels)));
+                                    "data", Map.of("result", updatedMetadata)));
             MatcherAssert.assertThat(
                     postResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS),
                     Matchers.equalTo(expectedResponse));

--- a/src/test/java/itest/RecordingMetadataIT.java
+++ b/src/test/java/itest/RecordingMetadataIT.java
@@ -37,6 +37,7 @@
  */
 package itest;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -78,6 +79,8 @@ public class RecordingMetadataIT extends StandardSelfTest {
 
         try {
             // create an in-memory recording
+            Map<String, String> startLabels = new HashMap<>(testLabels);
+            startLabels.put("template", "template=ALL,type=TARGET");
             CompletableFuture<Void> dumpRespFuture = new CompletableFuture<>();
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
             form.add("recordingName", RECORDING_NAME);
@@ -85,7 +88,7 @@ public class RecordingMetadataIT extends StandardSelfTest {
             form.add("events", "template=ALL");
             form.add(
                     "metadata",
-                    gson.toJson(new Metadata(testLabels), new TypeToken<Metadata>() {}.getType()));
+                    gson.toJson(new Metadata(startLabels), new TypeToken<Metadata>() {}.getType()));
             webClient
                     .post(String.format("/api/v1/targets/%s/recordings", TARGET_ID))
                     .sendForm(
@@ -117,7 +120,7 @@ public class RecordingMetadataIT extends StandardSelfTest {
 
             MatcherAssert.assertThat(
                     recordingInfo.getString("name"), Matchers.equalTo(RECORDING_NAME));
-            MatcherAssert.assertThat(actualMetadata.getLabels(), Matchers.equalTo(testLabels));
+            MatcherAssert.assertThat(actualMetadata.getLabels(), Matchers.equalTo(startLabels));
 
         } finally {
             // Clean up what we created
@@ -247,6 +250,8 @@ public class RecordingMetadataIT extends StandardSelfTest {
 
         try {
             // create an in-memory recording
+            Map<String, String> recordingLabels = new HashMap<>(testLabels);
+            recordingLabels.put("template", "template=ALL,type=TARGET");
             CompletableFuture<Void> dumpRespFuture = new CompletableFuture<>();
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
             form.add("recordingName", RECORDING_NAME);
@@ -254,7 +259,8 @@ public class RecordingMetadataIT extends StandardSelfTest {
             form.add("events", "template=ALL");
             form.add(
                     "metadata",
-                    gson.toJson(new Metadata(testLabels), new TypeToken<Metadata>() {}.getType()));
+                    gson.toJson(
+                            new Metadata(recordingLabels), new TypeToken<Metadata>() {}.getType()));
             webClient
                     .post(String.format("/api/v1/targets/%s/recordings", TARGET_ID))
                     .sendForm(
@@ -304,7 +310,7 @@ public class RecordingMetadataIT extends StandardSelfTest {
                             recordingInfo.getValue("metadata").toString(),
                             new TypeToken<Metadata>() {}.getType());
 
-            MatcherAssert.assertThat(actualMetadata.getLabels(), Matchers.equalTo(testLabels));
+            MatcherAssert.assertThat(actualMetadata.getLabels(), Matchers.equalTo(recordingLabels));
 
         } finally {
             // Clean up what we created


### PR DESCRIPTION
Fixes #860

The main feature work is a tiny change in the `feat(recordings): set recording template in label` commit. The commit before that is some simple refactoring (affecting a lot of call sites, but a minor change in itself) to generalize the `RecordingMetadataManager` to deal with the `Metadata` type rather than just the labels map, so that we can more easily extend the `Metadata` to contain other fields in the future. And the first commit in the series fixes an oversight where GraphQL responses did not include the metadata/labels properties, so there was a discrepancy there vs the standard HTTP API.