### PR TITLE
feat(graphql): implement k8s-style label selectors

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
@@ -44,10 +44,9 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
-
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
 
 class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescriptor>> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
@@ -69,14 +69,16 @@ class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescript
                             .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.LABELS)) {
-            String labels = filter.get(FilterInput.Key.LABELS);
-            result =
-                    result.stream()
-                            .filter(
-                                    r ->
-                                            LabelSelectorMatcher.parse(labels)
-                                                    .test(r.getMetadata().getLabels()))
-                            .collect(Collectors.toList());
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                result =
+                        result.stream()
+                                .filter(
+                                        r ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(r.getMetadata().getLabels()))
+                                .collect(Collectors.toList());
+            }
         }
         if (filter.contains(FilterInput.Key.STATE)) {
             String state = filter.get(FilterInput.Key.STATE);

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
@@ -44,9 +44,10 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
+
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
 
 class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescriptor>> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ActiveRecordingsFetcher.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -65,6 +66,16 @@ class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescript
             result =
                     result.stream()
                             .filter(r -> Objects.equals(r.getName(), recordingName))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            String labels = filter.get(FilterInput.Key.LABELS);
+            result =
+                    result.stream()
+                            .filter(
+                                    r ->
+                                            LabelSelectorMatcher.parse(labels)
+                                                    .test(r.getMetadata().getLabels()))
                             .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.STATE)) {
@@ -114,17 +125,6 @@ class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescript
             result =
                     result.stream()
                             .filter(r -> r.getStartTime() >= startTime)
-                            .collect(Collectors.toList());
-        }
-        if (filter.contains(FilterInput.Key.TEMPLATE_LABEL)) {
-            String label = filter.get(FilterInput.Key.TEMPLATE_LABEL);
-            result =
-                    result.stream()
-                            .filter(
-                                    r ->
-                                            Objects.equals(
-                                                    r.getMetadata().getLabels().get("template"),
-                                                    label))
                             .collect(Collectors.toList());
         }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ArchivedRecordingsFetcher.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import io.cryostat.net.web.http.api.beta.graph.RecordingsFetcher.Recordings;
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
 import graphql.schema.DataFetcher;
@@ -64,6 +65,16 @@ class ArchivedRecordingsFetcher implements DataFetcher<List<ArchivedRecordingInf
             result =
                     result.stream()
                             .filter(r -> Objects.equals(r.getName(), recordingName))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            String labels = filter.get(FilterInput.Key.LABELS);
+            result =
+                    result.stream()
+                            .filter(
+                                    r ->
+                                            LabelSelectorMatcher.parse(labels)
+                                                    .test(r.getMetadata().getLabels()))
                             .collect(Collectors.toList());
         }
         return result;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/ArchivedRecordingsFetcher.java
@@ -68,14 +68,16 @@ class ArchivedRecordingsFetcher implements DataFetcher<List<ArchivedRecordingInf
                             .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.LABELS)) {
-            String labels = filter.get(FilterInput.Key.LABELS);
-            result =
-                    result.stream()
-                            .filter(
-                                    r ->
-                                            LabelSelectorMatcher.parse(labels)
-                                                    .test(r.getMetadata().getLabels()))
-                            .collect(Collectors.toList());
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                result =
+                        result.stream()
+                                .filter(
+                                        r ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(r.getMetadata().getLabels()))
+                                .collect(Collectors.toList());
+            }
         }
         return result;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
@@ -47,6 +47,7 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
@@ -71,6 +72,11 @@ class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>> {
         if (filter.contains(FilterInput.Key.NAME)) {
             String nodeName = filter.get(FilterInput.Key.NAME);
             nodes = filter(nodes, n -> Objects.equals(n.getName(), nodeName));
+        }
+
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            String labels = filter.get(FilterInput.Key.LABELS);
+            nodes = filter(nodes, n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()));
         }
 
         if (filter.contains(FilterInput.Key.NODE_TYPE)) {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/EnvironmentNodesFetcher.java
@@ -75,8 +75,10 @@ class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>> {
         }
 
         if (filter.contains(FilterInput.Key.LABELS)) {
-            String labels = filter.get(FilterInput.Key.LABELS);
-            nodes = filter(nodes, n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()));
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                nodes = filter(nodes, n -> LabelSelectorMatcher.parse(label).test(n.getLabels()));
+            }
         }
 
         if (filter.contains(FilterInput.Key.NODE_TYPE)) {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/FilterInput.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/FilterInput.java
@@ -66,6 +66,7 @@ class FilterInput {
 
     enum Key {
         NAME("name"),
+        LABELS("labels"),
         NODE_TYPE("nodeType"),
         STATE("state"),
         CONTINUOUS("continuous"),
@@ -74,7 +75,6 @@ class FilterInput {
         DURATION_LE("durationMsLessThanEqual"),
         START_TIME_BEFORE("startTimeMsBeforeEqual"),
         START_TIME_AFTER("startTimeMsAfterEqual"),
-        TEMPLATE_LABEL("templateLabel"),
         ;
 
         private final String key;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/FilterInput.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/FilterInput.java
@@ -67,6 +67,7 @@ class FilterInput {
     enum Key {
         NAME("name"),
         LABELS("labels"),
+        ANNOTATIONS("annotations"),
         NODE_TYPE("nodeType"),
         STATE("state"),
         CONTINUOUS("continuous"),

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
@@ -38,8 +38,11 @@
 package io.cryostat.net.web.http.api.beta.graph;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
@@ -83,6 +86,25 @@ class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>> {
             result =
                     result.stream()
                             .filter(n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.ANNOTATIONS)) {
+            String annotations = filter.get(FilterInput.Key.ANNOTATIONS);
+            Function<TargetNode, Map<String, String>> mergedAnnotations =
+                    n -> {
+                        Map<String, String> merged = new HashMap<>();
+                        n.getTarget()
+                                .getCryostatAnnotations()
+                                .forEach((key, val) -> merged.put(key.name(), val));
+                        merged.putAll(n.getTarget().getPlatformAnnotations());
+                        return merged;
+                    };
+            result =
+                    result.stream()
+                            .filter(
+                                    n ->
+                                            LabelSelectorMatcher.parse(annotations)
+                                                    .test(mergedAnnotations.apply(n)))
                             .collect(Collectors.toList());
         }
         return result;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
@@ -82,14 +82,16 @@ class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>> {
                             .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.LABELS)) {
-            String labels = filter.get(FilterInput.Key.LABELS);
-            result =
-                    result.stream()
-                            .filter(n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()))
-                            .collect(Collectors.toList());
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                result =
+                        result.stream()
+                                .filter(n -> LabelSelectorMatcher.parse(label).test(n.getLabels()))
+                                .collect(Collectors.toList());
+            }
         }
         if (filter.contains(FilterInput.Key.ANNOTATIONS)) {
-            String annotations = filter.get(FilterInput.Key.ANNOTATIONS);
+            List<String> annotations = filter.get(FilterInput.Key.ANNOTATIONS);
             Function<TargetNode, Map<String, String>> mergedAnnotations =
                     n -> {
                         Map<String, String> merged = new HashMap<>();
@@ -99,13 +101,15 @@ class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>> {
                         merged.putAll(n.getTarget().getPlatformAnnotations());
                         return merged;
                     };
-            result =
-                    result.stream()
-                            .filter(
-                                    n ->
-                                            LabelSelectorMatcher.parse(annotations)
-                                                    .test(mergedAnnotations.apply(n)))
-                            .collect(Collectors.toList());
+            for (String annotation : annotations) {
+                result =
+                        result.stream()
+                                .filter(
+                                        n ->
+                                                LabelSelectorMatcher.parse(annotation)
+                                                        .test(mergedAnnotations.apply(n)))
+                                .collect(Collectors.toList());
+            }
         }
         return result;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodeRecurseFetcher.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
@@ -75,6 +76,13 @@ class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>> {
             result =
                     result.stream()
                             .filter(n -> Objects.equals(n.getName(), nodeName))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            String labels = filter.get(FilterInput.Key.LABELS);
+            result =
+                    result.stream()
+                            .filter(n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()))
                             .collect(Collectors.toList());
         }
         return result;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
@@ -80,14 +80,16 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
                             .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.LABELS)) {
-            String labels = filter.get(FilterInput.Key.LABELS);
-            result =
-                    result.stream()
-                            .filter(n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()))
-                            .collect(Collectors.toList());
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                result =
+                        result.stream()
+                                .filter(n -> LabelSelectorMatcher.parse(label).test(n.getLabels()))
+                                .collect(Collectors.toList());
+            }
         }
         if (filter.contains(FilterInput.Key.ANNOTATIONS)) {
-            String annotations = filter.get(FilterInput.Key.ANNOTATIONS);
+            List<String> annotations = filter.get(FilterInput.Key.ANNOTATIONS);
             Function<TargetNode, Map<String, String>> mergedAnnotations =
                     n -> {
                         Map<String, String> merged = new HashMap<>();
@@ -97,13 +99,15 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
                         merged.putAll(n.getTarget().getPlatformAnnotations());
                         return merged;
                     };
-            result =
-                    result.stream()
-                            .filter(
-                                    n ->
-                                            LabelSelectorMatcher.parse(annotations)
-                                                    .test(mergedAnnotations.apply(n)))
-                            .collect(Collectors.toList());
+            for (String annotation : annotations) {
+                result =
+                        result.stream()
+                                .filter(
+                                        n ->
+                                                LabelSelectorMatcher.parse(annotation)
+                                                        .test(mergedAnnotations.apply(n)))
+                                .collect(Collectors.toList());
+            }
         }
         return result;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/TargetNodesFetcher.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.TargetNode;
 
 import graphql.schema.DataFetcher;
@@ -73,6 +74,13 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
             result =
                     result.stream()
                             .filter(n -> Objects.equals(n.getName(), nodeName))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            String labels = filter.get(FilterInput.Key.LABELS);
+            result =
+                    result.stream()
+                            .filter(n -> LabelSelectorMatcher.parse(labels).test(n.getLabels()))
                             .collect(Collectors.toList());
         }
         return result;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/EqualityMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/EqualityMatcher.java
@@ -91,4 +91,3 @@ public class EqualityMatcher implements LabelMatcher {
         }
     }
 }
-

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/EqualityMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/EqualityMatcher.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph.labels;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class EqualityMatcher implements LabelMatcher {
+
+    private final String key;
+    private final EqualityMatcher.Operator operator;
+    private final String value;
+
+    EqualityMatcher(String key, EqualityMatcher.Operator operator, String value) {
+        this.key = key;
+        this.operator = operator;
+        this.value = value;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean test(String s) {
+        return operator.with(value).test(s);
+    }
+
+    public enum Operator {
+        EQUAL("=", arg -> v -> Objects.equals(arg, v)),
+        DOUBLE_EQUAL("==", arg -> v -> Objects.equals(arg, v)),
+        NOT_EQUAL("!=", arg -> v -> !Objects.equals(arg, v)),
+        ;
+
+        private final String token;
+        private final Function<String, Predicate<String>> fn;
+
+        Operator(String token, Function<String, Predicate<String>> fn) {
+            this.token = token;
+            this.fn = fn;
+        }
+
+        Predicate<String> with(String value) {
+            return fn.apply(value);
+        }
+
+        public static Operator fromString(String str) {
+            for (Operator op : Operator.values()) {
+                if (op.token.equals(str)) {
+                    return op;
+                }
+            }
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelMatcher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph.labels;
+
+import java.util.function.Predicate;
+
+interface LabelMatcher extends Predicate<String> {
+    String getKey();
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -63,8 +63,7 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
     // parens, not a single matched pair. Regexes are hard. This works but is too tolerant of broken
     // expressions.
     static final Pattern SET_MEMBER_PATTERN =
-            Pattern.compile(
-                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./=, ]*)$",
+            Pattern.compile("(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+\\((?<values>(?:[a-zA-Z0-9-_./=, ]+[,\\s]*)+)\\)",
                     Pattern.CASE_INSENSITIVE);
 
     // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a
@@ -125,7 +124,7 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
             String op = m.group("op");
             SetMatcher.Operator operator = SetMatcher.Operator.fromString(op);
             Objects.requireNonNull(operator, "Unknown set operator " + op);
-            String value = m.group("values").replaceAll("[\\(\\)]+", "");
+            String value = m.group("values");
             List<String> values =
                     Arrays.asList(value.split(",")).stream()
                             .map(String::trim)

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph.labels;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
+
+    // ex. "my.prefix/label = something". Whitespaces around the operator are ignored. Left side
+    // must loosely look like a k8s label (not strictly enforced here), right side must loosely look
+    // like a k8s label value, which may be empty. Allowed operators are "=", "==", "!=".
+    static final Pattern EQUALITY_PATTERN =
+        Pattern.compile("^(?<key>[a-zA-Z0-9-_./]+)[\\s]*(?<op>=|==|!=)[\\s]*(?<value>[a-zA-Z0-9-_./]*)$");
+
+    // ex. "environment in (production, qa)" or "tier NotIn (frontend, backend)". Tests if the given
+    // label has or does not have any of the specified values.
+    // FIXME the part of the expression to the right of the operator actually allows mismatched
+    // parens, not a single matched pair. Regexes are hard. This works but is too tolerant of broken
+    // expressions.
+    static final Pattern SET_MEMBER_PATTERN = Pattern.compile("^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./, ]*)$", Pattern.CASE_INSENSITIVE);
+
+    // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a
+    // key, with or without a value.
+    static final Pattern SET_EXISTENCE_PATTERN = Pattern.compile("^(?<op>!?)(?<key>[a-zA-Z0-9-_./]+)$");
+
+    private final List<LabelMatcher> matchers = new ArrayList<>();
+
+    private LabelSelectorMatcher(Collection<LabelMatcher> matchers) {
+        this.matchers.addAll(matchers);
+    }
+
+    @Override
+    public boolean test(Map<String, String> labels) {
+        return this.matchers.stream().allMatch(m -> m.test(labels.get(m.getKey())));
+    }
+
+    public static LabelSelectorMatcher parse(String s) throws IllegalArgumentException {
+        List<LabelMatcher> matchers = new ArrayList<>();
+        List<String> clauses = Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
+        matchers.addAll(parseEqualities(clauses));
+        matchers.addAll(parseSetMemberships(clauses));
+        return new LabelSelectorMatcher(matchers);
+    }
+
+    private static Collection<LabelMatcher> parseEqualities(Collection<String> clauses) {
+        List<LabelMatcher> matchers = new ArrayList<>();
+        for (String clause : clauses) {
+            Matcher m = EQUALITY_PATTERN.matcher(clause);
+            if (!m.matches()) {
+                continue;
+            }
+            String key = m.group("key");
+            String op = m.group("op");
+            EqualityMatcher.Operator operator = EqualityMatcher.Operator.fromString(op);
+            Objects.requireNonNull(operator, "Unknown equality operator " + op);
+            String value = m.group("value");
+            EqualityMatcher em = new EqualityMatcher(key, operator, value);
+            matchers.add(em);
+        }
+        return matchers;
+    }
+
+    private static Collection<LabelMatcher> parseSetMemberships(Collection<String> clauses) {
+        List<LabelMatcher> matchers = new ArrayList<>();
+        for (String clause : clauses) {
+            Matcher m = SET_MEMBER_PATTERN.matcher(clause);
+            if (!m.matches()) {
+                continue;
+            }
+            String key = m.group("key");
+            String op = m.group("op");
+            SetMatcher.Operator operator = SetMatcher.Operator.fromString(op);
+            Objects.requireNonNull(operator, "Unknown set operator " + op);
+            String value = m.group("values").replaceAll("[\\(\\)]+", "");
+            List<String> values =
+                Arrays.asList(value.split(",")).stream().map(String::trim).collect(Collectors.toList());
+            SetMatcher em = new SetMatcher(key, operator, values);
+            matchers.add(em);
+        }
+        for (String clause : clauses) {
+            Matcher m = SET_EXISTENCE_PATTERN.matcher(clause);
+            if (!m.matches()) {
+                continue;
+            }
+            String key = m.group("key");
+            String op = m.group("op");
+            SetMatcher.Operator operator = SetMatcher.Operator.fromString(op);
+            Objects.requireNonNull(operator, "Unknown set operator " + op);
+            SetMatcher em = new SetMatcher(key, operator);
+            matchers.add(em);
+        }
+        return matchers;
+    }
+
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -55,7 +55,7 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
     // like a k8s label value, which may be empty. Allowed operators are "=", "==", "!=".
     static final Pattern EQUALITY_PATTERN =
             Pattern.compile(
-                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]*(?<op>=|==|!=)[\\s]*(?<value>[a-zA-Z0-9-_./]*)$");
+                    "^(?<key>[\\S]+)[\\s]*(?<op>=|==|!=)[\\s]*(?<value>[\\S]*)$");
 
     // ex. "environment in (production, qa)" or "tier NotIn (frontend, backend)". Tests if the given
     // label has or does not have any of the specified values.
@@ -63,7 +63,7 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
     // parens, not a single matched pair. Regexes are hard. This works but is too tolerant of broken
     // expressions.
     static final Pattern SET_MEMBER_PATTERN =
-            Pattern.compile("(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+\\((?<values>(?:[a-zA-Z0-9-_./=, ]+[,\\s]*)+)\\)",
+            Pattern.compile("(?<key>[\\S+]+)[\\s]+(?<op>in|notin)[\\s]+\\((?<values>(?:[\\S]+[,\\s]*)+)\\)",
                     Pattern.CASE_INSENSITIVE);
 
     // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -85,10 +85,12 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
 
     public static LabelSelectorMatcher parse(String s) throws IllegalArgumentException {
         List<LabelMatcher> matchers = new ArrayList<>();
-        List<String> clauses =
-                Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
-        matchers.addAll(parseEqualities(clauses));
-        matchers.addAll(parseSetMemberships(clauses));
+        if (s != null) {
+            List<String> clauses =
+                    Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
+            matchers.addAll(parseEqualities(clauses));
+            matchers.addAll(parseSetMemberships(clauses));
+        }
         return new LabelSelectorMatcher(matchers);
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -64,7 +64,7 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
     // expressions.
     static final Pattern SET_MEMBER_PATTERN =
             Pattern.compile(
-                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./, ]*)$",
+                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./=, ]*)$",
                     Pattern.CASE_INSENSITIVE);
 
     // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a
@@ -87,7 +87,9 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
         List<LabelMatcher> matchers = new ArrayList<>();
         if (s != null) {
             List<String> clauses =
-                    Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
+                    Arrays.asList(s.split(",")).stream()
+                            .map(String::trim)
+                            .collect(Collectors.toList());
             matchers.addAll(parseEqualities(clauses));
             matchers.addAll(parseSetMemberships(clauses));
         }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcher.java
@@ -54,18 +54,23 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
     // must loosely look like a k8s label (not strictly enforced here), right side must loosely look
     // like a k8s label value, which may be empty. Allowed operators are "=", "==", "!=".
     static final Pattern EQUALITY_PATTERN =
-        Pattern.compile("^(?<key>[a-zA-Z0-9-_./]+)[\\s]*(?<op>=|==|!=)[\\s]*(?<value>[a-zA-Z0-9-_./]*)$");
+            Pattern.compile(
+                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]*(?<op>=|==|!=)[\\s]*(?<value>[a-zA-Z0-9-_./]*)$");
 
     // ex. "environment in (production, qa)" or "tier NotIn (frontend, backend)". Tests if the given
     // label has or does not have any of the specified values.
     // FIXME the part of the expression to the right of the operator actually allows mismatched
     // parens, not a single matched pair. Regexes are hard. This works but is too tolerant of broken
     // expressions.
-    static final Pattern SET_MEMBER_PATTERN = Pattern.compile("^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./, ]*)$", Pattern.CASE_INSENSITIVE);
+    static final Pattern SET_MEMBER_PATTERN =
+            Pattern.compile(
+                    "^(?<key>[a-zA-Z0-9-_./]+)[\\s]+(?<op>in|notin)[\\s]+(?<values>[\\(\\)a-zA-Z0-9-_./, ]*)$",
+                    Pattern.CASE_INSENSITIVE);
 
     // ex. "mykey" or "!mykey". Tests whether the given key name exists in the test label set as a
     // key, with or without a value.
-    static final Pattern SET_EXISTENCE_PATTERN = Pattern.compile("^(?<op>!?)(?<key>[a-zA-Z0-9-_./]+)$");
+    static final Pattern SET_EXISTENCE_PATTERN =
+            Pattern.compile("^(?<op>!?)(?<key>[a-zA-Z0-9-_./]+)$");
 
     private final List<LabelMatcher> matchers = new ArrayList<>();
 
@@ -80,7 +85,8 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
 
     public static LabelSelectorMatcher parse(String s) throws IllegalArgumentException {
         List<LabelMatcher> matchers = new ArrayList<>();
-        List<String> clauses = Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
+        List<String> clauses =
+                Arrays.asList(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
         matchers.addAll(parseEqualities(clauses));
         matchers.addAll(parseSetMemberships(clauses));
         return new LabelSelectorMatcher(matchers);
@@ -117,7 +123,9 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
             Objects.requireNonNull(operator, "Unknown set operator " + op);
             String value = m.group("values").replaceAll("[\\(\\)]+", "");
             List<String> values =
-                Arrays.asList(value.split(",")).stream().map(String::trim).collect(Collectors.toList());
+                    Arrays.asList(value.split(",")).stream()
+                            .map(String::trim)
+                            .collect(Collectors.toList());
             SetMatcher em = new SetMatcher(key, operator, values);
             matchers.add(em);
         }
@@ -135,5 +143,4 @@ public class LabelSelectorMatcher implements Predicate<Map<String, String>> {
         }
         return matchers;
     }
-
 }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/SetMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/SetMatcher.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph.labels;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class SetMatcher implements LabelMatcher {
+
+    private final SetMatcher.Operator operator;
+    private final String key;
+    private final Set<String> values;
+
+    SetMatcher(String key, SetMatcher.Operator operator) {
+        this(key, operator, Set.of());
+    }
+
+    SetMatcher(String key, SetMatcher.Operator operator, Collection<String> values) {
+        this.key = key;
+        this.operator = operator;
+        this.values = new HashSet<>(values);
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean test(String s) {
+        return operator.with(values).test(s);
+    }
+
+    public enum Operator {
+        IN("In", args -> v -> contains(args, v)),
+        NOT_IN("NotIn", args -> v -> !contains(args, v)),
+        EXISTS("", args -> v -> v != null),
+        DOES_NOT_EXIST("!", args -> v -> v == null),
+        ;
+
+        private final String token;
+        private final Function<Collection<String>, Predicate<String>> fn;
+
+        Operator(String token, Function<Collection<String>, Predicate<String>> fn) {
+            this.token = token;
+            this.fn = fn;
+        }
+
+        Predicate<String> with(Collection<String> values) {
+            return fn.apply(values);
+        }
+
+        public static Operator fromString(String str) {
+            for (Operator op : Operator.values()) {
+                if (op.token.equalsIgnoreCase(str)) {
+                    return op;
+                }
+            }
+            return null;
+        }
+
+        private static boolean contains(Collection<String> args, String v) {
+            return args.stream().anyMatch(s -> s.equals(v));
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/SetMatcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/labels/SetMatcher.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.net.web.http.api.beta.graph.labels;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -8,14 +8,17 @@ scalar Long
 input EnvironmentNodeFilterInput {
     name: String
     nodeType: String
+    labels: String
 }
 
 input TargetNodesFilterInput {
     name: String
+    labels: String
 }
 
 input DescendantTargetsFilterInput {
     name: String
+    labels: String
 }
 
 input ActiveRecordingFilterInput {
@@ -27,11 +30,12 @@ input ActiveRecordingFilterInput {
     durationMsLessThanEqual: Long
     startTimeMsBeforeEqual: Long # TODO support/convert other DateTime formats, not just epoch timestamps
     startTimeMsAfterEqual: Long
-    templateLabel: String # TODO support proper label-based filtering with selectors, not just this special case
+    labels: String
 }
 
 input ArchivedRecordingFilterInput {
     name: String
+    labels: String
 }
 
 type ServiceRef {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -5,10 +5,6 @@ scalar Url
 scalar Boolean
 scalar Long
 
-input BasicFilterInput {
-    name: String
-}
-
 input EnvironmentNodeFilterInput {
     name: String
     nodeType: String

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -14,11 +14,13 @@ input EnvironmentNodeFilterInput {
 input TargetNodesFilterInput {
     name: String
     labels: String
+    annotations: String
 }
 
 input DescendantTargetsFilterInput {
     name: String
     labels: String
+    annotations: String
 }
 
 input ActiveRecordingFilterInput {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -8,19 +8,19 @@ scalar Long
 input EnvironmentNodeFilterInput {
     name: String
     nodeType: String
-    labels: String
+    labels: [String]
 }
 
 input TargetNodesFilterInput {
     name: String
-    labels: String
-    annotations: String
+    labels: [String]
+    annotations: [String]
 }
 
 input DescendantTargetsFilterInput {
     name: String
-    labels: String
-    annotations: String
+    labels: [String]
+    annotations: [String]
 }
 
 input ActiveRecordingFilterInput {
@@ -32,12 +32,12 @@ input ActiveRecordingFilterInput {
     durationMsLessThanEqual: Long
     startTimeMsBeforeEqual: Long # TODO support/convert other DateTime formats, not just epoch timestamps
     startTimeMsAfterEqual: Long
-    labels: String
+    labels: [String]
 }
 
 input ArchivedRecordingFilterInput {
     name: String
-    labels: String
+    labels: [String]
 }
 
 type ServiceRef {

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph.labels;
+
+import java.util.Map;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LabelSelectorMatcherTest {
+
+    final Map<String, String> labels = Map.of(
+            "foo", "bar",
+            "something", "else",
+            "my.prefixed/label", "expectedValue",
+            "env", "prod",
+            "present", "irrelevant"
+            );
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "foo=bar,something=else,env=prod : true",
+        "foo=bar,something=wrong : false",
+        ": true",
+        ",: true",
+        "my.prefixed/label = expectedValue, present, env in ( prod, stage ) : true"
+    }, delimiter = ':')
+    void testCombos(String expr, boolean pass) {
+        if (expr == null) {
+            expr = "";
+        }
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo=bar, true",
+        "something=wrong, false",
+        "my.prefixed/label = expectedValue, true"
+    })
+    void testSingleEquality(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo==bar, true",
+        "something==wrong, false",
+        "my.prefixed/label == expectedValue, true"
+    })
+    void testDoubleEquality(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo!=bar, false",
+        "something!=wrong, true",
+        "my.prefixed/label != expectedValue, false"
+    })
+    void testInequality(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "foo in (bar, baz) : true",
+        "something In (else, orother) : true",
+        "env IN (stage,qa) : false",
+    }, delimiter = ':')
+    void testSetIn(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "foo notin (bar, baz) : false",
+        "something NotIn (else, orother) : false",
+        "env NOTIN (stage,qa) : true",
+    }, delimiter = ':')
+    void testSetNotIn(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo, true",
+        "something, true",
+        "my.prefixed/label, true",
+        "another/missing-label, false",
+        "present, true"
+    })
+    void testExists(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "!foo, false",
+        "!something, false",
+        "!present, false"
+    })
+    void testNotExists(String expr, boolean pass) {
+        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
+        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+    }
+
+}

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -57,6 +58,7 @@ class LabelSelectorMatcherTest {
                     "env", "prod",
                     "present", "irrelevant");
 
+    @Disabled("Condition conjuction using comma separation is not currently supported")
     @ParameterizedTest
     @CsvSource(
             value = {

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -124,7 +124,7 @@ class LabelSelectorMatcherTest {
     @CsvSource(
             value = {
                 "foo notin (bar, baz) : false",
-                "something NotIn (else, orother) : false",
+                "something NotIn (orother, else, third) : false",
                 "env NOTIN (stage,qa) : true",
             },
             delimiter = ':')

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -41,7 +41,6 @@ import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -50,29 +49,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LabelSelectorMatcherTest {
 
-    final Map<String, String> labels =
+    private static final Map<String, String> TEST_LABELS =
             Map.of(
                     "foo", "bar",
                     "something", "else",
                     "my.prefixed/label", "expectedValue",
                     "env", "prod",
                     "present", "irrelevant");
-
-    @Disabled("Condition conjuction using comma separation is not currently supported")
-    @ParameterizedTest
-    @CsvSource(
-            value = {
-                "foo=bar,something=else,env=prod : true",
-                "foo=bar,something=wrong : false",
-                ": true",
-                ",: true",
-                "my.prefixed/label = expectedValue, present, env in ( prod, stage ) : true"
-            },
-            delimiter = ':')
-    void testCombos(String expr, boolean pass) {
-        LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
-    }
 
     @ParameterizedTest
     @CsvSource({
@@ -82,7 +65,7 @@ class LabelSelectorMatcherTest {
     })
     void testSingleEquality(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
@@ -93,7 +76,7 @@ class LabelSelectorMatcherTest {
     })
     void testDoubleEquality(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
@@ -104,7 +87,7 @@ class LabelSelectorMatcherTest {
     })
     void testInequality(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
@@ -117,7 +100,7 @@ class LabelSelectorMatcherTest {
             delimiter = ':')
     void testSetIn(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
@@ -130,7 +113,7 @@ class LabelSelectorMatcherTest {
             delimiter = ':')
     void testSetNotIn(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
@@ -143,13 +126,13 @@ class LabelSelectorMatcherTest {
     })
     void testExists(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 
     @ParameterizedTest
     @CsvSource({"!foo, false", "!something, false", "!present, false"})
     void testNotExists(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
-        MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
+        MatcherAssert.assertThat(expr, matcher.test(TEST_LABELS), Matchers.is(pass));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -68,9 +68,6 @@ class LabelSelectorMatcherTest {
             },
             delimiter = ':')
     void testCombos(String expr, boolean pass) {
-        if (expr == null) {
-            expr = "";
-        }
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
         MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/graph/labels/LabelSelectorMatcherTest.java
@@ -49,22 +49,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LabelSelectorMatcherTest {
 
-    final Map<String, String> labels = Map.of(
-            "foo", "bar",
-            "something", "else",
-            "my.prefixed/label", "expectedValue",
-            "env", "prod",
-            "present", "irrelevant"
-            );
+    final Map<String, String> labels =
+            Map.of(
+                    "foo", "bar",
+                    "something", "else",
+                    "my.prefixed/label", "expectedValue",
+                    "env", "prod",
+                    "present", "irrelevant");
 
     @ParameterizedTest
-    @CsvSource(value = {
-        "foo=bar,something=else,env=prod : true",
-        "foo=bar,something=wrong : false",
-        ": true",
-        ",: true",
-        "my.prefixed/label = expectedValue, present, env in ( prod, stage ) : true"
-    }, delimiter = ':')
+    @CsvSource(
+            value = {
+                "foo=bar,something=else,env=prod : true",
+                "foo=bar,something=wrong : false",
+                ": true",
+                ",: true",
+                "my.prefixed/label = expectedValue, present, env in ( prod, stage ) : true"
+            },
+            delimiter = ':')
     void testCombos(String expr, boolean pass) {
         if (expr == null) {
             expr = "";
@@ -72,7 +74,6 @@ class LabelSelectorMatcherTest {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
         MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
     }
-
 
     @ParameterizedTest
     @CsvSource({
@@ -108,22 +109,26 @@ class LabelSelectorMatcherTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {
-        "foo in (bar, baz) : true",
-        "something In (else, orother) : true",
-        "env IN (stage,qa) : false",
-    }, delimiter = ':')
+    @CsvSource(
+            value = {
+                "foo in (bar, baz) : true",
+                "something In (else, orother) : true",
+                "env IN (stage,qa) : false",
+            },
+            delimiter = ':')
     void testSetIn(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
         MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
     }
 
     @ParameterizedTest
-    @CsvSource(value = {
-        "foo notin (bar, baz) : false",
-        "something NotIn (else, orother) : false",
-        "env NOTIN (stage,qa) : true",
-    }, delimiter = ':')
+    @CsvSource(
+            value = {
+                "foo notin (bar, baz) : false",
+                "something NotIn (else, orother) : false",
+                "env NOTIN (stage,qa) : true",
+            },
+            delimiter = ':')
     void testSetNotIn(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
         MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
@@ -143,14 +148,9 @@ class LabelSelectorMatcherTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "!foo, false",
-        "!something, false",
-        "!present, false"
-    })
+    @CsvSource({"!foo, false", "!something, false", "!present, false"})
     void testNotExists(String expr, boolean pass) {
         LabelSelectorMatcher matcher = LabelSelectorMatcher.parse(expr);
         MatcherAssert.assertThat(expr, matcher.test(labels), Matchers.is(pass));
     }
-
 }


### PR DESCRIPTION
Closes #846
Closes #825
Closes #822
Closes #821
Closes #820

This adds `labels` to GraphQL query filters for nodes in the deployment tree and for recordings, as well as `annotations` to query filters on target nodes. For `annotations` the Cryostat-generated annotations and the platform-provided annotations are merged together into one map. Both the `labels` and `annotations` query fields are optional, and can be given a Kubernetes label selector expression to match against the labels or annotations maps on the objects being queried.