### PR TITLE
fix(openshift): include subresource in access check

### DIFF
--- a/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftAuthManager.java
@@ -315,6 +315,7 @@ public class OpenShiftAuthManager extends AbstractAuthManager {
                                                 .withNamespace(namespace)
                                                 .withGroup(resource.getGroup())
                                                 .withResource(resource.getResource())
+                                                .withSubresource(resource.getSubResource())
                                                 .withVerb(verb)
                                                 .endResourceAttributes()
                                                 .endSpec()


### PR DESCRIPTION
Related to #635
Related to #979
Correction on #662
