### PR TITLE
chore(vertx): upgrade vertx 3->4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   <org.apache.commons.io.version>2.8.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
   <io.fabric8.client.version>5.4.1</io.fabric8.client.version>
-  <io.vertx.web.version>3.9.9</io.vertx.web.version>
+  <io.vertx.web.version>4.3.0</io.vertx.web.version>
   <com.nimbusds.jose.jwt.version>9.16.1</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.69</org.bouncycastle.version>
   <org.slf4j.version>1.7.30</org.slf4j.version>
@@ -150,12 +150,12 @@
   <dependency>
       <!--
       FIXME this needs to be synced with the vertx - is there a BOM to use or something?
-      https://github.com/graphql-java/graphql-java-extended-scalars#extended-scalars-for-graphql-java
-      https://github.com/vert-x3/vertx-web/blob/f1aacf7e3e39a76e26b0bce01165dee846a02b77/vertx-web-graphql/pom.xml#L35
+      https://github.com/graphql-java/graphql-java-extended-scalars/commit/2bc8468753ffe5d2e112416207ab749173712c10
+      https://github.com/vert-x3/vertx-web/blob/4.3.0/vertx-web-graphql/pom.xml#L35
       -->
     <groupId>com.graphql-java</groupId>
     <artifactId>graphql-java-extended-scalars</artifactId>
-    <version>1.0.1</version>
+    <version>18.1</version>
   </dependency>
   <dependency>
     <groupId>com.nimbusds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
   </dependency>
   <dependency>
       <!--
-      FIXME this needs to be synced with the vertx - is there a BOM to use or something?
+      FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
       https://github.com/graphql-java/graphql-java-extended-scalars/commit/2bc8468753ffe5d2e112416207ab749173712c10
       https://github.com/vert-x3/vertx-web/blob/4.3.0/vertx-web-graphql/pom.xml#L35
       -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   <org.apache.commons.io.version>2.8.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
   <io.fabric8.client.version>5.4.1</io.fabric8.client.version>
-  <io.vertx.web.version>4.3.0</io.vertx.web.version>
+  <io.vertx.web.version>4.2.5</io.vertx.web.version>
   <com.nimbusds.jose.jwt.version>9.16.1</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.69</org.bouncycastle.version>
   <org.slf4j.version>1.7.30</org.slf4j.version>
@@ -151,11 +151,11 @@
       <!--
       FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
       https://github.com/graphql-java/graphql-java-extended-scalars/commit/2bc8468753ffe5d2e112416207ab749173712c10
-      https://github.com/vert-x3/vertx-web/blob/4.3.0/vertx-web-graphql/pom.xml#L35
+      https://github.com/vert-x3/vertx-web/blob/4.2.5/vertx-web-graphql/pom.xml#L35
       -->
     <groupId>com.graphql-java</groupId>
     <artifactId>graphql-java-extended-scalars</artifactId>
-    <version>18.1</version>
+    <version>17.0</version>
   </dependency>
   <dependency>
     <groupId>com.nimbusds</groupId>

--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -80,18 +80,26 @@ class Cryostat {
 
         client.credentialsManager().load();
         client.ruleRegistry().loadRules();
-        client.ruleProcessor().enable();
         client.vertx()
                 .deployVerticle(
                         client.httpServer(),
-                        new DeploymentOptions().setWorker(false),
+                        new DeploymentOptions(),
                         res -> logger.info("HTTP Server Verticle Started"));
         client.vertx()
                 .deployVerticle(
                         client.webServer(),
                         new DeploymentOptions().setWorker(true),
                         res -> logger.info("WebServer Verticle Started"));
-        client.messagingServer().start();
+        client.vertx()
+                .deployVerticle(
+                        client.messagingServer(),
+                        new DeploymentOptions(),
+                        res -> logger.info("MessagingServer Verticle Started"));
+        client.vertx()
+                .deployVerticle(
+                        client.ruleProcessor(),
+                        new DeploymentOptions().setWorker(true),
+                        res -> logger.info("RuleProcessor Verticle Started"));
         client.platformClient().start();
         client.recordingMetadataManager().load();
 

--- a/src/main/java/io/cryostat/net/HttpServer.java
+++ b/src/main/java/io/cryostat/net/HttpServer.java
@@ -43,8 +43,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.cryostat.core.log.Logger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;

--- a/src/main/java/io/cryostat/net/HttpServer.java
+++ b/src/main/java/io/cryostat/net/HttpServer.java
@@ -43,12 +43,11 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import io.cryostat.core.log.Logger;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.cryostat.core.log.Logger;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -99,7 +98,7 @@ public class HttpServer extends AbstractVerticle {
     }
 
     @Override
-    public void start(Future<Void> future) {
+    public void start(Promise<Void> future) {
         if (isAlive()) {
             future.fail(new IllegalStateException("Already started"));
             return;

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -128,7 +128,8 @@ public class WebServer extends AbstractVerticle {
                         exception = (HttpException) ctx.failure();
                     } else if (ctx.failure() instanceof ApiException) {
                         ApiException ex = (ApiException) ctx.failure();
-                        exception = new HttpException(ex.getStatusCode(), ex.getFailureReason(), ex);
+                        exception =
+                                new HttpException(ex.getStatusCode(), ex.getFailureReason(), ex);
                     } else {
                         exception = new HttpException(500, ctx.failure());
                     }

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -129,14 +129,12 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
             if (!m.find()) {
                 ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
-                throw new HttpException(
-                        427, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
+                throw new HttpException(427, "Invalid " + JMX_AUTHORIZATION_HEADER + " format");
             }
             String t = m.group("type");
             if (!"basic".equals(t.toLowerCase())) {
                 ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
-                throw new HttpException(
-                        427, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
+                throw new HttpException(427, "Unacceptable " + JMX_AUTHORIZATION_HEADER + " type");
             }
             String c;
             try {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -106,6 +106,7 @@ public abstract class GraphModule {
                 RuntimeWiring.newRuntimeWiring()
                         .scalar(ExtendedScalars.Object)
                         .scalar(ExtendedScalars.GraphQLLong)
+                        .scalar(ExtendedScalars.Url)
                         .scalar(Scalars.GraphQLBoolean)
                         .scalar(
                                 ExtendedScalars.newAliasedScalar("ServiceURI")

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -73,6 +73,10 @@ public abstract class GraphModule {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindGraphPostBodyHandler(GraphQLPostBodyHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindGraphPostHandler(GraphQLPostHandler handler);
 
     @Binds

--- a/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/graph/GraphModule.java
@@ -105,8 +105,7 @@ public abstract class GraphModule {
         RuntimeWiring wiring =
                 RuntimeWiring.newRuntimeWiring()
                         .scalar(ExtendedScalars.Object)
-                        .scalar(ExtendedScalars.Url)
-                        .scalar(Scalars.GraphQLLong)
+                        .scalar(ExtendedScalars.GraphQLLong)
                         .scalar(Scalars.GraphQLBoolean)
                         .scalar(
                                 ExtendedScalars.newAliasedScalar("ServiceURI")

--- a/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandler.java
@@ -53,7 +53,7 @@ import com.google.gson.Gson;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class GrafanaDashboardUrlGetHandler implements RequestHandler {
 
@@ -102,7 +102,7 @@ class GrafanaDashboardUrlGetHandler implements RequestHandler {
             // Fall back to GRAFANA_DASHBOARD_URL if no external URL is provided
             dashboardURL = env.getEnv(Variables.GRAFANA_DASHBOARD_ENV);
         } else {
-            throw new HttpStatusException(500, "Deployment has no Grafana configuration");
+            throw new HttpException(500, "Deployment has no Grafana configuration");
         }
         ctx.response()
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())

--- a/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandler.java
@@ -53,7 +53,7 @@ import com.google.gson.Gson;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class GrafanaDatasourceUrlGetHandler implements RequestHandler {
 
@@ -96,7 +96,7 @@ class GrafanaDatasourceUrlGetHandler implements RequestHandler {
     @Override
     public void handle(RoutingContext ctx) {
         if (!this.env.hasEnv(Variables.GRAFANA_DATASOURCE_ENV)) {
-            throw new HttpStatusException(500, "Deployment has no Grafana configuration");
+            throw new HttpException(500, "Deployment has no Grafana configuration");
         }
         ctx.response()
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime())

--- a/src/main/java/io/cryostat/net/web/http/api/v1/NotificationsUrlGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/NotificationsUrlGetHandler.java
@@ -55,7 +55,7 @@ import com.google.gson.Gson;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class NotificationsUrlGetHandler implements RequestHandler {
 
@@ -109,7 +109,7 @@ class NotificationsUrlGetHandler implements RequestHandler {
                             netConf.getExternalWebServerPort());
             ctx.response().end(gson.toJson(Map.of("notificationsUrl", notificationsUrl)));
         } catch (SocketException | UnknownHostException e) {
-            throw new HttpStatusException(500, e);
+            throw new HttpException(500, e);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandler.java
@@ -54,7 +54,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
@@ -104,7 +104,7 @@ public class RecordingDeleteHandler extends AbstractAuthenticatedRequestHandler 
             ctx.response().end();
         } catch (ExecutionException e) {
             if (ExceptionUtils.getRootCause(e) instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new HttpException(404, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingGetHandler.java
@@ -57,7 +57,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class RecordingGetHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -111,7 +111,7 @@ class RecordingGetHandler extends AbstractAuthenticatedRequestHandler {
             ctx.response().sendFile(archivedRecording.toString());
         } catch (ExecutionException e) {
             if (e.getCause() instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new HttpException(404, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -68,7 +68,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.multipart.MultipartForm;
 import org.apache.commons.validator.routines.UrlValidator;
 
@@ -128,7 +128,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             boolean isValidUploadUrl =
                     new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS).isValid(uploadUrl.toString());
             if (!isValidUploadUrl) {
-                throw new HttpStatusException(
+                throw new HttpException(
                         501,
                         String.format(
                                 "$%s=%s is an invalid datasource URL",
@@ -138,7 +138,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode)
                     || response.statusMessage == null
                     || response.body == null) {
-                throw new HttpStatusException(
+                throw new HttpException(
                         512,
                         String.format(
                                 "Invalid response from datasource server; datasource URL may be incorrect, or server may not be functioning properly: %d %s",
@@ -148,7 +148,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             ctx.response().setStatusMessage(response.statusMessage);
             ctx.response().end(response.body);
         } catch (MalformedURLException e) {
-            throw new HttpStatusException(501, e);
+            throw new HttpException(501, e);
         }
     }
 
@@ -158,7 +158,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             recordingPath = recordingArchiveHelper.getRecordingPath(recordingName).get();
         } catch (ExecutionException e) {
             if (e.getCause() instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new HttpException(404, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandler.java
@@ -57,7 +57,7 @@ import io.cryostat.rules.ArchivedRecordingInfo;
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -108,7 +108,7 @@ class RecordingsGetHandler extends AbstractAuthenticatedRequestHandler {
             ctx.response().end(gson.toJson(result));
         } catch (ExecutionException e) {
             if (e.getCause() instanceof ArchivePathException) {
-                throw new HttpStatusException(501, e.getMessage(), e);
+                throw new HttpException(501, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandler.java
@@ -81,7 +81,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -159,7 +159,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
     @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
         if (!fs.isDirectory(savedRecordingsPath)) {
-            throw new HttpStatusException(503, "Recording saving not available");
+            throw new HttpException(503, "Recording saving not available");
         }
 
         FileUpload upload = null;
@@ -173,13 +173,13 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
         }
 
         if (upload == null) {
-            throw new HttpStatusException(400, "No recording submission");
+            throw new HttpException(400, "No recording submission");
         }
 
         String fileName = upload.fileName();
         if (fileName == null || fileName.isEmpty()) {
             deleteTempFileUpload(upload);
-            throw new HttpStatusException(400, "Recording name must not be empty");
+            throw new HttpException(400, "Recording name must not be empty");
         }
 
         if (fileName.endsWith(".jfr")) {
@@ -189,7 +189,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
         Matcher m = RECORDING_FILENAME_PATTERN.matcher(fileName);
         if (!m.matches()) {
             deleteTempFileUpload(upload);
-            throw new HttpStatusException(400, "Incorrect recording file name pattern");
+            throw new HttpException(400, "Incorrect recording file name pattern");
         }
 
         String targetName = m.group(1);
@@ -275,7 +275,7 @@ class RecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
                         Throwable t;
                         if (res.cause() instanceof CouldNotLoadRecordingException) {
                             t =
-                                    new HttpStatusException(
+                                    new HttpException(
                                             400, "Not a valid JFR recording file", res.cause());
                         } else {
                             t = res.cause();

--- a/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/ReportGetHandler.java
@@ -62,7 +62,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
@@ -132,10 +132,10 @@ class ReportGetHandler extends AbstractAuthenticatedRequestHandler {
             if (ExceptionUtils.getRootCause(ee) instanceof ReportGenerationException) {
                 ReportGenerationException rge =
                         (ReportGenerationException) ExceptionUtils.getRootCause(ee);
-                throw new HttpStatusException(rge.getStatusCode(), ee.getMessage());
+                throw new HttpException(rge.getStatusCode(), ee.getMessage());
             }
             if (ExceptionUtils.getRootCause(ee) instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, ee);
+                throw new HttpException(404, ee);
             }
             throw ee;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandler.java
@@ -55,7 +55,7 @@ import io.cryostat.recordings.RecordingTargetHelper;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
@@ -107,7 +107,7 @@ class TargetRecordingDeleteHandler extends AbstractAuthenticatedRequestHandler {
             ctx.response().end();
         } catch (ExecutionException e) {
             if (ExceptionUtils.getRootCause(e) instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new HttpException(404, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandler.java
@@ -62,7 +62,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
     protected static final int WRITE_BUFFER_SIZE = 64 * 1024; // 64 KB
@@ -126,7 +126,7 @@ class TargetRecordingGetHandler extends AbstractAuthenticatedRequestHandler {
                 recordingTargetHelper.getRecording(connectionDescriptor, recordingName).get();
 
         if (stream.isEmpty()) {
-            throw new HttpStatusException(404, String.format("%s not found", recordingName));
+            throw new HttpException(404, String.format("%s not found", recordingName));
         }
 
         ctx.response().setChunked(true);

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandler.java
@@ -65,7 +65,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -123,7 +123,7 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
         MultiMap attrs = ctx.request().formAttributes();
         if (attrs.contains("toDisk")) {
             Matcher m = bool.matcher(attrs.get("toDisk"));
-            if (!m.matches()) throw new HttpStatusException(400, "Invalid options");
+            if (!m.matches()) throw new HttpException(400, "Invalid options");
         }
         Arrays.asList("maxAge", "maxSize")
                 .forEach(
@@ -136,7 +136,7 @@ class TargetRecordingOptionsPatchHandler extends AbstractAuthenticatedRequestHan
                                     }
                                     Long.parseLong(v);
                                 } catch (NumberFormatException e) {
-                                    throw new HttpStatusException(400, "Invalid options");
+                                    throw new HttpException(400, "Invalid options");
                                 }
                             }
                         });

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
@@ -51,7 +51,7 @@ import io.cryostat.net.web.http.api.ApiVersion;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -105,7 +105,7 @@ public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHan
         String mtd = ctx.getBodyAsString();
 
         if (mtd == null) {
-            throw new HttpStatusException(400, "Unsupported null operation");
+            throw new HttpException(400, "Unsupported null operation");
         }
         switch (mtd.toLowerCase()) {
             case "save":
@@ -115,7 +115,7 @@ public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHan
                 patchStop.handle(ctx, getConnectionDescriptorFromContext(ctx));
                 break;
             default:
-                throw new HttpStatusException(400, "Unsupported operation " + mtd);
+                throw new HttpException(400, "Unsupported operation " + mtd);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchSave.java
@@ -47,7 +47,7 @@ import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
 
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetRecordingPatchSave {
@@ -71,7 +71,7 @@ class TargetRecordingPatchSave {
             ctx.response().end(saveName);
         } catch (ExecutionException e) {
             if (ExceptionUtils.getRootCause(e) instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new HttpException(404, e.getMessage(), e);
             } else if (e.getCause() instanceof EmptyRecordingException) {
                 ctx.response().setStatusCode(204);
                 ctx.response().end();

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStop.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStop.java
@@ -44,7 +44,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 import io.cryostat.recordings.RecordingTargetHelper;
 
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TargetRecordingPatchStop {
 
@@ -61,7 +61,7 @@ class TargetRecordingPatchStop {
         try {
             recordingTargetHelper.stopRecording(connectionDescriptor, recordingName);
         } catch (RecordingNotFoundException rnfe) {
-            throw new HttpStatusException(404, rnfe);
+            throw new HttpException(404, rnfe);
         }
         ctx.response().setStatusCode(200);
         ctx.response().end();

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -72,7 +72,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.multipart.MultipartForm;
 import org.apache.commons.validator.routines.UrlValidator;
 
@@ -134,7 +134,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             boolean isValidUploadUrl =
                     new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS).isValid(uploadUrl.toString());
             if (!isValidUploadUrl) {
-                throw new HttpStatusException(
+                throw new HttpException(
                         501,
                         String.format(
                                 "$%s=%s is an invalid datasource URL",
@@ -144,7 +144,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode)
                     || response.statusMessage == null
                     || response.body == null) {
-                throw new HttpStatusException(
+                throw new HttpException(
                         512,
                         String.format(
                                 "Invalid response from datasource server; datasource URL may be incorrect, or server may not be functioning properly: %d %s",
@@ -154,9 +154,9 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             ctx.response().setStatusMessage(response.statusMessage);
             ctx.response().end(response.body);
         } catch (MalformedURLException e) {
-            throw new HttpStatusException(501, e);
+            throw new HttpException(501, e);
         } catch (RecordingNotFoundException e) {
-            throw new HttpStatusException(404, e);
+            throw new HttpException(404, e);
         }
     }
 
@@ -221,7 +221,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
                                 }
                                 return tempFile;
                             } catch (Exception e) {
-                                throw new HttpStatusException(500, e);
+                                throw new HttpException(500, e);
                             }
                         });
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -78,7 +78,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -147,11 +147,11 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
         MultiMap attrs = ctx.request().formAttributes();
         String recordingName = attrs.get("recordingName");
         if (StringUtils.isBlank(recordingName)) {
-            throw new HttpStatusException(400, "\"recordingName\" form parameter must be provided");
+            throw new HttpException(400, "\"recordingName\" form parameter must be provided");
         }
         String eventSpecifier = attrs.get("events");
         if (StringUtils.isBlank(eventSpecifier)) {
-            throw new HttpStatusException(400, "\"events\" form parameter must be provided");
+            throw new HttpException(400, "\"events\" form parameter must be provided");
         }
 
         try {
@@ -174,7 +174,7 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                     Pattern bool = Pattern.compile("true|false");
                                     Matcher m = bool.matcher(attrs.get("toDisk"));
                                     if (!m.matches())
-                                        throw new HttpStatusException(400, "Invalid options");
+                                        throw new HttpException(400, "Invalid options");
                                     builder = builder.toDisk(Boolean.valueOf(attrs.get("toDisk")));
                                 }
                                 if (attrs.contains("maxAge")) {
@@ -220,7 +220,7 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                 } catch (QuantityConversionException
                                         | URISyntaxException
                                         | IOException e) {
-                                    throw new HttpStatusException(500, e);
+                                    throw new HttpException(500, e);
                                 }
                             });
 
@@ -229,10 +229,10 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
             ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
             ctx.response().end(gson.toJson(linkedDescriptor));
         } catch (NumberFormatException | JsonSyntaxException ex) {
-            throw new HttpStatusException(
+            throw new HttpException(
                     400, String.format("Invalid argument: %s", ex.getMessage()), ex);
         } catch (IllegalArgumentException iae) {
-            throw new HttpStatusException(400, iae.getMessage(), iae);
+            throw new HttpException(400, iae.getMessage(), iae);
         }
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandler.java
@@ -61,7 +61,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
@@ -133,7 +133,7 @@ class TargetReportGetHandler extends AbstractAuthenticatedRequestHandler {
             Exception rootCause = (Exception) ExceptionUtils.getRootCause(ee);
 
             if (targetRecordingNotFound(rootCause)) {
-                throw new HttpStatusException(404, ee);
+                throw new HttpException(404, ee);
             }
             throw ee;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandler.java
@@ -56,7 +56,7 @@ import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetSnapshotPostHandler extends AbstractAuthenticatedRequestHandler {
@@ -136,7 +136,7 @@ class TargetSnapshotPostHandler extends AbstractAuthenticatedRequestHandler {
     private void handleExecutionException(ExecutionException e) throws ExecutionException {
         Throwable cause = ExceptionUtils.getRootCause(e);
         if (cause instanceof SnapshotCreationException) {
-            throw new HttpStatusException(500, cause.getMessage());
+            throw new HttpException(500, cause.getMessage());
         }
         throw e;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandler.java
@@ -55,7 +55,7 @@ import io.cryostat.net.web.http.api.ApiVersion;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -111,7 +111,7 @@ class TargetTemplateGetHandler extends AbstractAuthenticatedRequestHandler {
                             ctx.response().end(doc.toString());
                         },
                         () -> {
-                            throw new HttpStatusException(404);
+                            throw new HttpException(404);
                         });
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandler.java
@@ -59,7 +59,7 @@ import io.cryostat.net.web.http.api.ApiVersion;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -112,7 +112,7 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
                     templateService.getTemplates().stream()
                             .filter(t -> Objects.equals(templateName, t.getName()))
                             .findFirst();
-            Template t = opt.orElseThrow(() -> new HttpStatusException(404, templateName));
+            Template t = opt.orElseThrow(() -> new HttpException(404, templateName));
             templateService.deleteTemplate(t);
             ctx.response().end();
             notificationFactory
@@ -123,7 +123,7 @@ class TemplateDeleteHandler extends AbstractAuthenticatedRequestHandler {
                     .build()
                     .send();
         } catch (InvalidEventTemplateException iete) {
-            throw new HttpStatusException(400, iete.getMessage(), iete);
+            throw new HttpException(400, iete.getMessage(), iete);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandler.java
@@ -62,7 +62,7 @@ import io.cryostat.net.web.http.api.ApiVersion;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -139,10 +139,10 @@ class TemplatesPostHandler extends AbstractAuthenticatedRequestHandler {
                 }
             }
         } catch (InvalidXmlException | InvalidEventTemplateException e) {
-            throw new HttpStatusException(400, e.getMessage(), e);
+            throw new HttpException(400, e.getMessage(), e);
         }
         if (!handledUpload) {
-            throw new HttpStatusException(400, "No template submission");
+            throw new HttpException(400, "No template submission");
         }
         ctx.response().end();
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
@@ -37,16 +37,22 @@
  */
 package io.cryostat.net.web.http.api.v2;
 
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
-public class ApiException extends HttpStatusException {
+public class ApiException extends RuntimeException {
 
+    protected final int statusCode;
     protected final String apiStatus;
     protected final String reason;
 
+    public ApiException() {
+        this(500);
+    }
+
     public ApiException(int statusCode, String apiStatus, String reason, Throwable cause) {
-        super(statusCode, cause);
-        this.apiStatus = apiStatus;
+        super(reason, cause);
+        this.statusCode = statusCode;
+        this.apiStatus = apiStatus != null ? apiStatus : HttpResponseStatus.valueOf(statusCode).reasonPhrase();
         this.reason = reason;
     }
 
@@ -68,6 +74,10 @@ public class ApiException extends HttpStatusException {
 
     public ApiException(int statusCode) {
         this(statusCode, (String) null);
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 
     public String getApiStatus() {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiException.java
@@ -52,7 +52,10 @@ public class ApiException extends RuntimeException {
     public ApiException(int statusCode, String apiStatus, String reason, Throwable cause) {
         super(reason, cause);
         this.statusCode = statusCode;
-        this.apiStatus = apiStatus != null ? apiStatus : HttpResponseStatus.valueOf(statusCode).reasonPhrase();
+        this.apiStatus =
+                apiStatus != null
+                        ? apiStatus
+                        : HttpResponseStatus.valueOf(statusCode).reasonPhrase();
         this.reason = reason;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
@@ -43,6 +43,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
@@ -52,9 +54,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
 
@@ -124,7 +124,7 @@ class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
                     .build()
                     .send();
         } catch (Exception e) {
-            throw new HttpStatusException(400, e.getMessage(), e);
+            throw new ApiException(400, e.getMessage(), e);
         }
         return new IntermediateResponse().body(null);
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
@@ -43,8 +43,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
@@ -54,6 +52,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 
 class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
@@ -45,8 +45,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
 import io.cryostat.core.log.Logger;
@@ -57,6 +55,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
@@ -45,6 +45,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
 import io.cryostat.core.log.Logger;
@@ -55,10 +57,8 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
 
@@ -145,10 +145,10 @@ class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
             }
         } catch (ProbeValidationException pve) {
             logger.error(pve.getMessage());
-            throw new HttpStatusException(400, pve.getMessage(), pve);
+            throw new ApiException(400, pve.getMessage(), pve);
         } catch (Exception e) {
             logger.error(e.getMessage());
-            throw new HttpStatusException(500, e.getMessage(), e);
+            throw new ApiException(500, e.getMessage(), e);
         }
         return new IntermediateResponse().body(null);
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RecordingGetHandler.java
@@ -44,9 +44,6 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
-import com.nimbusds.jwt.JWT;
-
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -56,6 +53,9 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
+
+import com.nimbusds.jwt.JWT;
+import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RecordingGetHandler.java
@@ -44,6 +44,9 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import com.nimbusds.jwt.JWT;
+
+import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -53,13 +56,9 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingNotFoundException;
-
-import com.nimbusds.jwt.JWT;
-import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class RecordingGetHandler extends AbstractJwtConsumingHandler {
 
@@ -118,7 +117,7 @@ class RecordingGetHandler extends AbstractJwtConsumingHandler {
             ctx.response().sendFile(archivedRecording.toAbsolutePath().toString());
         } catch (ExecutionException e) {
             if (e.getCause() instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, e.getMessage(), e);
+                throw new ApiException(404, e.getMessage(), e);
             }
             throw e;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ReportGetHandler.java
@@ -47,11 +47,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.nimbusds.jwt.JWT;
-
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -62,9 +57,13 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
+
+import com.nimbusds.jwt.JWT;
+import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class ReportGetHandler extends AbstractJwtConsumingHandler {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ReportGetHandler.java
@@ -47,6 +47,11 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.nimbusds.jwt.JWT;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -57,14 +62,9 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
-
-import com.nimbusds.jwt.JWT;
-import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class ReportGetHandler extends AbstractJwtConsumingHandler {
 
@@ -132,7 +132,7 @@ class ReportGetHandler extends AbstractJwtConsumingHandler {
             ctx.response().sendFile(report.toAbsolutePath().toString());
         } catch (ExecutionException | CompletionException ee) {
             if (ExceptionUtils.getRootCause(ee) instanceof RecordingNotFoundException) {
-                throw new HttpStatusException(404, ee);
+                throw new ApiException(404, ee);
             }
             throw ee;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -42,6 +42,10 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
@@ -53,10 +57,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.StringUtils;
 
 class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
 
@@ -118,7 +119,7 @@ class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
         StringBuilder sb = new StringBuilder();
         if (StringUtils.isBlank(targetId)) {
             sb.append("targetId is required.");
-            throw new HttpStatusException(400, sb.toString().trim());
+            throw new ApiException(400, sb.toString().trim());
         }
         try {
             return connectionManager.executeConnectedTask(

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -42,10 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang3.StringUtils;
-
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
@@ -57,7 +53,9 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
 
 class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
@@ -42,6 +42,10 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
@@ -54,10 +58,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * TargetProbePostHandler will facilitate adding probes to a target and will have the following form
@@ -153,7 +154,7 @@ class TargetProbePostHandler extends AbstractV2RequestHandler<Void> {
             if (StringUtils.isBlank(probeTemplate)) {
                 sb.append("\"probeTemplate\" is required.");
             }
-            throw new HttpStatusException(400, sb.toString().trim());
+            throw new ApiException(400, sb.toString().trim());
         }
         return connectionManager.executeConnectedTask(
                 getConnectionDescriptorFromParams(requestParams),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
@@ -42,10 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang3.StringUtils;
-
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
@@ -58,7 +54,9 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * TargetProbePostHandler will facilitate adding probes to a target and will have the following form

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
@@ -42,10 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang3.StringUtils;
-
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
@@ -54,7 +50,9 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
 
 class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
@@ -42,6 +42,10 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.gson.Gson;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
@@ -50,10 +54,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.StringUtils;
 
 class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
 
@@ -106,7 +107,7 @@ class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
         StringBuilder sb = new StringBuilder();
         if (StringUtils.isBlank(targetId)) {
             sb.append("targetId is required.");
-            throw new HttpStatusException(400, sb.toString().trim());
+            throw new ApiException(400, sb.toString().trim());
         }
         return connectionManager.executeConnectedTask(
                 getConnectionDescriptorFromParams(requestParams),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandler.java
@@ -46,11 +46,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.nimbusds.jwt.JWT;
-
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -62,9 +57,13 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
+
+import com.nimbusds.jwt.JWT;
+import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetReportGetHandler extends AbstractJwtConsumingHandler {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandler.java
@@ -46,6 +46,11 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.nimbusds.jwt.JWT;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
@@ -57,14 +62,9 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.recordings.RecordingNotFoundException;
-
-import com.nimbusds.jwt.JWT;
-import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 
 class TargetReportGetHandler extends AbstractJwtConsumingHandler {
 
@@ -135,7 +135,7 @@ class TargetReportGetHandler extends AbstractJwtConsumingHandler {
             Exception rootCause = (Exception) ExceptionUtils.getRootCause(ee);
 
             if (targetRecordingNotFound(rootCause)) {
-                throw new HttpStatusException(404, ee);
+                throw new ApiException(404, ee);
             }
             throw ee;
         }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandler.java
@@ -42,6 +42,9 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.nimbusds.jwt.JWT;
+
+import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
@@ -51,13 +54,9 @@ import io.cryostat.net.security.jwt.AssetJwtHelper;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
-
-import com.nimbusds.jwt.JWT;
-import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 class TargetTemplateGetHandler extends AbstractJwtConsumingHandler {
 
@@ -114,7 +113,7 @@ class TargetTemplateGetHandler extends AbstractJwtConsumingHandler {
                             ctx.response().end(doc.toString());
                         },
                         () -> {
-                            throw new HttpStatusException(404);
+                            throw new ApiException(404);
                         });
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandler.java
@@ -42,9 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.nimbusds.jwt.JWT;
-
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.net.AuthManager;
@@ -54,6 +51,9 @@ import io.cryostat.net.security.jwt.AssetJwtHelper;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.nimbusds.jwt.JWT;
+import dagger.Lazy;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;

--- a/src/main/java/io/cryostat/net/web/http/generic/CorsEnablingHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/CorsEnablingHandler.java
@@ -95,7 +95,7 @@ class CorsEnablingHandler implements RequestHandler {
 
     @Override
     public HttpMethod httpMethod() {
-        return HttpMethod.OTHER; // unused for ALL_PATHS handlers
+        return null; // unused for ALL_PATHS handlers
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/generic/WebClientAssetsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/WebClientAssetsGetHandler.java
@@ -52,7 +52,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 class WebClientAssetsGetHandler implements RequestHandler {
 
@@ -96,7 +96,7 @@ class WebClientAssetsGetHandler implements RequestHandler {
     @Override
     public void handle(RoutingContext ctx) {
         if (!hasIndexHtml) {
-            throw new HttpStatusException(404);
+            throw new HttpException(404);
         }
         ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.HTML.mime());
         ctx.response().sendFile(INDEX_HTML.toString());

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -588,7 +588,7 @@ public class RecordingTargetHelper {
                                     promiseHandler,
                                     false,
                                     result -> {
-                                        if (result.succeeded()) {
+                                        if (result.failed()) {
                                             return;
                                         }
                                         this.issueNotification(

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -41,8 +41,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import javax.inject.Named;
@@ -78,7 +76,6 @@ public abstract class RulesModule {
     public static final String RULES_SUBDIRECTORY = "rules";
     public static final String RULES_WEB_CLIENT = "RULES_WEB_CLIENT";
     public static final String RULES_HEADERS_FACTORY = "RULES_HEADERS_FACTORY";
-    static final String RULE_SCHEDULER = "RULE_SCHEDULER";
 
     @Provides
     @Singleton
@@ -108,9 +105,9 @@ public abstract class RulesModule {
     @Provides
     @Singleton
     static RuleProcessor provideRuleProcessor(
+            Vertx vertx,
             PlatformClient platformClient,
             RuleRegistry registry,
-            @Named(RULE_SCHEDULER) ScheduledExecutorService scheduler,
             CredentialsManager credentialsManager,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             TargetConnectionManager targetConnectionManager,
@@ -121,9 +118,9 @@ public abstract class RulesModule {
             Logger logger,
             Base32 base32) {
         return new RuleProcessor(
+                vertx,
                 platformClient,
                 registry,
-                scheduler,
                 credentialsManager,
                 recordingOptionsBuilderFactory,
                 targetConnectionManager,
@@ -133,22 +130,6 @@ public abstract class RulesModule {
                 periodicArchiverFactory,
                 logger,
                 base32);
-    }
-
-    @Provides
-    @Named(RULE_SCHEDULER)
-    @Singleton
-    static ScheduledExecutorService provideRuleScheduler() {
-        ScheduledExecutorService ses =
-                Executors.newScheduledThreadPool(
-                        Runtime.getRuntime().availableProcessors(),
-                        r -> {
-                            Thread t = Executors.defaultThreadFactory().newThread(r);
-                            t.setDaemon(true);
-                            return t;
-                        });
-        Runtime.getRuntime().addShutdownHook(new Thread(ses::shutdownNow));
-        return ses;
     }
 
     @Provides

--- a/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
@@ -113,8 +113,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(false));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -126,8 +125,7 @@ class AbstractAuthenticatedRequestHandlerTest {
                                 new PermissionDeniedException(
                                         "namespace", "group", "resource", "verb", "reason")));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -136,8 +134,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new KubernetesClientException("test")));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -155,8 +152,7 @@ class AbstractAuthenticatedRequestHandlerTest {
                                                 "verb",
                                                 "reason"))));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -170,8 +166,7 @@ class AbstractAuthenticatedRequestHandlerTest {
                                         new KubernetesClientException(
                                                 "test", new Exception("test2")))));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -180,8 +175,7 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new NullPointerException()));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandlerTest.java
@@ -62,7 +62,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -113,8 +113,8 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(false));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -126,8 +126,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                 new PermissionDeniedException(
                                         "namespace", "group", "resource", "verb", "reason")));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -136,8 +136,8 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new KubernetesClientException("test")));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -155,8 +155,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                                 "verb",
                                                 "reason"))));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -170,8 +170,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                         new KubernetesClientException(
                                                 "test", new Exception("test2")))));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -180,8 +180,8 @@ class AbstractAuthenticatedRequestHandlerTest {
         when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new NullPointerException()));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -195,14 +195,14 @@ class AbstractAuthenticatedRequestHandlerTest {
         }
 
         @Test
-        void shouldPropagateIfHandlerThrowsHttpStatusException() {
-            Exception expectedException = new HttpStatusException(200);
+        void shouldPropagateIfHandlerThrowsHttpException() {
+            Exception expectedException = new HttpException(200);
             handler =
                     new ThrowingAuthenticatedHandler(
                             auth, credentialsManager, logger, expectedException);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex, Matchers.sameInstance(expectedException));
         }
 
@@ -213,8 +213,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                     new ThrowingAuthenticatedHandler(
                             auth, credentialsManager, logger, expectedException);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         }
 
@@ -229,8 +229,8 @@ class AbstractAuthenticatedRequestHandlerTest {
 
             Mockito.when(ctx.response()).thenReturn(resp);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             Mockito.verify(resp).putHeader("X-JMX-Authenticate", "Basic");
         }
@@ -244,8 +244,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                     new ThrowingAuthenticatedHandler(
                             auth, credentialsManager, logger, expectedException);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(502));
             MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Target SSL Untrusted"));
         }
@@ -259,8 +259,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                     new ThrowingAuthenticatedHandler(
                             auth, credentialsManager, logger, expectedException);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
             MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Target Not Found"));
         }
@@ -272,8 +272,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                     new ThrowingAuthenticatedHandler(
                             auth, credentialsManager, logger, expectedException);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         }
     }
@@ -326,8 +326,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             MatcherAssert.assertThat(
                     ex.getPayload(), Matchers.equalTo("Invalid X-JMX-Authorization format"));
@@ -352,8 +352,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             MatcherAssert.assertThat(
                     ex.getPayload(), Matchers.equalTo("Unacceptable X-JMX-Authorization type"));
@@ -378,8 +378,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             MatcherAssert.assertThat(
                     ex.getPayload(),
@@ -404,8 +404,8 @@ class AbstractAuthenticatedRequestHandlerTest {
                                     AbstractAuthenticatedRequestHandler.JMX_AUTHORIZATION_HEADER))
                     .thenReturn(authHeader);
 
-            HttpStatusException ex =
-                    Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            HttpException ex =
+                    Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
             MatcherAssert.assertThat(
                     ex.getPayload(),

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
@@ -43,27 +43,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
-import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
-
-import io.cryostat.core.net.JFRConnection;
-import io.cryostat.messaging.notifications.Notification;
-import io.cryostat.messaging.notifications.NotificationFactory;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.web.http.HttpMimeType;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.net.web.http.api.v2.IntermediateResponse;
-import io.cryostat.net.web.http.api.v2.RequestParameters;
-import io.cryostat.recordings.RecordingArchiveHelper;
-import io.cryostat.recordings.RecordingMetadataManager;
-import io.cryostat.recordings.RecordingMetadataManager.Metadata;
-import io.cryostat.recordings.RecordingNotFoundException;
-
 import com.google.gson.Gson;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -75,6 +56,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.messaging.notifications.Notification;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingMetadataManager.Metadata;
+import io.cryostat.recordings.RecordingNotFoundException;
+import io.vertx.core.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingMetadataLabelsPostHandlerTest {
@@ -215,9 +215,9 @@ public class RecordingMetadataLabelsPostHandlerTest {
             Mockito.doThrow(new IllegalArgumentException())
                     .when(recordingMetadataManager)
                     .parseRecordingLabels("invalid");
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParameters));
+                            ApiException.class, () -> handler.handle(requestParameters));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         }
 
@@ -237,9 +237,9 @@ public class RecordingMetadataLabelsPostHandlerTest {
                                     new RecordingNotFoundException(
                                             RecordingArchiveHelper.ARCHIVES, recordingName)));
 
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParameters));
+                            ApiException.class, () -> handler.handle(requestParameters));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
             Assertions.assertTrue(
                     ExceptionUtils.getRootCause(ex) instanceof RecordingNotFoundException);

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
@@ -43,19 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -74,7 +61,20 @@ import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingNotFoundException;
+
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingMetadataLabelsPostHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
@@ -43,6 +43,19 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import com.google.gson.Gson;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -55,28 +68,15 @@ import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.ApiException;
 import io.cryostat.net.web.http.api.v2.IntermediateResponse;
 import io.cryostat.net.web.http.api.v2.RequestParameters;
 import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingNotFoundException;
 import io.cryostat.recordings.RecordingTargetHelper;
-
-import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetRecordingMetadataLabelsPostHandlerTest {
@@ -240,9 +240,9 @@ public class TargetRecordingMetadataLabelsPostHandlerTest {
                     .when(recordingMetadataManager)
                     .parseRecordingLabels("invalid");
 
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParameters));
+                            ApiException.class, () -> handler.handle(requestParameters));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         }
 
@@ -272,9 +272,9 @@ public class TargetRecordingMetadataLabelsPostHandlerTest {
                                                     arg0.getArgument(1))
                                             .execute(connection));
 
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParameters));
+                            ApiException.class, () -> handler.handle(requestParameters));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
             Assertions.assertTrue(
                     ExceptionUtils.getRootCause(ex) instanceof RecordingNotFoundException);

--- a/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
@@ -43,19 +43,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -75,8 +62,21 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingNotFoundException;
 import io.cryostat.recordings.RecordingTargetHelper;
+
+import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetRecordingMetadataLabelsPostHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
@@ -53,7 +53,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -123,8 +123,8 @@ class AuthPostHandlerTest {
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -137,8 +137,8 @@ class AuthPostHandlerTest {
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/AuthPostHandlerTest.java
@@ -123,8 +123,7 @@ class AuthPostHandlerTest {
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -137,8 +136,7 @@ class AuthPostHandlerTest {
         HttpServerRequest req = mock(HttpServerRequest.class);
         when(ctx.request()).thenReturn(req);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandlerTest.java
@@ -54,7 +54,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -141,8 +141,8 @@ class GrafanaDashboardUrlGetHandlerTest {
         when(env.hasEnv("GRAFANA_DASHBOARD_EXT_URL")).thenReturn(false);
         when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(false);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
         MatcherAssert.assertThat(
                 e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDashboardUrlGetHandlerTest.java
@@ -141,8 +141,7 @@ class GrafanaDashboardUrlGetHandlerTest {
         when(env.hasEnv("GRAFANA_DASHBOARD_EXT_URL")).thenReturn(false);
         when(env.hasEnv("GRAFANA_DASHBOARD_URL")).thenReturn(false);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
         MatcherAssert.assertThat(
                 e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandlerTest.java
@@ -53,7 +53,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -121,8 +121,8 @@ class GrafanaDatasourceUrlGetHandlerTest {
 
         when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(false);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
         MatcherAssert.assertThat(
                 e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/GrafanaDatasourceUrlGetHandlerTest.java
@@ -121,8 +121,7 @@ class GrafanaDatasourceUrlGetHandlerTest {
 
         when(env.hasEnv("GRAFANA_DATASOURCE_URL")).thenReturn(false);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(e.getMessage(), Matchers.equalTo("Internal Server Error"));
         MatcherAssert.assertThat(
                 e.getPayload(), Matchers.equalTo("Deployment has no Grafana configuration"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/NotificationsUrlGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/NotificationsUrlGetHandlerTest.java
@@ -56,7 +56,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -128,7 +128,7 @@ class NotificationsUrlGetHandlerTest {
             HttpServerResponse rep = mock(HttpServerResponse.class);
             when(ctx.response()).thenReturn(rep);
             when(netConf.getWebServerHost()).thenThrow(UnknownHostException.class);
-            Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+            Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         }
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
@@ -52,7 +52,7 @@ import io.cryostat.rules.ArchivedRecordingInfo;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -118,8 +118,8 @@ class RecordingDeleteHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingDeleteHandlerTest.java
@@ -118,8 +118,7 @@ class RecordingDeleteHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
@@ -122,8 +122,7 @@ class RecordingGetHandlerTest {
         Mockito.when(e.getCause())
                 .thenReturn(new RecordingNotFoundException("archives", recordingName));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingGetHandlerTest.java
@@ -55,7 +55,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -122,8 +122,8 @@ class RecordingGetHandlerTest {
         Mockito.when(e.getCause())
                 .thenReturn(new RecordingNotFoundException("archives", recordingName));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -145,8 +145,7 @@ class RecordingUploadPostHandlerTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(rawUrl);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
     }
 
@@ -172,8 +171,7 @@ class RecordingUploadPostHandlerTest {
         Mockito.when(e.getCause())
                 .thenReturn(new RecordingNotFoundException("archives", recordingName));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -277,8 +275,7 @@ class RecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -335,8 +332,7 @@ class RecordingUploadPostHandlerTest {
                 .when(httpReq)
                 .sendMultipartForm(Mockito.any(), Mockito.any());
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -393,8 +389,7 @@ class RecordingUploadPostHandlerTest {
                 .when(httpReq)
                 .sendMultipartForm(Mockito.any(), Mockito.any());
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -59,7 +59,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -145,8 +145,8 @@ class RecordingUploadPostHandlerTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
         Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(rawUrl);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
     }
 
@@ -172,8 +172,8 @@ class RecordingUploadPostHandlerTest {
         Mockito.when(e.getCause())
                 .thenReturn(new RecordingNotFoundException("archives", recordingName));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -277,8 +277,8 @@ class RecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -335,8 +335,8 @@ class RecordingUploadPostHandlerTest {
                 .when(httpReq)
                 .sendMultipartForm(Mockito.any(), Mockito.any());
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -393,8 +393,8 @@ class RecordingUploadPostHandlerTest {
                 .when(httpReq)
                 .sendMultipartForm(Mockito.any(), Mockito.any());
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsGetHandlerTest.java
@@ -56,7 +56,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -120,8 +120,8 @@ class RecordingsGetHandlerTest {
         Mockito.when(future.get()).thenThrow(e);
         Mockito.when(e.getCause()).thenReturn(new ArchivePathException("/some/path", "test"));
 
-        HttpStatusException httpEx =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException httpEx =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(httpEx.getStatusCode(), Matchers.equalTo(501));
         MatcherAssert.assertThat(
                 httpEx.getCause().getCause().getMessage(),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -45,8 +45,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -161,7 +159,7 @@ class RecordingsPostHandlerTest {
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
         FileUpload upload = mock(FileUpload.class);
-        when(ctx.fileUploads()).thenReturn(List.of(upload));
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn(filename);
         when(upload.uploadedFileName()).thenReturn("foo");
@@ -327,7 +325,7 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        when(ctx.fileUploads()).thenReturn(new ArrayList<FileUpload>());
+        when(ctx.fileUploads()).thenReturn(Set.of());
 
         HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
@@ -351,7 +349,7 @@ class RecordingsPostHandlerTest {
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
         FileUpload upload = mock(FileUpload.class);
-        when(ctx.fileUploads()).thenReturn(List.of(upload));
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
         when(upload.name()).thenReturn("incorrect_field_name");
         when(upload.uploadedFileName()).thenReturn("foo");
 
@@ -384,7 +382,7 @@ class RecordingsPostHandlerTest {
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
         FileUpload upload = mock(FileUpload.class);
-        when(ctx.fileUploads()).thenReturn(List.of(upload));
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn("");
         when(upload.uploadedFileName()).thenReturn("foo");
@@ -421,7 +419,7 @@ class RecordingsPostHandlerTest {
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
         FileUpload upload = mock(FileUpload.class);
-        when(ctx.fileUploads()).thenReturn(List.of(upload));
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn(filename);
         when(upload.uploadedFileName()).thenReturn("foo");

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -45,7 +45,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -159,10 +160,8 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);
-        uploads.add(upload);
-        when(ctx.fileUploads()).thenReturn(uploads);
+        when(ctx.fileUploads()).thenReturn(List.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn(filename);
         when(upload.uploadedFileName()).thenReturn("foo");
@@ -328,10 +327,9 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        when(ctx.fileUploads()).thenReturn(new HashSet<FileUpload>());
+        when(ctx.fileUploads()).thenReturn(new ArrayList<FileUpload>());
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("No recording submission"));
     }
@@ -352,10 +350,8 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);
-        uploads.add(upload);
-        when(ctx.fileUploads()).thenReturn(uploads);
+        when(ctx.fileUploads()).thenReturn(List.of(upload));
         when(upload.name()).thenReturn("incorrect_field_name");
         when(upload.uploadedFileName()).thenReturn("foo");
 
@@ -364,8 +360,7 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("No recording submission"));
 
@@ -388,10 +383,8 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);
-        uploads.add(upload);
-        when(ctx.fileUploads()).thenReturn(uploads);
+        when(ctx.fileUploads()).thenReturn(List.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn("");
         when(upload.uploadedFileName()).thenReturn("foo");
@@ -401,8 +394,7 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(
                 ex.getPayload(), Matchers.equalTo("Recording name must not be empty"));
@@ -428,10 +420,8 @@ class RecordingsPostHandlerTest {
 
         when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
 
-        Set<FileUpload> uploads = new HashSet<>();
         FileUpload upload = mock(FileUpload.class);
-        uploads.add(upload);
-        when(ctx.fileUploads()).thenReturn(uploads);
+        when(ctx.fileUploads()).thenReturn(List.of(upload));
         when(upload.name()).thenReturn("recording");
         when(upload.fileName()).thenReturn(filename);
         when(upload.uploadedFileName()).thenReturn("foo");
@@ -441,8 +431,7 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(
                 ex.getPayload(), Matchers.equalTo("Incorrect recording file name pattern"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -72,7 +72,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -330,8 +330,8 @@ class RecordingsPostHandlerTest {
 
         when(ctx.fileUploads()).thenReturn(new HashSet<FileUpload>());
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("No recording submission"));
     }
@@ -364,8 +364,8 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("No recording submission"));
 
@@ -401,8 +401,8 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(
                 ex.getPayload(), Matchers.equalTo("Recording name must not be empty"));
@@ -441,8 +441,8 @@ class RecordingsPostHandlerTest {
         io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
         when(vertx.fileSystem()).thenReturn(vertxFs);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(
                 ex.getPayload(), Matchers.equalTo("Incorrect recording file name pattern"));

--- a/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
@@ -166,8 +166,7 @@ class ReportGetHandlerTest {
                         CompletableFuture.failedFuture(
                                 new RecordingNotFoundException(null, "someRecording")));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
 
         Mockito.verify(reportService).get("someRecording");

--- a/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/ReportGetHandlerTest.java
@@ -57,7 +57,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -166,8 +166,8 @@ class ReportGetHandlerTest {
                         CompletableFuture.failedFuture(
                                 new RecordingNotFoundException(null, "someRecording")));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
 
         Mockito.verify(reportService).get("someRecording");

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingDeleteHandlerTest.java
@@ -54,7 +54,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -143,9 +143,9 @@ class TargetRecordingDeleteHandlerTest {
                         new ExecutionException(
                                 new RecordingNotFoundException("someTarget", "someRecording")));
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
 
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
@@ -165,8 +165,7 @@ class TargetRecordingGetHandlerTest {
         when(future.get()).thenReturn(stream);
         when(stream.isEmpty()).thenReturn(true);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -197,8 +196,7 @@ class TargetRecordingGetHandlerTest {
                         new ExecutionException(
                                 "fake exception for testing purposes", new NullPointerException()));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -242,8 +240,7 @@ class TargetRecordingGetHandlerTest {
         when(targetConnectionManager.markConnectionInUse(Mockito.any())).thenReturn(false);
         // ********************************************************************
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(
                 ex.getCause().getCause().getMessage(),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingGetHandlerTest.java
@@ -75,7 +75,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -165,8 +165,8 @@ class TargetRecordingGetHandlerTest {
         when(future.get()).thenReturn(stream);
         when(stream.isEmpty()).thenReturn(true);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -197,8 +197,8 @@ class TargetRecordingGetHandlerTest {
                         new ExecutionException(
                                 "fake exception for testing purposes", new NullPointerException()));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -242,8 +242,8 @@ class TargetRecordingGetHandlerTest {
         when(targetConnectionManager.markConnectionInUse(Mockito.any())).thenReturn(false);
         // ********************************************************************
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(
                 ex.getCause().getCause().getMessage(),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingOptionsPatchHandlerTest.java
@@ -62,7 +62,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -225,9 +225,9 @@ class TargetRecordingOptionsPatchHandlerTest {
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.formAttributes()).thenReturn(requestAttrs);
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
@@ -51,7 +51,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -120,8 +120,8 @@ class TargetRecordingPatchHandlerTest {
         Mockito.when(authManager.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(false));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -138,8 +138,8 @@ class TargetRecordingPatchHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
@@ -120,8 +120,7 @@ class TargetRecordingPatchHandlerTest {
         Mockito.when(authManager.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(false));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(401));
     }
 
@@ -138,8 +137,7 @@ class TargetRecordingPatchHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStopTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStopTest.java
@@ -103,8 +103,7 @@ class TargetRecordingPatchStopTest {
 
         HttpException ex =
                 Assertions.assertThrows(
-                        HttpException.class,
-                        () -> patchStop.handle(ctx, connectionDescriptor));
+                        HttpException.class, () -> patchStop.handle(ctx, connectionDescriptor));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStopTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchStopTest.java
@@ -49,7 +49,7 @@ import io.cryostat.recordings.RecordingTargetHelper;
 
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -101,9 +101,9 @@ class TargetRecordingPatchStopTest {
         Mockito.when(recordingTargetHelper.stopRecording(Mockito.any(), Mockito.anyString()))
                 .thenThrow(new RecordingNotFoundException("myTarget", "someRecording"));
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class,
+                        HttpException.class,
                         () -> patchStop.handle(ctx, connectionDescriptor));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -69,7 +69,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -162,8 +162,8 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
     }
 
@@ -192,9 +192,9 @@ class TargetRecordingUploadPostHandlerTest {
         Mockito.when(svc.getAvailableRecordings()).thenReturn(Collections.emptyList());
         Mockito.when(env.getEnv("GRAFANA_DATASOURCE_URL")).thenReturn(DATASOURCE_URL);
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class,
+                        HttpException.class,
                         () -> {
                             handler.handle(ctx);
                         });
@@ -329,8 +329,8 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -401,8 +401,8 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -473,8 +473,8 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpStatusException e =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException e =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -162,8 +162,7 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(501));
     }
 
@@ -329,8 +328,7 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -401,8 +399,7 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(
@@ -473,8 +470,7 @@ class TargetRecordingUploadPostHandlerTest {
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
 
-        HttpException e =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException e = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
 
         MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(512));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -73,7 +73,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -294,15 +294,15 @@ class TargetRecordingsPostHandlerTest {
         attrs.add("recordingName", "someRecording");
         attrs.add("events", "template=Foo");
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 
     @Test
     void shouldHandleException() throws Exception {
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -359,8 +359,8 @@ class TargetRecordingsPostHandlerTest {
         attrs.add("events", "template=Foo");
         Mockito.when(req.formAttributes()).thenReturn(attrs);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -294,15 +294,13 @@ class TargetRecordingsPostHandlerTest {
         attrs.add("recordingName", "someRecording");
         attrs.add("events", "template=Foo");
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 
     @Test
     void shouldHandleException() throws Exception {
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
@@ -359,8 +357,7 @@ class TargetRecordingsPostHandlerTest {
         attrs.add("events", "template=Foo");
         Mockito.when(req.formAttributes()).thenReturn(attrs);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
@@ -62,7 +62,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -159,8 +159,8 @@ class TargetReportGetHandlerTest {
         when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
         when(ctx.pathParam("recordingName")).thenReturn("someRecording");
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -189,8 +189,8 @@ class TargetReportGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -218,8 +218,8 @@ class TargetReportGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetReportGetHandlerTest.java
@@ -159,8 +159,7 @@ class TargetReportGetHandlerTest {
         when(ctx.pathParam("targetId")).thenReturn("fooHost:0");
         when(ctx.pathParam("recordingName")).thenReturn("someRecording");
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -189,8 +188,7 @@ class TargetReportGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 
@@ -218,8 +216,7 @@ class TargetReportGetHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn(targetId);
         Mockito.when(ctx.pathParam("recordingName")).thenReturn(recordingName);
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
@@ -147,8 +147,7 @@ class TargetSnapshotPostHandlerTest {
                         new ExecutionException(
                                 new SnapshotCreationException("some error message")));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("some error message"));
     }
@@ -186,8 +185,7 @@ class TargetSnapshotPostHandlerTest {
                         new ExecutionException(
                                 new SnapshotCreationException("some error message")));
 
-        HttpException ex =
-                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("some error message"));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetSnapshotPostHandlerTest.java
@@ -54,7 +54,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -147,8 +147,8 @@ class TargetSnapshotPostHandlerTest {
                         new ExecutionException(
                                 new SnapshotCreationException("some error message")));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("some error message"));
     }
@@ -186,8 +186,8 @@ class TargetSnapshotPostHandlerTest {
                         new ExecutionException(
                                 new SnapshotCreationException("some error message")));
 
-        HttpStatusException ex =
-                Assertions.assertThrows(HttpStatusException.class, () -> handler.handle(ctx));
+        HttpException ex =
+                Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("some error message"));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetTemplateGetHandlerTest.java
@@ -58,7 +58,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.nodes.Document;
@@ -158,9 +158,9 @@ class TargetTemplateGetHandlerTest {
                             }
                         });
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplateDeleteHandlerTest.java
@@ -58,7 +58,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -138,9 +138,9 @@ class TemplateDeleteHandlerTest {
         Mockito.when(ctx.pathParam("templateName")).thenReturn("FooTemplate");
         Mockito.when(templateService.getTemplates()).thenReturn(List.of());
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
     }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.lenient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -127,7 +128,7 @@ class TemplatesPostHandlerTest {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         FileUpload upload = Mockito.mock(FileUpload.class);
         Mockito.when(upload.name()).thenReturn("template");
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
         Path uploadPath = Mockito.mock(Path.class);
@@ -146,7 +147,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -172,7 +173,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("invalidUploadName");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -195,7 +196,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -231,7 +232,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
@@ -62,7 +62,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -157,9 +157,9 @@ class TemplatesPostHandlerTest {
         Mockito.when(templateService.addTemplate(Mockito.any()))
                 .thenThrow(InvalidXmlException.class);
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         Mockito.verify(fs).deleteIfExists(uploadPath);
     }
@@ -177,9 +177,9 @@ class TemplatesPostHandlerTest {
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
 
-        HttpStatusException ex =
+        HttpException ex =
                 Assertions.assertThrows(
-                        HttpStatusException.class, () -> handler.handleAuthenticated(ctx));
+                        HttpException.class, () -> handler.handleAuthenticated(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         Mockito.verify(fs).deleteIfExists(uploadPath);
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TemplatesPostHandlerTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.lenient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -128,7 +127,7 @@ class TemplatesPostHandlerTest {
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         FileUpload upload = Mockito.mock(FileUpload.class);
         Mockito.when(upload.name()).thenReturn("template");
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
         Path uploadPath = Mockito.mock(Path.class);
@@ -147,7 +146,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -173,7 +172,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("invalidUploadName");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -196,7 +195,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
@@ -232,7 +231,7 @@ class TemplatesPostHandlerTest {
         Mockito.when(upload.name()).thenReturn("template");
         Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
 
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(upload));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(upload));
 
         Path uploadPath = Mockito.mock(Path.class);
         Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.rmi.ConnectIOException;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -94,7 +94,7 @@ class AbstractV2RequestHandlerTest {
     void setup() {
         Mockito.lenient().when(ctx.pathParams()).thenReturn(pathParams);
         Mockito.lenient().when(ctx.queryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-        Mockito.lenient().when(ctx.fileUploads()).thenReturn(Collections.emptySet());
+        Mockito.lenient().when(ctx.fileUploads()).thenReturn(List.of());
 
         this.headers = MultiMap.caseInsensitiveMultiMap();
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.rmi.ConnectIOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -94,7 +93,7 @@ class AbstractV2RequestHandlerTest {
     void setup() {
         Mockito.lenient().when(ctx.pathParams()).thenReturn(pathParams);
         Mockito.lenient().when(ctx.queryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-        Mockito.lenient().when(ctx.fileUploads()).thenReturn(List.of());
+        Mockito.lenient().when(ctx.fileUploads()).thenReturn(Set.of());
 
         this.headers = MultiMap.caseInsensitiveMultiMap();
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
@@ -40,20 +40,8 @@ package io.cryostat.net.web.http.api.v2;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.AuthenticationScheme;
-import io.cryostat.net.UnknownUserException;
-import io.cryostat.net.UserInfo;
-import io.cryostat.net.security.ResourceAction;
-
 import com.google.gson.Gson;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -64,6 +52,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.AuthenticationScheme;
+import io.cryostat.net.UnknownUserException;
+import io.cryostat.net.UserInfo;
+import io.cryostat.net.security.ResourceAction;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class AuthPostHandlerTest {
@@ -110,7 +110,7 @@ class AuthPostHandlerTest {
         Mockito.when(auth.getUserInfo(Mockito.any()))
                 .thenReturn(CompletableFuture.failedFuture(new UnknownUserException("unknown")));
 
-        HttpStatusException ex =
+        ApiException ex =
                 Assertions.assertThrows(ApiException.class, () -> handler.handle(requestParams));
 
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
@@ -40,8 +40,19 @@ package io.cryostat.net.web.http.api.v2;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.AuthenticationScheme;
+import io.cryostat.net.UnknownUserException;
+import io.cryostat.net.UserInfo;
+import io.cryostat.net.security.ResourceAction;
 
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -52,18 +63,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.AuthenticationScheme;
-import io.cryostat.net.UnknownUserException;
-import io.cryostat.net.UserInfo;
-import io.cryostat.net.security.ResourceAction;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class AuthPostHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -51,6 +51,18 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import com.google.gson.Gson;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
@@ -63,8 +75,6 @@ import io.cryostat.net.web.http.api.ApiData;
 import io.cryostat.net.web.http.api.ApiMeta;
 import io.cryostat.net.web.http.api.ApiResponse;
 import io.cryostat.net.web.http.api.ApiResultData;
-
-import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -72,16 +82,6 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CertificatePostHandlerTest {
@@ -141,7 +141,7 @@ class CertificatePostHandlerTest {
     @Test
     void shouldThrow400IfNoCertInRequest() {
         Mockito.when(ctx.fileUploads()).thenReturn(Collections.<FileUpload>emptySet());
-        HttpStatusException ex =
+        ApiException ex =
                 Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
@@ -151,7 +151,7 @@ class CertificatePostHandlerTest {
         Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(env.hasEnv(Mockito.any())).thenReturn(false);
-        HttpStatusException ex =
+        ApiException ex =
                 Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
@@ -169,7 +169,7 @@ class CertificatePostHandlerTest {
         Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
         Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
         Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
-        HttpStatusException ex =
+        ApiException ex =
                 Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(409));
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -46,7 +46,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -139,14 +138,14 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldThrow400IfNoCertInRequest() {
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of());
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of());
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 
     @Test
     void shouldThrow500IfNoTruststoreDirSet() {
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(env.hasEnv(Mockito.any())).thenReturn(false);
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -155,7 +154,7 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldThrow409IfCertAlreadyExists() {
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -172,7 +171,7 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldThrowExceptionIfCertIsMalformed() throws Exception {
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -196,7 +195,7 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldAddCertToTruststore() throws Exception {
-        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(Set.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -45,23 +45,11 @@ import java.nio.file.Path;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-
-import com.google.gson.Gson;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
@@ -75,6 +63,8 @@ import io.cryostat.net.web.http.api.ApiData;
 import io.cryostat.net.web.http.api.ApiMeta;
 import io.cryostat.net.web.http.api.ApiResponse;
 import io.cryostat.net.web.http.api.ApiResultData;
+
+import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -82,6 +72,15 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CertificatePostHandlerTest {
@@ -140,25 +139,23 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldThrow400IfNoCertInRequest() {
-        Mockito.when(ctx.fileUploads()).thenReturn(Collections.<FileUpload>emptySet());
-        ApiException ex =
-                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of());
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 
     @Test
     void shouldThrow500IfNoTruststoreDirSet() {
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(env.hasEnv(Mockito.any())).thenReturn(false);
-        ApiException ex =
-                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
     }
 
     @Test
     void shouldThrow409IfCertAlreadyExists() {
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -169,14 +166,13 @@ class CertificatePostHandlerTest {
         Mockito.when(truststorePath.normalize()).thenReturn(truststorePath);
         Mockito.when(truststorePath.toString()).thenReturn("/truststore/certificate.cer");
         Mockito.when(fs.exists(Mockito.any())).thenReturn(true);
-        ApiException ex =
-                Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(409));
     }
 
     @Test
     void shouldThrowExceptionIfCertIsMalformed() throws Exception {
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -200,7 +196,7 @@ class CertificatePostHandlerTest {
 
     @Test
     void shouldAddCertToTruststore() throws Exception {
-        Mockito.when(ctx.fileUploads()).thenReturn(Set.<FileUpload>of(fu));
+        Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
@@ -55,8 +55,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
 import com.google.gson.Gson;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -67,6 +66,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
 public class ProbeTemplateDeleteHandlerTest {
@@ -146,9 +147,9 @@ public class ProbeTemplateDeleteHandlerTest {
             Mockito.when(requestParams.getPathParams())
                     .thenReturn(Map.of("probetemplateName", "foo.xml"));
             Mockito.doThrow(new IOException()).when(templateService).deleteTemplate("foo.xml");
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParams));
+                            ApiException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
@@ -55,7 +55,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
 import com.google.gson.Gson;
-
+import io.vertx.core.http.HttpMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -66,8 +66,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.vertx.core.http.HttpMethod;
 
 @ExtendWith(MockitoExtension.class)
 public class ProbeTemplateDeleteHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
@@ -45,6 +45,19 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.gson.Gson;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import io.cryostat.MainModule;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
@@ -57,20 +70,8 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ProbeTemplateUploadHandlerTest {
@@ -158,9 +159,9 @@ public class ProbeTemplateUploadHandlerTest {
             Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
 
             Mockito.when(fs.newInputStream(Mockito.any())).thenThrow(IOException.class);
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParams));
+                            ApiException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
             Mockito.verify(fs).deleteIfExists(uploadPath);
         }
@@ -185,9 +186,9 @@ public class ProbeTemplateUploadHandlerTest {
                     .when(templateService)
                     .addTemplate(stream, "foo.xml");
 
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParams));
+                            ApiException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
             Mockito.verify(fs).deleteIfExists(uploadPath);
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
@@ -45,19 +45,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.gson.Gson;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import io.cryostat.MainModule;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
@@ -70,8 +57,19 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ProbeTemplateUploadHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RecordingGetHandlerTest.java
@@ -136,8 +136,7 @@ class RecordingGetHandlerTest {
             Mockito.when(archive.getRecordingPath(Mockito.anyString())).thenReturn(future);
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RecordingGetHandlerTest.java
@@ -57,7 +57,6 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -135,9 +134,9 @@ class RecordingGetHandlerTest {
                     CompletableFuture.failedFuture(
                             new RecordingNotFoundException("archive", "myrecording"));
             Mockito.when(archive.getRecordingPath(Mockito.anyString())).thenReturn(future);
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ReportGetHandlerTest.java
@@ -43,8 +43,20 @@ import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import com.nimbusds.jwt.JWT;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.reports.ReportService;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.recordings.RecordingNotFoundException;
 
+import com.nimbusds.jwt.JWT;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -56,19 +68,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.reports.ReportService;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.recordings.RecordingNotFoundException;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class ReportGetHandlerTest {
@@ -141,8 +140,7 @@ class ReportGetHandlerTest {
             Mockito.when(reports.get(Mockito.anyString())).thenReturn(future);
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ReportGetHandlerTest.java
@@ -43,21 +43,8 @@ import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.reports.ReportService;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.recordings.RecordingNotFoundException;
-
 import com.nimbusds.jwt.JWT;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -69,6 +56,19 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.reports.ReportService;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.recordings.RecordingNotFoundException;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class ReportGetHandlerTest {
@@ -139,9 +139,9 @@ class ReportGetHandlerTest {
                     CompletableFuture.failedFuture(
                             new RecordingNotFoundException("archive", "myrecording"));
             Mockito.when(reports.get(Mockito.anyString())).thenReturn(future);
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
@@ -45,17 +45,6 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import com.google.gson.Gson;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -72,8 +61,18 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbeDeleteHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
@@ -45,6 +45,17 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
+import com.google.gson.Gson;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -61,19 +72,8 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbeDeleteHandlerTest {
@@ -184,7 +184,7 @@ public class TargetProbeDeleteHandlerTest {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", ""));
             try {
                 IntermediateResponse<Void> response = handler.handle(requestParams);
-            } catch (HttpStatusException e) {
+            } catch (ApiException e) {
                 MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(400));
             }
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
@@ -45,17 +45,6 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import com.google.gson.Gson;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -73,8 +62,18 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbeGetHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
@@ -45,6 +45,17 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
+import com.google.gson.Gson;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -62,19 +73,8 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbeGetHandlerTest {
@@ -184,7 +184,7 @@ public class TargetProbeGetHandlerTest {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", ""));
             try {
                 IntermediateResponse<String> response = handler.handle(requestParams);
-            } catch (HttpStatusException e) {
+            } catch (ApiException e) {
                 MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(400));
             }
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
@@ -45,17 +45,6 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import com.google.gson.Gson;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -73,8 +62,18 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
+import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbePostHandlerTest {

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
@@ -45,6 +45,17 @@ import java.util.Map;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
+import com.google.gson.Gson;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
@@ -62,19 +73,8 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 
-import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class TargetProbePostHandlerTest {
@@ -193,7 +193,7 @@ public class TargetProbePostHandlerTest {
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", ""));
             try {
                 IntermediateResponse<Void> response = handler.handle(requestParams);
-            } catch (HttpStatusException e) {
+            } catch (ApiException e) {
                 MatcherAssert.assertThat(e.getStatusCode(), Matchers.equalTo(400));
             }
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingGetHandlerTest.java
@@ -44,6 +44,23 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
@@ -59,9 +76,6 @@ import io.cryostat.net.security.jwt.AssetJwtHelper;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
-
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.jwt.JWTClaimsSet;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -73,21 +87,6 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.jsoup.nodes.Document;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class TargetRecordingGetHandlerTest {
@@ -178,9 +177,9 @@ class TargetRecordingGetHandlerTest {
                             });
             Mockito.when(conn.getService()).thenReturn(svc);
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of());
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
@@ -211,9 +210,9 @@ class TargetRecordingGetHandlerTest {
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of(desc));
             Mockito.when(svc.openStream(Mockito.any(), Mockito.eq(false)))
                     .thenThrow(new FlightRecorderException(""));
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         }
@@ -265,9 +264,9 @@ class TargetRecordingGetHandlerTest {
                     .thenReturn(false);
             // ********************************************************************
 
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
             MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingGetHandlerTest.java
@@ -44,23 +44,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.jwt.JWTClaimsSet;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.jsoup.nodes.Document;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
@@ -76,6 +59,9 @@ import io.cryostat.net.security.jwt.AssetJwtHelper;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -87,6 +73,20 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class TargetRecordingGetHandlerTest {
@@ -179,8 +179,7 @@ class TargetRecordingGetHandlerTest {
             Mockito.when(svc.getAvailableRecordings()).thenReturn(List.of());
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
 
@@ -212,8 +211,7 @@ class TargetRecordingGetHandlerTest {
                     .thenThrow(new FlightRecorderException(""));
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
         }
 
@@ -266,8 +264,7 @@ class TargetRecordingGetHandlerTest {
 
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
             MatcherAssert.assertThat(
                     ex.getCause().getCause().getMessage(),

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandlerTest.java
@@ -41,22 +41,9 @@ import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.reports.ReportService;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.recordings.RecordingNotFoundException;
-
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -67,6 +54,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.reports.ReportService;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.recordings.RecordingNotFoundException;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class TargetReportGetHandlerTest {
@@ -144,9 +144,9 @@ class TargetReportGetHandlerTest {
                     CompletableFuture.failedFuture(
                             new RecordingNotFoundException("target", "myrecording"));
             Mockito.when(reports.get(Mockito.any(), Mockito.anyString())).thenReturn(future);
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetReportGetHandlerTest.java
@@ -41,9 +41,21 @@ import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.reports.ReportService;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.recordings.RecordingNotFoundException;
+
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -54,19 +66,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.reports.ReportService;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.recordings.RecordingNotFoundException;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class TargetReportGetHandlerTest {
@@ -146,8 +145,7 @@ class TargetReportGetHandlerTest {
             Mockito.when(reports.get(Mockito.any(), Mockito.anyString())).thenReturn(future);
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandlerTest.java
@@ -40,24 +40,9 @@ package io.cryostat.net.web.http.api.v2;
 import java.util.EnumSet;
 import java.util.Optional;
 
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnection;
-import io.cryostat.core.templates.TemplateService;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.nodes.Document;
@@ -71,6 +56,21 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.templates.TemplateService;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class TargetTemplateGetHandlerTest {
@@ -160,9 +160,9 @@ class TargetTemplateGetHandlerTest {
                             });
             Mockito.when(templateService.getXml(Mockito.anyString(), Mockito.any()))
                     .thenReturn(Optional.empty());
-            HttpStatusException ex =
+            ApiException ex =
                     Assertions.assertThrows(
-                            HttpStatusException.class,
+                            ApiException.class,
                             () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetTemplateGetHandlerTest.java
@@ -40,9 +40,23 @@ package io.cryostat.net.web.http.api.v2;
 import java.util.EnumSet;
 import java.util.Optional;
 
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.templates.TemplateService;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.AssetJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.nodes.Document;
@@ -56,21 +70,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-
-import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnection;
-import io.cryostat.core.templates.TemplateService;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.security.ResourceAction;
-import io.cryostat.net.security.jwt.AssetJwtHelper;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
 class TargetTemplateGetHandlerTest {
@@ -162,8 +161,7 @@ class TargetTemplateGetHandlerTest {
                     .thenReturn(Optional.empty());
             ApiException ex =
                     Assertions.assertThrows(
-                            ApiException.class,
-                            () -> handler.handleWithValidJwt(ctx, token));
+                            ApiException.class, () -> handler.handleWithValidJwt(ctx, token));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
         }
 

--- a/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
@@ -83,7 +83,7 @@ class CorsEnablingHandlerTest {
 
     @Test
     void shouldApplyToOtherMethod() {
-        MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.OTHER));
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.nullValue());
     }
 
     @ParameterizedTest

--- a/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/CorsEnablingHandlerTest.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -140,10 +139,9 @@ class CorsEnablingHandlerTest {
         }
 
         @ParameterizedTest
-        @EnumSource(
-                value = HttpMethod.class,
-                names = {"GET", "POST", "PATCH", "OPTIONS", "HEAD", "DELETE"})
-        void shouldRespondOKToOPTIONSWithAcceptedMethod(HttpMethod method) {
+        @ValueSource(strings = {"GET", "POST", "PATCH", "OPTIONS", "HEAD", "DELETE"})
+        void shouldRespondOKToOPTIONSWithAcceptedMethod(String methodName) {
+            HttpMethod method = HttpMethod.valueOf(methodName);
             Mockito.when(req.method()).thenReturn(HttpMethod.OPTIONS);
             Mockito.when(headers.get(HttpHeaders.ORIGIN)).thenReturn(CUSTOM_ORIGIN);
             Mockito.when(headers.get(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD))

--- a/src/test/java/itest/AutoRulesIT.java
+++ b/src/test/java/itest/AutoRulesIT.java
@@ -51,7 +51,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.ExternalTargetsTest;
 import itest.util.ITestCleanupFailedException;
 import itest.util.Podman;
@@ -550,7 +550,7 @@ class AutoRulesIT extends ExternalTargetsTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -568,7 +568,7 @@ class AutoRulesIT extends ExternalTargetsTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -57,7 +57,7 @@ import com.google.gson.reflect.TypeToken;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.ExternalTargetsTest;
 import itest.util.ITestCleanupFailedException;
 import itest.util.Podman;
@@ -111,7 +111,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -132,7 +132,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -153,7 +153,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -176,7 +176,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -197,7 +197,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -220,7 +220,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -279,7 +279,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ee.getCause()).getStatusCode(), Matchers.equalTo(427));
+                ((HttpException) ee.getCause()).getStatusCode(), Matchers.equalTo(427));
 
         // Confirm invalid credentials automatically deleted by attempting to delete them
         CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
@@ -294,7 +294,7 @@ public class CredentialsIT extends ExternalTargetsTest {
                         ExecutionException.class,
                         () -> deleteResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 

--- a/src/test/java/itest/MessagingServerIT.java
+++ b/src/test/java/itest/MessagingServerIT.java
@@ -77,7 +77,7 @@ public class MessagingServerIT extends StandardSelfTest {
                 Assertions.assertThrows(
                         ExecutionException.class,
                         () -> sendMessage("ping").get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        String errorMessage = "Websocket connection attempt returned HTTP status code 410";
+        String errorMessage = "WebSocket upgrade failure: 410 (Gone)";
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo(errorMessage));
     }
 }

--- a/src/test/java/itest/NonExistentTargetIT.java
+++ b/src/test/java/itest/NonExistentTargetIT.java
@@ -41,7 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.json.JsonArray;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.hamcrest.MatcherAssert;
@@ -70,6 +70,6 @@ public class NonExistentTargetIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
     }
 }

--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -50,7 +50,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import org.hamcrest.MatcherAssert;
@@ -236,7 +236,7 @@ public class ReportIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -47,7 +47,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import org.hamcrest.MatcherAssert;
@@ -92,7 +92,7 @@ class RulesPostFormIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -136,7 +136,7 @@ class RulesPostFormIT extends StandardSelfTest {
                     Assertions.assertThrows(
                             ExecutionException.class, () -> duplicatePostResponse.get());
             MatcherAssert.assertThat(
-                    ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
+                    ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
             MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
         } finally {
@@ -186,7 +186,7 @@ class RulesPostFormIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -85,7 +85,7 @@ class RulesPostFormIT extends StandardSelfTest {
                 .post("/api/v2/rules")
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.MULTIPART_FORM.mime())
                 .sendForm(
-                        null,
+                        MultiMap.caseInsensitiveMultiMap(),
                         ar -> {
                             assertRequestStatus(ar, response);
                         });

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -46,7 +46,7 @@ import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import org.hamcrest.MatcherAssert;
@@ -91,7 +91,7 @@ class RulesPostJsonIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -110,7 +110,7 @@ class RulesPostJsonIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
         MatcherAssert.assertThat(
                 ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
@@ -130,7 +130,7 @@ class RulesPostJsonIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(415));
         MatcherAssert.assertThat(
                 ex.getCause().getMessage(), Matchers.equalTo("Unsupported Media Type"));
     }
@@ -175,7 +175,7 @@ class RulesPostJsonIT extends StandardSelfTest {
                     Assertions.assertThrows(
                             ExecutionException.class, () -> duplicatePostResponse.get());
             MatcherAssert.assertThat(
-                    ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
+                    ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
             MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
 
         } finally {
@@ -225,7 +225,7 @@ class RulesPostJsonIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 }

--- a/src/test/java/itest/SnapshotIT.java
+++ b/src/test/java/itest/SnapshotIT.java
@@ -50,7 +50,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import org.hamcrest.MatcherAssert;
@@ -217,7 +217,7 @@ public class SnapshotIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> snapshotResponse.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -431,7 +431,7 @@ public class SnapshotIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> snapshotName.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/TargetPostDeleteIT.java
+++ b/src/test/java/itest/TargetPostDeleteIT.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.hamcrest.MatcherAssert;
@@ -70,7 +70,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -91,7 +91,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -113,7 +113,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -135,7 +135,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -156,7 +156,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -178,7 +178,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -196,7 +196,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -218,7 +218,7 @@ public class TargetPostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/TargetRecordingsClientErrorIT.java
+++ b/src/test/java/itest/TargetRecordingsClientErrorIT.java
@@ -82,7 +82,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         webClient
                 .post(REQ_URL)
                 .sendForm(
-                        null,
+                        MultiMap.caseInsensitiveMultiMap(),
                         ar -> {
                             assertRequestStatus(ar, response);
                         });

--- a/src/test/java/itest/TargetRecordingsClientErrorIT.java
+++ b/src/test/java/itest/TargetRecordingsClientErrorIT.java
@@ -45,7 +45,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -89,7 +89,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -110,7 +110,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -131,7 +131,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -153,7 +153,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -175,7 +175,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -198,7 +198,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -221,7 +221,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -238,7 +238,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -255,7 +255,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -277,7 +277,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -299,7 +299,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -318,7 +318,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
@@ -337,7 +337,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -356,7 +356,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -374,7 +374,7 @@ public class TargetRecordingsClientErrorIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/TargetReportIT.java
+++ b/src/test/java/itest/TargetReportIT.java
@@ -50,7 +50,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import org.hamcrest.MatcherAssert;
@@ -199,7 +199,7 @@ public class TargetReportIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 }

--- a/src/test/java/itest/TemplatePostDeleteIT.java
+++ b/src/test/java/itest/TemplatePostDeleteIT.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.multipart.MultipartForm;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
@@ -83,7 +83,7 @@ public class TemplatePostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -112,7 +112,7 @@ public class TemplatePostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -130,7 +130,7 @@ public class TemplatePostDeleteIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 

--- a/src/test/java/itest/UploadCertificateIT.java
+++ b/src/test/java/itest/UploadCertificateIT.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ExecutionException;
 import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.multipart.MultipartForm;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
@@ -77,7 +77,7 @@ public class UploadCertificateIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -104,7 +104,7 @@ public class UploadCertificateIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -122,7 +122,7 @@ public class UploadCertificateIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
     }
 
@@ -179,7 +179,7 @@ public class UploadCertificateIT extends StandardSelfTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> duplicateResponse.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(409));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Conflict"));
     }
 }

--- a/src/test/java/itest/WrongServiceListeningOnPortIT.java
+++ b/src/test/java/itest/WrongServiceListeningOnPortIT.java
@@ -44,7 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.json.JsonArray;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.bases.ExternalTargetsTest;
 import itest.util.Podman;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -110,6 +110,6 @@ public class WrongServiceListeningOnPortIT extends ExternalTargetsTest {
         ExecutionException ex =
                 Assertions.assertThrows(ExecutionException.class, () -> response.get());
         MatcherAssert.assertThat(
-                ((HttpStatusException) ex.getCause()).getStatusCode(), Matchers.equalTo(500));
+                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(500));
     }
 }

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -58,7 +58,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 import itest.util.Podman;
 import itest.util.Utils;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -138,7 +138,7 @@ public abstract class StandardSelfTest {
         if (!HttpStatusCodeIdentifier.isSuccessCode(response.statusCode())) {
             System.err.println("HTTP " + response.statusCode() + ": " + response.statusMessage());
             future.completeExceptionally(
-                    new HttpStatusException(response.statusCode(), response.statusMessage()));
+                    new HttpException(response.statusCode(), response.statusMessage()));
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes #453

This is a very large looking PR, but it only does a couple of things. They just touched a lot of places.

First it upgrades the Vert.x version in the `pom.xml` from a 3.x to 4.3.0 (latest). This comes with a change moving the `HttpStatusException` class to a different package and renaming it `HttpException`, as well as making it final. This is the bulk of the file touches in the PR, because we were using `HttpStatusException` nearly everywhere. It moved from Vert.x "internal" package to a public API one at Vert.x version 4.1.0, so this shouldn't happen to us again. This necessitated a small adjustment to the `ApiException` handling in various places as well, since that can no longer subclass the `final class HttpException`.

Next it makes a few small adjustments to get functionality working again due to various changes in the 4.x line. For example, the Vert.x-GraphQL `GraphQLHandler` is no longer a `BodyHandler` on its own, so I had to add a specific `BodyHandler` instance in front of that one like we have elsewhere. The GraphQL Scalar type was also deprecated, removed, and replaced by one in the `extended-scalars` package.

Next it turns a few more pieces into Verticles. For the most part this isn't actually achieving anything at this point, since these new pieces aren't taking much advantage of Vert.x event loop architecture, but this opens the door to refactor them better in the future.

Finally it replaces various `(Scheduled)ExecutorService` usages with `vertx.setTimer()` and `vertx.setPeriodic`. This lets us make better use of the existing Vert.x worker thread pool, rather than maintaining our own competing thread pool(s). Unlikely to have serious impact here yet, but it allows us to refactor things to make better use of the event loop and reactive/non-blocking architecture in the future.