### PR TITLE
chore(build): Update SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
   <com.google.code.gson.version>2.8.6</com.google.code.gson.version>
   <com.github.ben-manes.caffeine.version>3.0.1</com.github.ben-manes.caffeine.version>
 
-  <com.github.spotbugs.version>4.2.3</com.github.spotbugs.version>
-  <com.github.spotbugs.plugin.version>4.2.3</com.github.spotbugs.plugin.version>
+  <com.github.spotbugs.version>4.5.3</com.github.spotbugs.version>
+  <com.github.spotbugs.plugin.version>4.5.3.0</com.github.spotbugs.plugin.version>
   <org.junit.jupiter.version>5.7.1</org.junit.jupiter.version>
   <org.hamcrest.version>2.2</org.hamcrest.version>
   <org.mockito.version>3.9.0</org.mockito.version>

--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -69,7 +69,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import dagger.Module;
 import dagger.Provides;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base32;
 
 @Module(
@@ -146,7 +145,6 @@ public abstract class MainModule {
         return builder.create();
     }
 
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Provides
     @Singleton
     @Named(RECORDINGS_PATH)

--- a/src/main/java/io/cryostat/configuration/ConfigurationModule.java
+++ b/src/main/java/io/cryostat/configuration/ConfigurationModule.java
@@ -57,7 +57,6 @@ import io.cryostat.platform.PlatformClient;
 import com.google.gson.Gson;
 import dagger.Module;
 import dagger.Provides;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base32;
 
 @Module
@@ -65,7 +64,6 @@ public abstract class ConfigurationModule {
     public static final String CONFIGURATION_PATH = "CONFIGURATION_PATH";
     public static final String CREDENTIALS_SUBDIRECTORY = "credentials";
 
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Provides
     @Singleton
     @Named(CONFIGURATION_PATH)

--- a/src/main/java/io/cryostat/jmc/serialization/SerializableEventTypeInfo.java
+++ b/src/main/java/io/cryostat/jmc/serialization/SerializableEventTypeInfo.java
@@ -86,7 +86,7 @@ public class SerializableEventTypeInfo {
     }
 
     public Map<String, SerializableOptionDescriptor> getOptionDescriptors() {
-        return options;
+        return new HashMap<String, SerializableOptionDescriptor>(options);
     }
 
     @Override

--- a/src/main/java/io/cryostat/messaging/notifications/Notification.java
+++ b/src/main/java/io/cryostat/messaging/notifications/Notification.java
@@ -43,9 +43,6 @@ import io.cryostat.messaging.MessagingServer;
 import io.cryostat.messaging.WsMessage;
 import io.cryostat.net.web.http.HttpMimeType;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("URF_UNREAD_FIELD")
 public class Notification<T> extends WsMessage {
 
     private final transient MessagingServer server;

--- a/src/main/java/io/cryostat/net/HttpServer.java
+++ b/src/main/java/io/cryostat/net/HttpServer.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Future;
 
 import io.cryostat.core.log.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
@@ -164,6 +165,7 @@ public class HttpServer {
         return isAlive;
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
     public Vertx getVertx() {
         return vertx;
     }

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -311,6 +311,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private boolean deleteToken(String token) throws IOException, TokenNotFoundException {
         try (OpenShiftClient client = clientProvider.apply(getServiceAccountToken())) {
             Boolean deleted =
@@ -345,6 +346,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private Future<TokenReviewStatus> performTokenReview(String token) {
         try (OpenShiftClient client = clientProvider.apply(getServiceAccountToken())) {
             TokenReview review =

--- a/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/OpenShiftAuthManager.java
@@ -523,7 +523,6 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
-    @SuppressWarnings("serial")
     public static class PermissionDeniedException extends Exception {
         private final String namespace;
         private final String resource;

--- a/src/main/java/io/cryostat/net/UnauthorizedException.java
+++ b/src/main/java/io/cryostat/net/UnauthorizedException.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.net;
 
-@SuppressWarnings("serial")
 public class UnauthorizedException extends Exception {
     UnauthorizedException(String user) {
         super(String.format("User \"%s\" failed auth", user));

--- a/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
+++ b/src/main/java/io/cryostat/net/reports/AbstractReportGeneratorService.java
@@ -55,8 +55,6 @@ import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.recordings.RecordingNotFoundException;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 abstract class AbstractReportGeneratorService implements ReportGeneratorService {
 
     static final int READ_BUFFER_SIZE = 64 * 1024; // 64 KB
@@ -100,7 +98,6 @@ abstract class AbstractReportGeneratorService implements ReportGeneratorService 
                                 conn, cd, recordingName, fs.createTempFile(null, null)));
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     Path copyRecordingToFile(
             JFRConnection conn, ConnectionDescriptor cd, String recordingName, Path path)
             throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -67,7 +67,6 @@ import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
@@ -161,8 +160,6 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
         }
     }
 
-    // FindBugs thinks the recordingPath or its properties is null somehow
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private ResponseMessage doPost(RoutingContext ctx, URL uploadUrl) throws Exception {
         String targetId = ctx.pathParam("targetId");
         String recordingName = ctx.pathParam("recordingName");

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
@@ -56,7 +56,6 @@ import io.cryostat.net.web.http.api.ApiVersion;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import dagger.Lazy;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.http.HttpMethod;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -124,7 +123,6 @@ class ApiGetHandler extends AbstractV2RequestHandler<ApiGetHandler.ApiResponse> 
                 .body(new ApiResponse(resourceFilePath, serializedHandlers));
     }
 
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     static class ApiResponse {
         @SerializedName("overview")
         final URL resourceFilePath;
@@ -138,7 +136,6 @@ class ApiGetHandler extends AbstractV2RequestHandler<ApiGetHandler.ApiResponse> 
         }
     }
 
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     static class SerializedHandler {
         @SerializedName("version")
         final ApiVersion apiVersion;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/IntermediateResponse.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/IntermediateResponse.java
@@ -77,7 +77,7 @@ public class IntermediateResponse<T> {
     }
 
     public Map<CharSequence, CharSequence> getHeaders() {
-        return this.headers;
+        return new HashMap<CharSequence, CharSequence>(this.headers);
     }
 
     public String getStatusMessage() {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
@@ -109,7 +109,7 @@ public class RequestParameters {
     }
 
     public Map<String, String> getPathParams() {
-        return this.pathParams;
+        return new HashMap<>(this.pathParams);
     }
 
     public MultiMap getQueryParams() {
@@ -125,7 +125,7 @@ public class RequestParameters {
     }
 
     public Set<FileUpload> getFileUploads() {
-        return this.fileUploads;
+        return new HashSet<>(this.fileUploads);
     }
 
     public String getBody() {

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -54,12 +54,21 @@ public class ServiceRef {
 
     private final @SerializedName("connectUrl") URI serviceUri;
     private final String alias;
-    private final Map<String, String> labels = new HashMap<>();
-    private final Annotations annotations = new Annotations();
+    private final Map<String, String> labels;
+    private final Annotations annotations;
 
     public ServiceRef(URI uri, String alias) {
         this.serviceUri = Objects.requireNonNull(uri);
         this.alias = alias;
+        this.labels = new HashMap<>();
+        this.annotations = new Annotations();
+    }
+
+    public ServiceRef(ServiceRef sr) {
+        this.serviceUri = sr.serviceUri;
+        this.alias = sr.alias;
+        this.labels = new HashMap<String, String>(sr.labels);
+        this.annotations = new Annotations(sr.annotations);
     }
 
     public URI getServiceUri() {
@@ -142,8 +151,21 @@ public class ServiceRef {
     }
 
     private static class Annotations {
-        private final Map<String, String> platform = new HashMap<>();
-        private final Map<AnnotationKey, String> cryostat = new EnumMap<>(AnnotationKey.class);
+        private final Map<String, String> platform;
+        private final Map<AnnotationKey, String> cryostat;
+
+        public Annotations() {
+            this.platform = new HashMap<>();
+            this.cryostat = new EnumMap<>(AnnotationKey.class);
+        }
+
+        public Annotations(Annotations a) {
+            this.platform = new HashMap<String, String>(a.platform);
+            this.cryostat =
+                    a.cryostat.isEmpty()
+                            ? (new EnumMap<>(AnnotationKey.class))
+                            : (new EnumMap<AnnotationKey, String>(a.cryostat));
+        }
 
         @Override
         public boolean equals(Object other) {

--- a/src/main/java/io/cryostat/platform/TargetDiscoveryEvent.java
+++ b/src/main/java/io/cryostat/platform/TargetDiscoveryEvent.java
@@ -45,7 +45,7 @@ public class TargetDiscoveryEvent {
 
     public TargetDiscoveryEvent(EventKind kind, ServiceRef serviceRef) {
         this.kind = kind;
-        this.serviceRef = serviceRef;
+        this.serviceRef = new ServiceRef(serviceRef);
     }
 
     public EventKind getEventKind() {
@@ -53,6 +53,6 @@ public class TargetDiscoveryEvent {
     }
 
     public ServiceRef getServiceRef() {
-        return this.serviceRef;
+        return new ServiceRef(this.serviceRef);
     }
 }

--- a/src/main/java/io/cryostat/platform/discovery/TargetNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/TargetNode.java
@@ -42,7 +42,6 @@ import java.util.Map;
 
 import io.cryostat.platform.ServiceRef;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -52,16 +51,16 @@ public class TargetNode extends AbstractNode {
 
     public TargetNode(NodeType nodeType, ServiceRef target) {
         super(target.getServiceUri().toString(), nodeType, Collections.emptyMap());
-        this.target = target;
+        this.target = new ServiceRef(target);
     }
 
     public TargetNode(NodeType nodeType, ServiceRef target, Map<String, String> labels) {
         super(target.getServiceUri().toString(), nodeType, labels);
-        this.target = target;
+        this.target = new ServiceRef(target);
     }
 
     public ServiceRef getTarget() {
-        return target;
+        return new ServiceRef(target);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/discovery/TargetNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/TargetNode.java
@@ -46,7 +46,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class TargetNode extends AbstractNode {
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     private final ServiceRef target;
 
     public TargetNode(NodeType nodeType, ServiceRef target) {

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -58,6 +58,7 @@ import io.cryostat.platform.discovery.TargetNode;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CustomTargetPlatformClient extends AbstractPlatformClient {
 
@@ -70,6 +71,7 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
     private final FileSystem fs;
     private final Gson gson;
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Field is never mutated")
     public CustomTargetPlatformClient(Path confDir, FileSystem fs, Gson gson) {
         this.targets = new TreeSet<>((u1, u2) -> u1.getServiceUri().compareTo(u2.getServiceUri()));
         this.saveFile = confDir.resolve(SAVEFILE_NAME);

--- a/src/main/java/io/cryostat/platform/internal/MergingPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/MergingPlatformClient.java
@@ -38,6 +38,7 @@
 package io.cryostat.platform.internal;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -62,7 +63,7 @@ public class MergingPlatformClient implements PlatformClient, Consumer<TargetDis
 
     public MergingPlatformClient(
             NotificationFactory notificationFactory, List<PlatformClient> clients) {
-        this.clients = clients;
+        this.clients = new ArrayList<PlatformClient>(clients);
         this.listeners = new HashSet<>();
         this.clients.forEach(pc -> pc.addTargetDiscoveryListener(this));
 

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -82,7 +82,6 @@ class OpenShiftPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlat
         return PRIORITY_PLATFORM + 15;
     }
 
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Override
     public boolean isAvailable() {
         logger.trace("Testing OpenShift Platform Availability");

--- a/src/main/java/io/cryostat/recordings/EventOptionsBuilder.java
+++ b/src/main/java/io/cryostat/recordings/EventOptionsBuilder.java
@@ -53,6 +53,8 @@ import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceV2;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.tui.ClientWriter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class EventOptionsBuilder {
 
     private final boolean isV2;
@@ -107,6 +109,7 @@ public class EventOptionsBuilder {
         return (V) t;
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
     public IConstrainedMap<EventOptionID> build() {
         if (!isV2) {
             return null;

--- a/src/main/java/io/cryostat/recordings/EventOptionsBuilder.java
+++ b/src/main/java/io/cryostat/recordings/EventOptionsBuilder.java
@@ -117,14 +117,12 @@ public class EventOptionsBuilder {
         return map;
     }
 
-    @SuppressWarnings("serial")
     public static class EventTypeException extends Exception {
         EventTypeException(String eventType) {
             super(String.format("Unknown event type \"%s\"", eventType));
         }
     }
 
-    @SuppressWarnings("serial")
     static class EventOptionException extends Exception {
         EventOptionException(String eventType, String option) {
             super(String.format("Unknown option \"%s\" for event \"%s\"", option, eventType));

--- a/src/main/java/io/cryostat/recordings/RecordingMetadataManager.java
+++ b/src/main/java/io/cryostat/recordings/RecordingMetadataManager.java
@@ -253,11 +253,11 @@ public class RecordingMetadataManager {
         }
 
         public Metadata(Map<String, String> labels) {
-            this.labels = labels;
+            this.labels = new ConcurrentHashMap<>(labels);
         }
 
         public Map<String, String> getLabels() {
-            return labels;
+            return new ConcurrentHashMap<>(labels);
         }
 
         @Override

--- a/src/main/java/io/cryostat/rules/IllegalMatchExpressionException.java
+++ b/src/main/java/io/cryostat/rules/IllegalMatchExpressionException.java
@@ -39,7 +39,6 @@ package io.cryostat.rules;
 
 import jdk.nashorn.api.tree.Tree;
 
-@SuppressWarnings("serial")
 class IllegalMatchExpressionException extends RuntimeException {
     IllegalMatchExpressionException() {
         this("matchExpression parsing failed");

--- a/src/main/java/io/cryostat/rules/MatchExpressionValidationException.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionValidationException.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.rules;
 
-@SuppressWarnings("serial")
 public class MatchExpressionValidationException extends Exception {
 
     MatchExpressionValidationException(Throwable cause) {

--- a/src/main/java/io/cryostat/rules/RuleException.java
+++ b/src/main/java/io/cryostat/rules/RuleException.java
@@ -39,7 +39,6 @@ package io.cryostat.rules;
 
 import java.io.IOException;
 
-@SuppressWarnings("serial")
 public class RuleException extends IOException {
     RuleException(String reason) {
         super(reason);

--- a/src/main/java/io/cryostat/util/JavaProcess.java
+++ b/src/main/java/io/cryostat/util/JavaProcess.java
@@ -46,6 +46,8 @@ import java.util.Objects;
 
 import io.cryostat.core.log.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class JavaProcess {
 
     static Process exec(
@@ -78,16 +80,19 @@ public class JavaProcess {
             return this;
         }
 
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
         public Builder env(Map<String, String> env) {
             this.env = env;
             return this;
         }
 
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
         public Builder jvmArgs(List<String> jvmArgs) {
             this.jvmArgs = jvmArgs;
             return this;
         }
 
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
         public Builder processArgs(List<String> processArgs) {
             this.processArgs = processArgs;
             return this;

--- a/src/main/java/io/cryostat/util/RelativeURIException.java
+++ b/src/main/java/io/cryostat/util/RelativeURIException.java
@@ -40,7 +40,6 @@ package io.cryostat.util;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-@SuppressWarnings("serial")
 public class RelativeURIException extends URISyntaxException {
     public RelativeURIException(URI u) {
         super(u.toString(), "Not a valid absolute URI");


### PR DESCRIPTION
Fixes #813 

Most of the new bugs were related to the `ServiceRef` object constructors and getters. Spotbugs outputs an [EI_EXPOSE_REP](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#ei-may-expose-internal-representation-by-returning-reference-to-mutable-object-ei-expose-rep) bug for these, where "returning a reference to a mutable object value stored in one of the object's fields exposes the internal representation of the object". I've added a copy constructor to return new copies of the ServiceRef objects. Let me know what you think.