### PR TITLE
feat(graphql): Add query for all archived recordings

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -201,7 +201,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                         ? 0
                         : Integer.parseInt(m.group(4).substring(1));
 
-        final String subdirectoryName = RecordingArchiveHelper.UNLABELLED;
+        final String subdirectoryName = RecordingArchiveHelper.UPLOADED_RECORDINGS_SUBDIRECTORY;
         final String basename = String.format("%s_%s_%s", targetName, recordingName, timestamp);
         final String uploadedFileName = upload.uploadedFileName();
         validateRecording(

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/AllArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/AllArchivedRecordingsFetcher.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.web.http.api.beta.graph;
+package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
+import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/AllArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/AllArchivedRecordingsFetcher.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta.graph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import io.cryostat.net.web.http.api.beta.graph.labels.LabelSelectorMatcher;
+import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.rules.ArchivedRecordingInfo;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+class AllArchivedRecordingsFetcher implements DataFetcher<List<ArchivedRecordingInfo>> {
+
+    private final RecordingArchiveHelper archiveHelper;
+
+    @Inject
+    AllArchivedRecordingsFetcher(RecordingArchiveHelper archiveHelper) {
+        this.archiveHelper = archiveHelper;
+    }
+
+    public List<ArchivedRecordingInfo> get(DataFetchingEnvironment environment) throws Exception {
+        FilterInput filter = FilterInput.from(environment);
+        List<ArchivedRecordingInfo> result = new ArrayList<>();
+        if (filter.contains(FilterInput.Key.SOURCE_TARGET)) {
+            String targetId = filter.get(FilterInput.Key.SOURCE_TARGET);
+            result = archiveHelper.getRecordings(targetId).get();
+        } else {
+            result = archiveHelper.getRecordings().get();
+        }
+        if (filter.contains(FilterInput.Key.NAME)) {
+            String recordingName = filter.get(FilterInput.Key.NAME);
+            result =
+                    result.stream()
+                            .filter(r -> Objects.equals(r.getName(), recordingName))
+                            .collect(Collectors.toList());
+        }
+        if (filter.contains(FilterInput.Key.LABELS)) {
+            List<String> labels = filter.get(FilterInput.Key.LABELS);
+            for (String label : labels) {
+                result =
+                        result.stream()
+                                .filter(
+                                        r ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(r.getMetadata().getLabels()))
+                                .collect(Collectors.toList());
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -49,9 +49,15 @@ import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
+@SuppressFBWarnings(
+        value = "URF_UNREAD_FIELD",
+        justification =
+                "The Archived and AggregateInfo fields are serialized and returned to the client by"
+                        + " the GraphQL engine")
 class ArchivedRecordingsFetcher implements DataFetcher<Archived> {
 
     @Inject

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -59,7 +59,7 @@ class ArchivedRecordingsFetcher implements DataFetcher<List<ArchivedRecordingInf
     public List<ArchivedRecordingInfo> get(DataFetchingEnvironment environment) throws Exception {
         Recordings source = environment.getSource();
         FilterInput filter = FilterInput.from(environment);
-        List<ArchivedRecordingInfo> result = new ArrayList<>(source.archived);
+        List<ArchivedRecordingInfo> result = new ArrayList<>(source.archived.recordings);
         if (filter.contains(FilterInput.Key.NAME)) {
             String recordingName = filter.get(FilterInput.Key.NAME);
             result =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -64,23 +64,23 @@ class ArchivedRecordingsFetcher implements DataFetcher<Archived> {
         if (filter.contains(FilterInput.Key.NAME)) {
             String recordingName = filter.get(FilterInput.Key.NAME);
             recordings =
-                        recordings.stream()
-                                     .filter(r -> Objects.equals(r.getName(), recordingName))
-                                     .collect(Collectors.toList());
+                    recordings.stream()
+                            .filter(r -> Objects.equals(r.getName(), recordingName))
+                            .collect(Collectors.toList());
         }
         if (filter.contains(FilterInput.Key.LABELS)) {
             List<String> labels = filter.get(FilterInput.Key.LABELS);
             for (String label : labels) {
                 recordings =
-                            recordings.stream()
-                                       .filter(
-                                            r ->
-                                                    LabelSelectorMatcher.parse(label)
-                                                            .test(r.getMetadata().getLabels()))
-                                       .collect(Collectors.toList());
+                        recordings.stream()
+                                .filter(
+                                        r ->
+                                                LabelSelectorMatcher.parse(label)
+                                                        .test(r.getMetadata().getLabels()))
+                                .collect(Collectors.toList());
             }
         }
-        
+
         Archived archived = new Archived();
         AggregateInfo aggregate = new AggregateInfo();
         archived.data = recordings;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
@@ -68,6 +68,7 @@ class FilterInput {
         NAME("name"),
         LABELS("labels"),
         ANNOTATIONS("annotations"),
+        SOURCE_TARGET("sourceTarget"),
         NODE_TYPE("nodeType"),
         STATE("state"),
         CONTINUOUS("continuous"),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
@@ -100,6 +100,7 @@ public abstract class GraphModule {
             RecordingsFetcher recordingsFetcher,
             ActiveRecordingsFetcher activeRecordingsFetcher,
             ArchivedRecordingsFetcher archivedRecordingsFetcher,
+            AllArchivedRecordingsFetcher allArchivedRecordingsFetcher,
             StartRecordingOnTargetMutator startRecordingOnTargetMutator,
             SnapshotOnTargetMutator snapshotOnTargetMutator,
             StopRecordingMutator stopRecordingMutator,
@@ -129,6 +130,9 @@ public abstract class GraphModule {
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("Query")
                                         .dataFetcher("targetNodes", targetNodesFetcher))
+                        .type(
+                                TypeRuntimeWiring.newTypeWiring("Query")
+                                        .dataFetcher("archivedRecordings", allArchivedRecordingsFetcher))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("EnvironmentNode")
                                         .dataFetcher("children", nodeChildrenFetcher))

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
@@ -132,7 +132,8 @@ public abstract class GraphModule {
                                         .dataFetcher("targetNodes", targetNodesFetcher))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("Query")
-                                        .dataFetcher("archivedRecordings", allArchivedRecordingsFetcher))
+                                        .dataFetcher(
+                                                "archivedRecordings", allArchivedRecordingsFetcher))
                         .type(
                                 TypeRuntimeWiring.newTypeWiring("EnvironmentNode")
                                         .dataFetcher("children", nodeChildrenFetcher))

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
@@ -152,12 +152,7 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
         }
 
         if (requestedFields.contains("archived")) {
-            Archived archived = new Archived();
-            AggregateInfo aggregate = new AggregateInfo();
-            archived.recordings = archiveHelper.getRecordings(targetId).get();
-            aggregate.count = Long.valueOf(archived.recordings.size());
-            archived.aggregate = aggregate;
-            recordings.archived = archived;
+            recordings.archived = archiveHelper.getRecordings(targetId).get();
         }
 
         return recordings;
@@ -165,15 +160,6 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
 
     static class Recordings {
         List<GraphRecordingDescriptor> active;
-        Archived archived;
-    }
-
-    static class Archived {
-        List<ArchivedRecordingInfo> recordings;
-        AggregateInfo aggregate;
-    }
-
-    static class AggregateInfo {
-        Long count;
+        List<ArchivedRecordingInfo> archived;
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import org.openjdk.jmc.common.item.Aggregators.AggregatorBase;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 
 import io.cryostat.configuration.CredentialsManager;
@@ -65,7 +64,6 @@ import io.cryostat.rules.ArchivedRecordingInfo;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.SelectedField;
 
 class RecordingsFetcher implements DataFetcher<Recordings> {
 
@@ -104,7 +102,10 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
         String targetId = target.getServiceUri().toString();
         Recordings recordings = new Recordings();
 
-        List<String> requestedFields = environment.getSelectionSet().getFields().stream().map(field -> field.getName()).collect(Collectors.toList());
+        List<String> requestedFields =
+                environment.getSelectionSet().getFields().stream()
+                        .map(field -> field.getName())
+                        .collect(Collectors.toList());
 
         if (requestedFields.contains("active")) {
             ConnectionDescriptor cd =
@@ -115,38 +116,38 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
                     tcm.executeConnectedTask(
                             cd,
                             conn -> {
-                            return conn.getService().getAvailableRecordings().stream()
-                                    .map(
-                                            r -> {
+                                return conn.getService().getAvailableRecordings().stream()
+                                        .map(
+                                                r -> {
                                                     try {
-                                                    String downloadUrl =
-                                                            webServer
-                                                                    .get()
-                                                                    .getDownloadURL(
-                                                                            conn, r.getName());
-                                                    String reportUrl =
-                                                            webServer
-                                                                    .get()
-                                                                    .getReportURL(
-                                                                            conn, r.getName());
-                                                    Metadata metadata =
-                                                            metadataManager.getMetadata(
-                                                                    targetId, r.getName());
-                                                    return new GraphRecordingDescriptor(
-                                                            target,
-                                                            r,
-                                                            downloadUrl,
-                                                            reportUrl,
-                                                            metadata);
+                                                        String downloadUrl =
+                                                                webServer
+                                                                        .get()
+                                                                        .getDownloadURL(
+                                                                                conn, r.getName());
+                                                        String reportUrl =
+                                                                webServer
+                                                                        .get()
+                                                                        .getReportURL(
+                                                                                conn, r.getName());
+                                                        Metadata metadata =
+                                                                metadataManager.getMetadata(
+                                                                        targetId, r.getName());
+                                                        return new GraphRecordingDescriptor(
+                                                                target,
+                                                                r,
+                                                                downloadUrl,
+                                                                reportUrl,
+                                                                metadata);
                                                     } catch (QuantityConversionException
                                                             | URISyntaxException
                                                             | IOException e) {
-                                                    logger.error(e);
-                                                    return null;
+                                                        logger.error(e);
+                                                        return null;
                                                     }
-                                            })
-                                    .filter(Objects::nonNull)
-                                    .collect(Collectors.toList());
+                                                })
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.toList());
                             },
                             false);
         }

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -103,6 +103,7 @@ public class RecordingArchiveHelper {
 
     public static final String UNLABELLED = "unlabelled";
     public static final String ARCHIVES = "archives";
+    public static final String UPLOADED_RECORDINGS_SUBDIRECTORY = "uploads";
 
     RecordingArchiveHelper(
             FileSystem fs,
@@ -273,8 +274,8 @@ public class RecordingArchiveHelper {
     public Future<List<ArchivedRecordingInfo>> getRecordings(String targetId) {
         CompletableFuture<List<ArchivedRecordingInfo>> future = new CompletableFuture<>();
 
-        String encodedServiceUri = base32.encodeAsString(targetId.getBytes(StandardCharsets.UTF_8));
-        Path specificRecordingsPath = archivedRecordingsPath.resolve(encodedServiceUri);
+        String subdirectory = targetId.equals(UPLOADED_RECORDINGS_SUBDIRECTORY) ? targetId : base32.encodeAsString(targetId.getBytes(StandardCharsets.UTF_8));
+        Path specificRecordingsPath = archivedRecordingsPath.resolve(subdirectory);
 
         try {
             if (!fs.exists(archivedRecordingsPath)) {
@@ -308,7 +309,7 @@ public class RecordingArchiveHelper {
                             file -> {
                                 try {
                                     return new ArchivedRecordingInfo(
-                                            encodedServiceUri,
+                                            subdirectory,
                                             file,
                                             webServer.getArchivedDownloadURL(file),
                                             webServer.getArchivedReportURL(file),

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -274,7 +274,10 @@ public class RecordingArchiveHelper {
     public Future<List<ArchivedRecordingInfo>> getRecordings(String targetId) {
         CompletableFuture<List<ArchivedRecordingInfo>> future = new CompletableFuture<>();
 
-        String subdirectory = targetId.equals(UPLOADED_RECORDINGS_SUBDIRECTORY) ? targetId : base32.encodeAsString(targetId.getBytes(StandardCharsets.UTF_8));
+        String subdirectory =
+                targetId.equals(UPLOADED_RECORDINGS_SUBDIRECTORY)
+                        ? targetId
+                        : base32.encodeAsString(targetId.getBytes(StandardCharsets.UTF_8));
         Path specificRecordingsPath = archivedRecordingsPath.resolve(subdirectory);
 
         try {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -101,7 +101,6 @@ public class RecordingArchiveHelper {
     private static final String SAVE_NOTIFICATION_CATEGORY = "ActiveRecordingSaved";
     private static final String DELETE_NOTIFICATION_CATEGORY = "ArchivedRecordingDeleted";
 
-    public static final String UNLABELLED = "unlabelled";
     public static final String ARCHIVES = "archives";
     public static final String UPLOADED_RECORDINGS_SUBDIRECTORY = "uploads";
 
@@ -221,7 +220,7 @@ public class RecordingArchiveHelper {
                                     ARCHIVES, recordingName));
             String subdirectoryName = parentPath.getFileName().toString();
             String targetId =
-                    (subdirectoryName.equals(UNLABELLED))
+                    (subdirectoryName.equals(UPLOADED_RECORDINGS_SUBDIRECTORY))
                             ? ""
                             : new String(base32.decode(subdirectoryName), StandardCharsets.UTF_8);
             notificationFactory

--- a/src/main/resources/queries.graphqls
+++ b/src/main/resources/queries.graphqls
@@ -1,5 +1,6 @@
 type Query {
     rootNode: EnvironmentNode!
     environmentNodes(filter: EnvironmentNodeFilterInput): [EnvironmentNode!]!
-    targetNodes(filter: TargetNodesFilterInput): [TargetNode!]! # TODO add filters for names, labels, annotations
+    targetNodes(filter: TargetNodesFilterInput): [TargetNode!]!
+    archivedRecordings(filter: ArchivedRecordingFilterInput): [ArchivedRecording!]!
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -116,7 +116,7 @@ type ArchivedRecording implements Recording {
 }
 
 type Archived {
-    recordings: [ArchivedRecording!]!
+    data: [ArchivedRecording!]!
     aggregate: AggregateInfo!
 }
 

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -83,7 +83,7 @@ interface Node {
 
 type Recordings {
     active(filter: ActiveRecordingFilterInput): [ActiveRecording!]!
-    archived(filter: ArchivedRecordingFilterInput): [ArchivedRecording!]!
+    archived(filter: ArchivedRecordingFilterInput): Archived!
 }
 
 type ActiveRecording implements Recording {
@@ -113,6 +113,15 @@ type ArchivedRecording implements Recording {
     metadata: RecordingMetadata!
 
     doDelete: ArchivedRecording!
+}
+
+type Archived {
+    recordings: [ArchivedRecording!]!
+    aggregate: AggregateInfo!
+}
+
+type AggregateInfo {
+    count: Long!
 }
 
 interface Recording {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -38,6 +38,7 @@ input ActiveRecordingFilterInput {
 input ArchivedRecordingFilterInput {
     name: String
     labels: [String]
+    sourceTarget: String
 }
 
 type ServiceRef {

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -349,8 +349,8 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) { recordings {"
-                    + " active { name doDelete { name } } archived { name doDelete { name } } } }"
-                    + " }");
+                    + " active { name doDelete { name } } archived { data { name doDelete { name }"
+                    + " } aggregate { count } } } } }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -370,10 +370,11 @@ class GraphQLIT extends ExternalTargetsTest {
         TargetNode node = actual.data.targetNodes.get(0);
 
         MatcherAssert.assertThat(node.recordings.active, Matchers.hasSize(1));
-        MatcherAssert.assertThat(node.recordings.archived, Matchers.hasSize(1));
+        MatcherAssert.assertThat(node.recordings.archived.data, Matchers.hasSize(1));
+        MatcherAssert.assertThat(node.recordings.archived.aggregate.count, Matchers.equalTo(1L));
 
         ActiveRecording activeRecording = node.recordings.active.get(0);
-        ArchivedRecording archivedRecording = node.recordings.archived.get(0);
+        ArchivedRecording archivedRecording = node.recordings.archived.data.get(0);
 
         MatcherAssert.assertThat(activeRecording.name, Matchers.equalTo("graphql-itest"));
         MatcherAssert.assertThat(activeRecording.doDelete.name, Matchers.equalTo("graphql-itest"));
@@ -488,9 +489,68 @@ class GraphQLIT extends ExternalTargetsTest {
         }
     }
 
+    static class AggregateInfo {
+        Long count;
+
+        @Override
+        public String toString() {
+            return "AggregateInfo [count=" + count + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(count);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            AggregateInfo other = (AggregateInfo) obj;
+            return Objects.equals(count, other.count);
+        }
+    }
+
+    static class Archived {
+        List<ArchivedRecording> data;
+        AggregateInfo aggregate;
+
+        @Override
+        public String toString() {
+            return "Archived [data=" + data + ", aggregate=" + aggregate + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data, aggregate);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Archived other = (Archived) obj;
+            return Objects.equals(data, other.data) && Objects.equals(aggregate, other.aggregate);
+        }
+    }
+
     static class Recordings {
         List<ActiveRecording> active;
-        List<ArchivedRecording> archived;
+        Archived archived;
 
         @Override
         public String toString() {


### PR DESCRIPTION
Fixes #923 

Add a query for all archived recordings with the ability to filter on target source, name, and labels. Besides differentiating between JVM targets, the target source can also be used to retrieve only those recordings uploaded directly to archives (i.e. recordings not associated with a target).

Change the subdirectory name for uploaded recordings from "unlabelled" to "uploads" for clarity. 

Add a new field for archived recordings in the GraphQL Schema containing aggregate information such as the count of recordings. 

Depends on https://github.com/cryostatio/cryostat-web/pull/431