### PR TITLE
fix(recordings): empty archive directories are now removed

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -45,7 +45,6 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
@@ -84,7 +83,6 @@ import io.cryostat.util.URIUtil;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base32;
-import org.apache.commons.io.FileUtils;
 
 public class RecordingArchiveHelper {
 
@@ -222,8 +220,8 @@ public class RecordingArchiveHelper {
                     .message(Map.of("recording", archivedRecordingInfo))
                     .build()
                     .send();
-            if (pathIsEmpty(parentPath)) {
-                FileUtils.deleteDirectory(parentPath.toFile());
+            if (fs.size(parentPath) == 0) {
+                fs.deleteIfExists(parentPath);
             }
             future.complete(archivedRecordingInfo);
         } catch (IOException | InterruptedException | ExecutionException | URISyntaxException e) {
@@ -233,15 +231,6 @@ public class RecordingArchiveHelper {
         }
 
         return future;
-    }
-
-    private Boolean pathIsEmpty(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
-                return !entries.iterator().hasNext();
-            }
-        }
-        return false;
     }
 
     private void validateSavePath(String recordingName, Path path) throws IOException {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -220,7 +220,7 @@ public class RecordingArchiveHelper {
                     .message(Map.of("recording", archivedRecordingInfo))
                     .build()
                     .send();
-            if (fs.size(parentPath) == 0) {
+            if (fs.listDirectoryChildren(parentPath).isEmpty()) {
                 fs.deleteIfExists(parentPath);
             }
             future.complete(archivedRecordingInfo);

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -45,6 +45,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
@@ -83,6 +84,7 @@ import io.cryostat.util.URIUtil;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base32;
+import org.apache.commons.io.FileUtils;
 
 public class RecordingArchiveHelper {
 
@@ -220,6 +222,9 @@ public class RecordingArchiveHelper {
                     .message(Map.of("recording", archivedRecordingInfo))
                     .build()
                     .send();
+            if (pathIsEmpty(parentPath)) {
+                FileUtils.deleteDirectory(parentPath.toFile());
+            }
             future.complete(archivedRecordingInfo);
         } catch (IOException | InterruptedException | ExecutionException | URISyntaxException e) {
             future.completeExceptionally(e);
@@ -228,6 +233,15 @@ public class RecordingArchiveHelper {
         }
 
         return future;
+    }
+
+    private Boolean pathIsEmpty(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
+                return !entries.iterator().hasNext();
+            }
+        }
+        return false;
     }
 
     private void validateSavePath(String recordingName, Path path) throws IOException {

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -802,8 +802,15 @@ class RecordingArchiveHelperTest {
         ArgumentCaptor<Map<String, Object>> messageCaptor = ArgumentCaptor.forClass(Map.class);
 
         Mockito.verify(fs, Mockito.times(3)).deleteIfExists(Mockito.any());
-        Mockito.verify(fs).deleteIfExists(archivedRecordingsPath.resolve(subdirectories.get(1)).resolve(recordingName).toAbsolutePath());
-        Mockito.verify(fs).deleteIfExists(archivedRecordingsPath.resolve(subdirectories.get(1)).toAbsolutePath());
+        Mockito.verify(fs)
+                .deleteIfExists(
+                        archivedRecordingsPath
+                                .resolve(subdirectories.get(1))
+                                .resolve(recordingName)
+                                .toAbsolutePath());
+        Mockito.verify(fs)
+                .deleteIfExists(
+                        archivedRecordingsPath.resolve(subdirectories.get(1)).toAbsolutePath());
         Mockito.verify(fs).deleteIfExists(archivedRecordingsReportPath);
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingDeleted");

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -801,7 +801,10 @@ class RecordingArchiveHelperTest {
 
         ArgumentCaptor<Map<String, Object>> messageCaptor = ArgumentCaptor.forClass(Map.class);
 
-        Mockito.verify(fs, Mockito.times(2)).deleteIfExists(Mockito.any());
+        Mockito.verify(fs, Mockito.times(3)).deleteIfExists(Mockito.any());
+        Mockito.verify(fs).deleteIfExists(archivedRecordingsPath.resolve(subdirectories.get(1)).resolve(recordingName).toAbsolutePath());
+        Mockito.verify(fs).deleteIfExists(archivedRecordingsPath.resolve(subdirectories.get(1)).toAbsolutePath());
+        Mockito.verify(fs).deleteIfExists(archivedRecordingsReportPath);
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingDeleted");
         Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);


### PR DESCRIPTION
Fixes #951 

There is a bug that is tracked with the spotbugs bug tracker 

`[ERROR] Medium: Nullcheck of entries at line 242 of value previously dereferenced in io.cryostat.recordings.RecordingArchiveHelper.pathIsEmpty(Path) [io.cryostat.recordings.RecordingArchiveHelper, io.cryostat.recordings.RecordingArchiveHelper] At RecordingArchiveHelper.java:[line 242]Redundant null check at RecordingArchiveHelper.java:[line 243] RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE`

I'm not sure why because I don't see a clear null checking in the code I added. 
