### PR TITLE
chore(openshift): use cached, lazy init client instances

### DIFF
--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -53,6 +53,7 @@ import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.core.tui.ClientWriter;
+import io.cryostat.net.openshift.OpenShiftNetworkModule;
 import io.cryostat.net.reports.ReportsModule;
 import io.cryostat.net.security.SecurityModule;
 import io.cryostat.net.web.WebModule;
@@ -64,8 +65,6 @@ import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
-import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -75,6 +74,7 @@ import io.vertx.ext.web.client.WebClientOptions;
             WebModule.class,
             ReportsModule.class,
             SecurityModule.class,
+            OpenShiftNetworkModule.class,
         })
 public abstract class NetworkModule {
 
@@ -192,21 +192,4 @@ public abstract class NetworkModule {
     @Binds
     @IntoSet
     abstract AuthManager bindBasicAuthManager(BasicAuthManager mgr);
-
-    @Provides
-    @Singleton
-    static OpenShiftAuthManager provideOpenShiftAuthManager(
-            Environment env, Logger logger, FileSystem fs) {
-        return new OpenShiftAuthManager(
-                env,
-                logger,
-                fs,
-                token ->
-                        new DefaultOpenShiftClient(
-                                new OpenShiftConfigBuilder().withOauthToken(token).build()));
-    }
-
-    @Binds
-    @IntoSet
-    abstract AuthManager bindOpenShiftAuthManager(OpenShiftAuthManager mgr);
 }

--- a/src/main/java/io/cryostat/net/PermissionDeniedException.java
+++ b/src/main/java/io/cryostat/net/PermissionDeniedException.java
@@ -37,8 +37,31 @@
  */
 package io.cryostat.net;
 
-public class AuthorizationErrorException extends Exception {
-    public AuthorizationErrorException(String msg) {
-        super(msg);
+public class PermissionDeniedException extends Exception {
+    private final String namespace;
+    private final String resource;
+    private final String verb;
+
+    public PermissionDeniedException(
+            String namespace, String group, String resource, String verb, String reason) {
+        super(
+                String.format(
+                        "Requesting client in namespace \"%s\" cannot %s %s.%s: %s",
+                        namespace, verb, resource, group, reason));
+        this.namespace = namespace;
+        this.resource = resource;
+        this.verb = verb;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getResourceType() {
+        return resource;
+    }
+
+    public String getVerb() {
+        return verb;
     }
 }

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
@@ -426,9 +426,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
     }
 
     private CompletableFuture<OAuthMetadata> computeOauthMetadata() {
-        return oauthMetadata.computeIfAbsent(
-                OAUTH_METADATA_KEY,
-                key -> queryOAuthServer());
+        return oauthMetadata.computeIfAbsent(OAUTH_METADATA_KEY, key -> queryOAuthServer());
     }
 
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
@@ -340,7 +340,6 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private boolean deleteToken(String token) throws TokenNotFoundException {
         Boolean deleted =
                 Optional.ofNullable(
@@ -375,7 +374,6 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         }
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private Future<TokenReviewStatus> performTokenReview(String token) {
         try {
             TokenReview review =
@@ -447,7 +445,6 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
         return oauthMetadata.computeIfAbsent(OAUTH_METADATA_KEY, key -> queryOAuthServer());
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private CompletableFuture<OAuthMetadata> queryOAuthServer() {
         CompletableFuture<OAuthMetadata> oauthMetadata = new CompletableFuture<>();
         try {

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net;
+package io.cryostat.net.openshift;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -60,6 +60,13 @@ import java.util.stream.Stream;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
+import io.cryostat.net.AbstractAuthManager;
+import io.cryostat.net.AuthenticationScheme;
+import io.cryostat.net.AuthorizationErrorException;
+import io.cryostat.net.MissingEnvironmentVariableException;
+import io.cryostat.net.PermissionDeniedException;
+import io.cryostat.net.TokenNotFoundException;
+import io.cryostat.net.UserInfo;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.security.ResourceType;
 import io.cryostat.net.security.ResourceVerb;
@@ -551,35 +558,6 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
             default:
                 throw new IllegalArgumentException(
                         String.format("Unknown resource verb \"%s\"", verb));
-        }
-    }
-
-    public static class PermissionDeniedException extends Exception {
-        private final String namespace;
-        private final String resource;
-        private final String verb;
-
-        public PermissionDeniedException(
-                String namespace, String group, String resource, String verb, String reason) {
-            super(
-                    String.format(
-                            "Requesting client in namespace \"%s\" cannot %s %s.%s: %s",
-                            namespace, verb, resource, group, reason));
-            this.namespace = namespace;
-            this.resource = resource;
-            this.verb = verb;
-        }
-
-        public String getNamespace() {
-            return namespace;
-        }
-
-        public String getResourceType() {
-            return resource;
-        }
-
-        public String getVerb() {
-            return verb;
         }
     }
 

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
@@ -39,6 +39,7 @@ package io.cryostat.net.openshift;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 import javax.inject.Named;
@@ -49,6 +50,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
+import com.github.benmanes.caffeine.cache.Scheduler;
 import dagger.Binds;
 import dagger.Lazy;
 import dagger.Module;
@@ -129,7 +131,13 @@ public abstract class OpenShiftNetworkModule {
             Lazy<OpenShiftClient> serviceAccountClient,
             Logger logger) {
         return new OpenShiftAuthManager(
-                env, namespace, serviceAccountClient, tokenedClient, logger);
+                env,
+                namespace,
+                serviceAccountClient,
+                tokenedClient,
+                ForkJoinPool.commonPool(),
+                Scheduler.systemScheduler(),
+                logger);
     }
 
     @Binds

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
@@ -35,10 +35,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net;
+package io.cryostat.net.openshift;
 
-public class AuthorizationErrorException extends Exception {
-    public AuthorizationErrorException(String msg) {
-        super(msg);
+import javax.inject.Singleton;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.Environment;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.net.AuthManager;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+
+@Module
+public abstract class OpenShiftNetworkModule {
+
+    @Provides
+    @Singleton
+    static OpenShiftAuthManager provideOpenShiftAuthManager(
+            Environment env, Logger logger, FileSystem fs) {
+        return new OpenShiftAuthManager(
+                env,
+                logger,
+                fs,
+                token ->
+                        new DefaultOpenShiftClient(
+                                new OpenShiftConfigBuilder().withOauthToken(token).build()));
     }
+
+    @Binds
+    @IntoSet
+    abstract AuthManager bindOpenShiftAuthManager(OpenShiftAuthManager mgr);
 }

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -57,7 +57,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
+import io.cryostat.net.PermissionDeniedException;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.vertx.core.http.HttpHeaders;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -52,7 +52,7 @@ import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.AuthorizationErrorException;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
+import io.cryostat.net.PermissionDeniedException;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.ApiMeta;

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -44,7 +44,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
-import io.cryostat.net.OpenShiftAuthManager;
+import io.cryostat.net.openshift.OpenShiftAuthManager;
 
 import dagger.Lazy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -46,7 +46,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.NetworkResolver;
 import io.cryostat.net.NoopAuthManager;
-import io.cryostat.net.OpenShiftAuthManager;
+import io.cryostat.net.openshift.OpenShiftAuthManager;
 
 import dagger.Lazy;
 import dagger.Module;

--- a/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
+++ b/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
@@ -39,7 +39,6 @@ package io.cryostat.net;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
 import javax.management.remote.JMXServiceURL;
@@ -236,7 +235,7 @@ class TargetConnectionManagerTest {
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
                         platformClient,
-                        new DirectExecutor(),
+                        Runnable::run,
                         Scheduler.disabledScheduler(),
                         Duration.ofSeconds(1),
                         0,
@@ -276,7 +275,7 @@ class TargetConnectionManagerTest {
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
                         platformClient,
-                        new DirectExecutor(),
+                        Runnable::run,
                         Scheduler.disabledScheduler(),
                         Duration.ofNanos(1),
                         -1,
@@ -309,12 +308,5 @@ class TargetConnectionManagerTest {
         JFRConnection conn1 = mgr.executeConnectedTask(desc1, a -> a);
         JFRConnection conn2 = mgr.executeConnectedTask(desc2, a -> a);
         MatcherAssert.assertThat(conn1, Matchers.not(Matchers.sameInstance(conn2)));
-    }
-
-    static class DirectExecutor implements Executor {
-        @Override
-        public void execute(Runnable r) {
-            r.run();
-        }
     }
 }

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -154,9 +154,7 @@ class OpenShiftAuthManagerTest {
     void setup() {
         client = Mockito.spy(client);
         tokenProvider = new TokenProvider(client);
-        mgr =
-                new OpenShiftAuthManager(
-                        env, () -> NAMESPACE, () -> SERVICE_ACCOUNT_TOKEN, tokenProvider, logger);
+        mgr = new OpenShiftAuthManager(env, () -> NAMESPACE, () -> client, tokenProvider, logger);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.set(HttpHeaders.AUTHORIZATION, "abcd1234==");
     }

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net;
+package io.cryostat.net.openshift;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
@@ -55,7 +55,11 @@ import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
-import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
+import io.cryostat.net.AuthenticationScheme;
+import io.cryostat.net.MissingEnvironmentVariableException;
+import io.cryostat.net.PermissionDeniedException;
+import io.cryostat.net.TokenNotFoundException;
+import io.cryostat.net.UserInfo;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.security.ResourceType;
 import io.cryostat.net.security.ResourceVerb;

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -59,6 +59,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.security.ResourceType;
 import io.cryostat.net.security.ResourceVerb;
 
+import com.github.benmanes.caffeine.cache.Scheduler;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.authentication.TokenReview;
 import io.fabric8.kubernetes.api.model.authentication.TokenReviewBuilder;
@@ -154,7 +155,15 @@ class OpenShiftAuthManagerTest {
     void setup() {
         client = Mockito.spy(client);
         tokenProvider = new TokenProvider(client);
-        mgr = new OpenShiftAuthManager(env, () -> NAMESPACE, () -> client, tokenProvider, logger);
+        mgr =
+                new OpenShiftAuthManager(
+                        env,
+                        () -> NAMESPACE,
+                        () -> client,
+                        tokenProvider,
+                        Runnable::run,
+                        Scheduler.disabledScheduler(),
+                        logger);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.set(HttpHeaders.AUTHORIZATION, "abcd1234==");
     }

--- a/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
@@ -51,7 +51,7 @@ import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
+import io.cryostat.net.PermissionDeniedException;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.ApiVersion;
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractJwtConsumingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractJwtConsumingHandlerTest.java
@@ -49,7 +49,7 @@ import org.openjdk.jmc.rjmx.ConnectionException;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.OpenShiftAuthManager.PermissionDeniedException;
+import io.cryostat.net.PermissionDeniedException;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.security.jwt.AssetJwtHelper;
 import io.cryostat.net.web.WebServer;


### PR DESCRIPTION
Fixes #883 

Refactors the `OpenShiftAuthManager`, moving it into its own subpackage with its own DI module for encapsulation. The mounted namespace and account token files are only read from filesystem once, and the `OpenShiftClient` instance using the service account token is created once with lazy initialization and then that instance reused for the lifetime of the Cryostat container. `OpenShiftClient` instances using a user's token are stored in a cache, expiring (closing the client instance) after 5 minutes of inactivity on the client instance, so that we can reuse the client and its HTTP connection(s) while a user is actively making API requests through Cryostat. This reduces the number of memory allocations we're doing and should allow for some HTTP connection reuse, too. The time-based cache eviction ensures that the cache does not grow unbounded for long-lived Cryostat deployments which may have many different users over time.