### PR TITLE
docs(api): Rename /api/beta/discovery to /api/v2.1/discovery

### DIFF
--- a/HTTP_API.md
+++ b/HTTP_API.md
@@ -1748,7 +1748,7 @@ The handler-specific descriptions below describe how each handler populates the
     belonging to ex. Pods, belonging to Deployments, etc.
 
     ###### request
-    `GET /api/beta/discovery`
+    `GET /api/v2.1/discovery`
 
     ###### response
     `200` - The result is the path of the saved file in the server's storage.


### PR DESCRIPTION
Fixes #935 

Rename discovery endpoint to /api/v2.1/discovery for 2.1.0 release.