### PR TITLE
ci(oci): run validate phase before evaluating tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
         echo "::set-output name=core-version::v$CORE_VERSION"
-        IMAGE_VERSION="$(mvn help:evaluate -Dexpression=cryostat.imageVersionLower -q -DforceStdout)"
+        IMAGE_VERSION="$(mvn validate help:evaluate -Dexpression=cryostat.imageVersionLower -q -DforceStdout)"
         echo "::set-output name=image-version::$IMAGE_VERSION"
     outputs:
       core-version: ${{ steps.query-pom.outputs.core-version }}


### PR DESCRIPTION
One more fix. In order for the `imageTagLower` property to be defined, run `validate` before `help:evaluate`.

Fixes: #973 