### PR TITLE
fix(oauth): use Kubernetes client to query OAuth server

### DIFF
--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -196,15 +196,14 @@ public abstract class NetworkModule {
     @Provides
     @Singleton
     static OpenShiftAuthManager provideOpenShiftAuthManager(
-            Environment env, Logger logger, FileSystem fs, WebClient webClient) {
+            Environment env, Logger logger, FileSystem fs) {
         return new OpenShiftAuthManager(
                 env,
                 logger,
                 fs,
                 token ->
                         new DefaultOpenShiftClient(
-                                new OpenShiftConfigBuilder().withOauthToken(token).build()),
-                webClient);
+                                new OpenShiftConfigBuilder().withOauthToken(token).build()));
     }
 
     @Binds


### PR DESCRIPTION
This PR uses the underlying HTTP client of the Fabric8 Kubernetes Client to make the GET request to query OAuth server metadata from the API server. The HTTP client is already configured to trust the cluster's root CA in order to talk to the API server as we do elsewhere in Cryostat [1].

We could instead add the CA cert bundle to our trust store at startup, but I'm concerned there may be edge cases where the CA bundle isn't mounted in the expected place. Leaving this to the Fabric8 client should give us less to think about. There's also some documentation that sounds like we should avoid trusting the CA bundle for anything other than talking to Kubernetes endpoints [2].

OkHttp and Jackson Databind are already dependencies of the Fabric8 Kubernetes Client, so we're not adding anything new.

In the tests, I had to remove the check that the TokenProvider is only called once. Some code paths now result in calling this twice. Maybe there's a better way to do this.

Fixes: #881 

[1] https://github.com/fabric8io/kubernetes-client#configuring-the-client
[2] https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#trusting-tls-in-a-cluster