### PR TITLE
fix(vertx): deploy verticles with async decorated blocking handlers

### DIFF
--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -56,6 +56,8 @@ import io.cryostat.rules.RuleRegistry;
 
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton;
 import dagger.Component;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
 
 class Cryostat {
 
@@ -79,8 +81,20 @@ class Cryostat {
         client.credentialsManager().load();
         client.ruleRegistry().loadRules();
         client.ruleProcessor().enable();
-        client.httpServer().start();
-        client.webServer().start();
+        client.vertx()
+                .deployVerticle(
+                        client.httpServer(),
+                        new DeploymentOptions().setWorker(false),
+                        res -> {
+                            System.out.println("HTTP Server Verticle Started");
+                        });
+        client.vertx()
+                .deployVerticle(
+                        client.webServer(),
+                        new DeploymentOptions().setWorker(true),
+                        res -> {
+                            System.out.println("WebServer Verticle Started");
+                        });
         client.messagingServer().start();
         client.platformClient().start();
         client.recordingMetadataManager().load();
@@ -96,6 +110,8 @@ class Cryostat {
         RuleRegistry ruleRegistry();
 
         RuleProcessor ruleProcessor();
+
+        Vertx vertx();
 
         HttpServer httpServer();
 

--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -85,16 +85,12 @@ class Cryostat {
                 .deployVerticle(
                         client.httpServer(),
                         new DeploymentOptions().setWorker(false),
-                        res -> {
-                            System.out.println("HTTP Server Verticle Started");
-                        });
+                        res -> logger.info("HTTP Server Verticle Started"));
         client.vertx()
                 .deployVerticle(
                         client.webServer(),
                         new DeploymentOptions().setWorker(true),
-                        res -> {
-                            System.out.println("WebServer Verticle Started");
-                        });
+                        res -> logger.info("WebServer Verticle Started"));
         client.messagingServer().start();
         client.platformClient().start();
         client.recordingMetadataManager().load();

--- a/src/main/java/io/cryostat/net/web/WebModule.java
+++ b/src/main/java/io/cryostat/net/web/WebModule.java
@@ -61,7 +61,6 @@ public abstract class WebModule {
     public static final String WEBSERVER_TEMP_DIR_PATH = "WEBSERVER_TEMP_DIR_PATH";
 
     @Provides
-    @Singleton
     static WebServer provideWebServer(
             HttpServer httpServer,
             NetworkConfiguration netConf,


### PR DESCRIPTION
Fixes #929

- tmp: add intentionally blocking API handler for testing
- fix(vertx): deploy verticles with async decorated blocking handlers

The first commit in this series is just for testing purposes. It adds an API handler at "/api/beta/block" that sleeps the current thread for 5 seconds, then returns a "hello" string response.

This can be used to test by doing:

```bash
https :8181/api/beta/block
```

in one terminal. In a second terminal, before that first request completes,

```bash
https :8181/health
```

In current `main`, the `/health` request will not return until after the `/block` request returns. After the fix in this PR is applied these requests are properly handled concurrently again.
