### PR TITLE
chore(api): Move Probe handlers from beta to v2 package

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
@@ -39,6 +39,12 @@ package io.cryostat.net.web.http.api.beta;
 
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.beta.graph.GraphModule;
+import io.cryostat.net.web.http.api.v2.ProbeTemplateDeleteHandler;
+import io.cryostat.net.web.http.api.v2.TargetProbePostHandler;
+import io.cryostat.net.web.http.api.v2.TargetProbeDeleteHandler;
+import io.cryostat.net.web.http.api.v2.TargetProbesGetHandler;
+import io.cryostat.net.web.http.api.v2.ProbeTemplateUploadBodyHandler;
+import io.cryostat.net.web.http.api.v2.ProbeTemplateUploadHandler;
 
 import dagger.Binds;
 import dagger.Module;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
@@ -39,12 +39,6 @@ package io.cryostat.net.web.http.api.beta;
 
 import io.cryostat.net.web.http.RequestHandler;
 import io.cryostat.net.web.http.api.beta.graph.GraphModule;
-import io.cryostat.net.web.http.api.v2.ProbeTemplateDeleteHandler;
-import io.cryostat.net.web.http.api.v2.TargetProbePostHandler;
-import io.cryostat.net.web.http.api.v2.TargetProbeDeleteHandler;
-import io.cryostat.net.web.http.api.v2.TargetProbesGetHandler;
-import io.cryostat.net.web.http.api.v2.ProbeTemplateUploadBodyHandler;
-import io.cryostat.net.web.http.api.v2.ProbeTemplateUploadHandler;
 
 import dagger.Binds;
 import dagger.Module;
@@ -52,32 +46,6 @@ import dagger.multibindings.IntoSet;
 
 @Module(includes = {GraphModule.class})
 public abstract class HttpApiBetaModule {
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindProbeTemplateUploadHandler(ProbeTemplateUploadHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindProbeTemplateUploadBodyHandler(
-            ProbeTemplateUploadBodyHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindProbeTemplateDeleteHandler(ProbeTemplateDeleteHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetProbePostHandler(TargetProbePostHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetProbeDeleteHandler(TargetProbeDeleteHandler handler);
-
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindTargetProbesGetHandler(TargetProbesGetHandler handler);
-
     @Binds
     @IntoSet
     abstract RequestHandler bindRecordingMetadataLabelsPostHandler(

--- a/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
@@ -55,6 +55,30 @@ import dagger.multibindings.IntoSet;
 
 @Module
 public abstract class HttpApiV2Module {
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindProbeTemplateUploadHandler(ProbeTemplateUploadHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindProbeTemplateUploadBodyHandler(
+            ProbeTemplateUploadBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindProbeTemplateDeleteHandler(ProbeTemplateDeleteHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetProbePostHandler(TargetProbePostHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetProbeDeleteHandler(TargetProbeDeleteHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindTargetProbesGetHandler(TargetProbesGetHandler handler);
 
     @Binds
     @IntoSet

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
@@ -56,7 +56,7 @@ import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
-public class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
+class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "probes/:probetemplateName";
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadBodyHandler.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.web.http.api.beta;
+package io.cryostat.net.web.http.api.v2;
 
 import java.util.Set;
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadBodyHandler.java
@@ -52,7 +52,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
-public class ProbeTemplateUploadBodyHandler extends AbstractAuthenticatedRequestHandler {
+class ProbeTemplateUploadBodyHandler extends AbstractAuthenticatedRequestHandler {
 
     static final BodyHandler BODY_HANDLER = BodyHandler.create(true);
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
@@ -60,7 +60,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
-public class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
+class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "probes/:probetemplateName";
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
@@ -60,7 +60,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
-class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
+public class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "probes/:probetemplateName";
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -58,7 +58,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import org.apache.commons.lang3.StringUtils;
 
-public class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
+class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "targets/:targetId/probes";
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.web.http.api.beta;
+package io.cryostat.net.web.http.api.v2;
 
 import java.util.Map;
 import java.util.Set;
@@ -43,38 +43,47 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.core.agent.AgentJMXHelper;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.Environment;
+import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
-import io.cryostat.net.web.http.api.v2.IntermediateResponse;
-import io.cryostat.net.web.http.api.v2.RequestParameters;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import org.apache.commons.lang3.StringUtils;
 
-public class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
+public class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "targets/:targetId/probes";
 
-    private final TargetConnectionManager connectionManager;
-    private static final String NOTIFICATION_CATEGORY = "TargetProbesGet";
+    private final Logger logger;
     private final NotificationFactory notificationFactory;
+    private final FileSystem fs;
+    private final TargetConnectionManager connectionManager;
+    private final Environment env;
+    private static final String NOTIFICATION_CATEGORY = "ProbeTemplateDeleted";
 
     @Inject
-    TargetProbesGetHandler(
+    TargetProbeDeleteHandler(
+            Logger logger,
+            NotificationFactory notificationFactory,
+            FileSystem fs,
             AuthManager auth,
             TargetConnectionManager connectionManager,
-            NotificationFactory notificationFactory,
+            Environment env,
             Gson gson) {
         super(auth, gson);
+        this.logger = logger;
         this.notificationFactory = notificationFactory;
         this.connectionManager = connectionManager;
+        this.env = env;
+        this.fs = fs;
     }
 
     @Override
@@ -89,7 +98,7 @@ public class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
 
     @Override
     public HttpMethod httpMethod() {
-        return HttpMethod.GET;
+        return HttpMethod.DELETE;
     }
 
     @Override
@@ -103,7 +112,7 @@ public class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
     }
 
     @Override
-    public IntermediateResponse<String> handle(RequestParameters requestParams) throws Exception {
+    public IntermediateResponse<Void> handle(RequestParameters requestParams) throws Exception {
         Map<String, String> pathParams = requestParams.getPathParams();
         String targetId = pathParams.get("targetId");
         StringBuilder sb = new StringBuilder();
@@ -111,26 +120,33 @@ public class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
             sb.append("targetId is required.");
             throw new HttpStatusException(400, sb.toString().trim());
         }
-        return connectionManager.executeConnectedTask(
-                getConnectionDescriptorFromParams(requestParams),
-                connection -> {
-                    connection.connect();
-                    AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
-                    String probes = helper.retrieveEventProbes();
-                    notificationFactory
-                            .createBuilder()
-                            .metaCategory(NOTIFICATION_CATEGORY)
-                            .metaType(HttpMimeType.JSON)
-                            .message(Map.of("targetId", targetId))
-                            .build()
-                            .send();
-                    return new IntermediateResponse<String>().body(probes);
-                });
+        try {
+            return connectionManager.executeConnectedTask(
+                    getConnectionDescriptorFromParams(requestParams),
+                    connection -> {
+                        connection.connect();
+                        AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
+                        // The convention for removing probes in the agent controller mbean is to
+                        // call
+                        // defineEventProbes with a null argument.
+                        helper.defineEventProbes(null);
+                        notificationFactory
+                                .createBuilder()
+                                .metaCategory(NOTIFICATION_CATEGORY)
+                                .metaType(HttpMimeType.JSON)
+                                .message(Map.of("targetId", targetId))
+                                .build()
+                                .send();
+                        return new IntermediateResponse<Void>().body(null);
+                    });
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     @Override
     public HttpMimeType mimeType() {
-        return HttpMimeType.JSON;
+        return HttpMimeType.PLAINTEXT;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
@@ -84,7 +84,7 @@ import org.apache.commons.lang3.StringUtils;
  * <p>427 - JMX authentication failed. The body is an error message. There will be an
  * X-JMX-Authenticate: $SCHEME header that indicates the authentication scheme that is used.
  */
-public class TargetProbePostHandler extends AbstractV2RequestHandler<Void> {
+class TargetProbePostHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "targets/:targetId/probes/:probeTemplate";
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
@@ -55,7 +55,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import org.apache.commons.lang3.StringUtils;
 
-public class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
+class TargetProbesGetHandler extends AbstractV2RequestHandler<String> {
 
     static final String PATH = "targets/:targetId/probes";
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
@@ -35,19 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.web.http.api.beta;
+package io.cryostat.net.web.http.api.v2;
 
 import static org.mockito.Mockito.lenient;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.agent.LocalProbeTemplateService;
-import io.cryostat.core.agent.ProbeValidationException;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.Notification;
@@ -56,12 +53,9 @@ import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.net.web.http.api.v2.IntermediateResponse;
-import io.cryostat.net.web.http.api.v2.RequestParameters;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -75,9 +69,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class ProbeTemplateUploadHandlerTest {
+public class ProbeTemplateDeleteHandlerTest {
 
-    ProbeTemplateUploadHandler handler;
+    ProbeTemplateDeleteHandler handler;
     @Mock AuthManager auth;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
@@ -102,7 +96,7 @@ public class ProbeTemplateUploadHandlerTest {
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
-                new ProbeTemplateUploadHandler(
+                new ProbeTemplateDeleteHandler(
                         auth, notificationFactory, templateService, logger, fs, gson);
     }
 
@@ -110,7 +104,7 @@ public class ProbeTemplateUploadHandlerTest {
     class BasicHandlerDefinition {
         @Test
         void shouldBePOSTHandler() {
-            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
         }
 
         @Test
@@ -128,7 +122,7 @@ public class ProbeTemplateUploadHandlerTest {
         void shouldHaveExpectedRequiredPermissions() {
             MatcherAssert.assertThat(
                     handler.resourceActions(),
-                    Matchers.equalTo(Set.of(ResourceAction.CREATE_PROBE_TEMPLATE)));
+                    Matchers.equalTo(Set.of(ResourceAction.DELETE_PROBE_TEMPLATE)));
         }
 
         @Test
@@ -148,73 +142,24 @@ public class ProbeTemplateUploadHandlerTest {
         @Mock RequestParameters requestParams;
 
         @Test
-        void shouldRespond500WhenUploadFails() throws Exception {
-            FileUpload upload = Mockito.mock(FileUpload.class);
-            Mockito.when(upload.name()).thenReturn("probeTemplate");
-            Mockito.when(requestParams.getFileUploads()).thenReturn(Set.of(upload));
+        void shouldRespond400WhenTemplateNotFound() throws Exception {
             Mockito.when(requestParams.getPathParams())
                     .thenReturn(Map.of("probetemplateName", "foo.xml"));
-
-            Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
-            Path uploadPath = Mockito.mock(Path.class);
-            Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
-
-            Mockito.when(fs.newInputStream(Mockito.any())).thenThrow(IOException.class);
-            HttpStatusException ex =
-                    Assertions.assertThrows(
-                            HttpStatusException.class, () -> handler.handle(requestParams));
-            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
-            Mockito.verify(fs).deleteIfExists(uploadPath);
-        }
-
-        @Test
-        void shouldRespond400IfXmlInvalid() throws Exception {
-            FileUpload upload = Mockito.mock(FileUpload.class);
-            Mockito.when(upload.name()).thenReturn("probeTemplate");
-            Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
-
-            Mockito.when(requestParams.getFileUploads()).thenReturn(Set.of(upload));
-            Mockito.when(requestParams.getPathParams())
-                    .thenReturn(Map.of("probetemplateName", "foo.xml"));
-
-            Path uploadPath = Mockito.mock(Path.class);
-            Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
-
-            InputStream stream = Mockito.mock(InputStream.class);
-            Mockito.when(fs.newInputStream(Mockito.any())).thenReturn(stream);
-
-            Mockito.doThrow(ProbeValidationException.class)
-                    .when(templateService)
-                    .addTemplate(stream, "foo.xml");
-
+            Mockito.doThrow(new IOException()).when(templateService).deleteTemplate("foo.xml");
             HttpStatusException ex =
                     Assertions.assertThrows(
                             HttpStatusException.class, () -> handler.handle(requestParams));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
-            Mockito.verify(fs).deleteIfExists(uploadPath);
         }
 
         @Test
-        void shouldProcessGoodRequest() throws Exception {
-            FileUpload upload = Mockito.mock(FileUpload.class);
-            Mockito.when(upload.name()).thenReturn("probeTemplate");
-            Mockito.when(upload.uploadedFileName()).thenReturn("/file-uploads/abcd-1234");
-
-            Mockito.when(requestParams.getFileUploads()).thenReturn(Set.of(upload));
+        void shouldCallThroughToService() throws Exception {
             Mockito.when(requestParams.getPathParams())
                     .thenReturn(Map.of("probetemplateName", "foo.xml"));
-
-            Path uploadPath = Mockito.mock(Path.class);
-            Mockito.when(fs.pathOf("/file-uploads/abcd-1234")).thenReturn(uploadPath);
-
-            InputStream stream = Mockito.mock(InputStream.class);
-            Mockito.when(fs.newInputStream(uploadPath)).thenReturn(stream);
-
             IntermediateResponse<Void> response = handler.handle(requestParams);
 
-            Mockito.verify(templateService).addTemplate(stream, "foo.xml");
+            Mockito.verify(templateService).deleteTemplate("foo.xml");
             Mockito.verifyNoMoreInteractions(templateService);
-            Mockito.verify(fs).deleteIfExists(uploadPath);
 
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
             MatcherAssert.assertThat(response.getBody(), Matchers.nullValue());


### PR DESCRIPTION
Fixes #928

Move Probe handlers from beta to v2 sub-package since they are available in v2 API. This includes moving source and test files. 

