### PR TITLE
feat(credentials): implement matchExpression-based credentials

### DIFF
--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -78,6 +78,7 @@ class Cryostat {
         CompletableFuture<Void> future = new CompletableFuture<>();
         client.httpServer().addShutdownListener(() -> future.complete(null));
 
+        client.credentialsManager().migrate();
         client.credentialsManager().load();
         client.ruleRegistry().loadRules();
         client.vertx()

--- a/src/main/java/io/cryostat/MainModule.java
+++ b/src/main/java/io/cryostat/MainModule.java
@@ -44,6 +44,8 @@ import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.management.remote.JMXServiceURL;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
 
 import io.cryostat.configuration.ConfigurationModule;
 import io.cryostat.configuration.Variables;
@@ -154,5 +156,11 @@ public abstract class MainModule {
         String archivePath = env.getEnv(Variables.ARCHIVE_PATH, "/flightrecordings");
         logger.info("Local save path for flight recordings set as {}", archivePath);
         return Paths.get(archivePath);
+    }
+
+    @Provides
+    @Singleton
+    public static ScriptEngine provideScriptEngine() {
+        return new ScriptEngineManager().getEngineByName("nashorn");
     }
 }

--- a/src/main/java/io/cryostat/configuration/ConfigurationModule.java
+++ b/src/main/java/io/cryostat/configuration/ConfigurationModule.java
@@ -53,6 +53,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.PlatformClient;
+import io.cryostat.rules.MatchExpressionEvaluator;
 
 import com.google.gson.Gson;
 import dagger.Module;
@@ -77,6 +78,7 @@ public abstract class ConfigurationModule {
     @Singleton
     static CredentialsManager provideCredentialsManager(
             @Named(CONFIGURATION_PATH) Path confDir,
+            MatchExpressionEvaluator matchExpressionEvaluator,
             FileSystem fs,
             PlatformClient platformClient,
             NotificationFactory notificationFactory,
@@ -95,7 +97,14 @@ public abstract class ConfigurationModule {
                                         PosixFilePermission.OWNER_EXECUTE)));
             }
             return new CredentialsManager(
-                    credentialsDir, fs, platformClient, notificationFactory, gson, base32, logger);
+                    credentialsDir,
+                    matchExpressionEvaluator,
+                    fs,
+                    platformClient,
+                    notificationFactory,
+                    gson,
+                    base32,
+                    logger);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -45,6 +45,7 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -241,7 +242,7 @@ public class CredentialsManager {
 
         private MatchedCredentials(String matchExpression, Collection<ServiceRef> targets) {
             this.matchExpression = matchExpression;
-            this.targets = targets;
+            this.targets = new HashSet<>(targets);
         }
 
         public String getMatchExpression() {
@@ -249,7 +250,7 @@ public class CredentialsManager {
         }
 
         public Collection<ServiceRef> getTargets() {
-            return targets;
+            return Collections.unmodifiableCollection(targets);
         }
     }
 

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -170,7 +170,7 @@ public class CredentialsManager {
         return deleted != null;
     }
 
-    public Credentials getCredentials(String targetId) {
+    public Credentials getCredentialsByTargetId(String targetId) {
         for (ServiceRef service : this.platformClient.listDiscoverableServices()) {
             if (Objects.equals(targetId, service.getServiceUri().toString())) {
                 return getCredentials(service);
@@ -213,8 +213,6 @@ public class CredentialsManager {
         List<ServiceRef> targets = platformClient.listDiscoverableServices();
         for (String expr : getMatchExpressions()) {
             Set<ServiceRef> matchedTargets = new HashSet<>();
-            MatchedCredentials match = new MatchedCredentials(expr, matchedTargets);
-            result.add(match);
             for (ServiceRef target : targets) {
                 try {
                     if (matchExpressionEvaluator.applies(expr, target)) {
@@ -225,6 +223,8 @@ public class CredentialsManager {
                     continue;
                 }
             }
+            MatchedCredentials match = new MatchedCredentials(expr, matchedTargets);
+            result.add(match);
         }
         return result;
     }
@@ -240,7 +240,7 @@ public class CredentialsManager {
         private final String matchExpression;
         private final Collection<ServiceRef> targets;
 
-        private MatchedCredentials(String matchExpression, Collection<ServiceRef> targets) {
+        MatchedCredentials(String matchExpression, Collection<ServiceRef> targets) {
             this.matchExpression = matchExpression;
             this.targets = new HashSet<>(targets);
         }
@@ -251,6 +251,27 @@ public class CredentialsManager {
 
         public Collection<ServiceRef> getTargets() {
             return Collections.unmodifiableCollection(targets);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(matchExpression, targets);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            MatchedCredentials other = (MatchedCredentials) obj;
+            return Objects.equals(matchExpression, other.matchExpression)
+                    && Objects.equals(targets, other.targets);
         }
     }
 
@@ -270,6 +291,27 @@ public class CredentialsManager {
         Credentials getCredentials() {
             return this.credentials;
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(credentials, matchExpression);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StoredCredentials other = (StoredCredentials) obj;
+            return Objects.equals(credentials, other.credentials)
+                    && Objects.equals(matchExpression, other.matchExpression);
+        }
     }
 
     @Deprecated(since = "2.2", forRemoval = true)
@@ -288,6 +330,27 @@ public class CredentialsManager {
 
         Credentials getCredentials() {
             return this.credentials;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(credentials, targetId);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TargetSpecificStoredCredentials other = (TargetSpecificStoredCredentials) obj;
+            return Objects.equals(credentials, other.credentials)
+                    && Objects.equals(targetId, other.targetId);
         }
     }
 }

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -37,17 +37,22 @@
  */
 package io.cryostat.configuration;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import javax.script.ScriptException;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
@@ -55,13 +60,16 @@ import io.cryostat.core.sys.FileSystem;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.MatchExpressionEvaluator;
 
 import com.google.gson.Gson;
 import org.apache.commons.codec.binary.Base32;
+import org.apache.commons.lang3.StringUtils;
 
 public class CredentialsManager {
 
     private final Path credentialsDir;
+    private final MatchExpressionEvaluator matchExpressionEvaluator;
     private final FileSystem fs;
     private final PlatformClient platformClient;
     private final Gson gson;
@@ -72,6 +80,7 @@ public class CredentialsManager {
 
     CredentialsManager(
             Path credentialsDir,
+            MatchExpressionEvaluator matchExpressionEvaluator,
             FileSystem fs,
             PlatformClient platformClient,
             NotificationFactory notificationFactory,
@@ -79,12 +88,44 @@ public class CredentialsManager {
             Base32 base32,
             Logger logger) {
         this.credentialsDir = credentialsDir;
+        this.matchExpressionEvaluator = matchExpressionEvaluator;
         this.fs = fs;
         this.platformClient = platformClient;
         this.gson = gson;
         this.base32 = base32;
         this.logger = logger;
         this.credentialsMap = new HashMap<>();
+    }
+
+    public void migrate() throws Exception {
+        for (String file : this.fs.listDirectoryChildren(credentialsDir)) {
+            BufferedReader reader;
+            try {
+                Path path = credentialsDir.resolve(file);
+                reader = fs.readFile(path);
+                TargetSpecificStoredCredentials targetSpecificCredential =
+                        gson.fromJson(reader, TargetSpecificStoredCredentials.class);
+
+                String targetId = targetSpecificCredential.getTargetId();
+                if (StringUtils.isNotBlank(targetId)) {
+                    addCredentials(
+                            targetIdToMatchExpression(targetSpecificCredential.getTargetId()),
+                            targetSpecificCredential.getCredentials());
+                    fs.deleteIfExists(path);
+                    logger.info("Migrated {}", path);
+                }
+            } catch (IOException e) {
+                logger.warn(e);
+                continue;
+            }
+        }
+    }
+
+    public static String targetIdToMatchExpression(String targetId) {
+        if (StringUtils.isBlank(targetId)) {
+            return null;
+        }
+        return String.format("target.connectUrl == \"%s\"", targetId);
     }
 
     public void load() throws IOException {
@@ -102,16 +143,17 @@ public class CredentialsManager {
                         })
                 .filter(Objects::nonNull)
                 .map(reader -> gson.fromJson(reader, StoredCredentials.class))
-                .forEach(sc -> credentialsMap.put(sc.getTargetId(), sc.getCredentials()));
+                .forEach(sc -> credentialsMap.put(sc.getMatchExpression(), sc.getCredentials()));
     }
 
-    public boolean addCredentials(String targetId, Credentials credentials) throws IOException {
-        boolean replaced = credentialsMap.containsKey(targetId);
-        credentialsMap.put(targetId, credentials);
-        Path destination = getPersistedPath(targetId);
+    public boolean addCredentials(String matchExpression, Credentials credentials)
+            throws IOException {
+        boolean replaced = credentialsMap.containsKey(matchExpression);
+        credentialsMap.put(matchExpression, credentials);
+        Path destination = getPersistedPath(matchExpression);
         fs.writeString(
                 destination,
-                gson.toJson(new StoredCredentials(targetId, credentials)),
+                gson.toJson(new StoredCredentials(matchExpression, credentials)),
                 StandardOpenOption.WRITE,
                 StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING);
@@ -121,47 +163,129 @@ public class CredentialsManager {
         return replaced;
     }
 
-    public boolean removeCredentials(String targetId) throws IOException {
-        Credentials deleted = this.credentialsMap.remove(targetId);
-        fs.deleteIfExists(getPersistedPath(targetId));
+    public boolean removeCredentials(String matchExpression) throws IOException {
+        Credentials deleted = this.credentialsMap.remove(matchExpression);
+        fs.deleteIfExists(getPersistedPath(matchExpression));
         return deleted != null;
     }
 
     public Credentials getCredentials(String targetId) {
-        return this.credentialsMap.get(targetId);
+        for (ServiceRef service : this.platformClient.listDiscoverableServices()) {
+            if (Objects.equals(targetId, service.getServiceUri().toString())) {
+                return getCredentials(service);
+            }
+        }
+        return null;
     }
 
     public Credentials getCredentials(ServiceRef serviceRef) {
-        return getCredentials(serviceRef.getServiceUri().toString());
+        for (Map.Entry<String, Credentials> entry : credentialsMap.entrySet()) {
+            try {
+                if (matchExpressionEvaluator.applies(entry.getKey(), serviceRef)) {
+                    return entry.getValue();
+                }
+            } catch (ScriptException e) {
+                logger.error(e);
+                continue;
+            }
+        }
+        return null;
     }
 
-    public List<ServiceRef> getCredentialKeys() {
-        return this.platformClient.listDiscoverableServices().stream()
-                .filter(target -> credentialsMap.containsKey(target.getServiceUri().toString()))
-                .collect(Collectors.toList());
+    public Collection<ServiceRef> getServiceRefsWithCredentials() {
+        List<ServiceRef> result = new ArrayList<>();
+        for (ServiceRef service : this.platformClient.listDiscoverableServices()) {
+            Credentials credentials = getCredentials(service);
+            if (credentials != null) {
+                result.add(service);
+            }
+        }
+        return result;
     }
 
-    private Path getPersistedPath(String targetId) {
+    public Collection<String> getMatchExpressions() {
+        return credentialsMap.keySet();
+    }
+
+    public List<MatchedCredentials> getMatchExpressionsWithMatchedTargets() {
+        List<MatchedCredentials> result = new ArrayList<>();
+        List<ServiceRef> targets = platformClient.listDiscoverableServices();
+        for (String expr : getMatchExpressions()) {
+            Set<ServiceRef> matchedTargets = new HashSet<>();
+            MatchedCredentials match = new MatchedCredentials(expr, matchedTargets);
+            result.add(match);
+            for (ServiceRef target : targets) {
+                try {
+                    if (matchExpressionEvaluator.applies(expr, target)) {
+                        matchedTargets.add(target);
+                    }
+                } catch (ScriptException e) {
+                    logger.error(e);
+                    continue;
+                }
+            }
+        }
+        return result;
+    }
+
+    private Path getPersistedPath(String matchExpression) {
         return credentialsDir.resolve(
                 String.format(
                         "%s.json",
-                        base32.encodeAsString(targetId.getBytes(StandardCharsets.UTF_8))));
+                        base32.encodeAsString(matchExpression.getBytes(StandardCharsets.UTF_8))));
     }
 
-    public static class StoredCredentials {
+    public static class MatchedCredentials {
+        private final String matchExpression;
+        private final Collection<ServiceRef> targets;
+
+        private MatchedCredentials(String matchExpression, Collection<ServiceRef> targets) {
+            this.matchExpression = matchExpression;
+            this.targets = targets;
+        }
+
+        public String getMatchExpression() {
+            return matchExpression;
+        }
+
+        public Collection<ServiceRef> getTargets() {
+            return targets;
+        }
+    }
+
+    static class StoredCredentials {
+        private final String matchExpression;
+        private final Credentials credentials;
+
+        StoredCredentials(String matchExpression, Credentials credentials) {
+            this.matchExpression = matchExpression;
+            this.credentials = credentials;
+        }
+
+        String getMatchExpression() {
+            return this.matchExpression;
+        }
+
+        Credentials getCredentials() {
+            return this.credentials;
+        }
+    }
+
+    @Deprecated(since = "2.2", forRemoval = true)
+    static class TargetSpecificStoredCredentials {
         private final String targetId;
         private final Credentials credentials;
 
-        StoredCredentials(String targetId, Credentials credentials) {
+        TargetSpecificStoredCredentials(String targetId, Credentials credentials) {
             this.targetId = targetId;
             this.credentials = credentials;
         }
 
-        public String getTargetId() {
+        String getTargetId() {
             return this.targetId;
         }
 
-        public Credentials getCredentials() {
+        Credentials getCredentials() {
             return this.credentials;
         }
     }

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -121,7 +121,7 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
 
     protected ConnectionDescriptor getConnectionDescriptorFromContext(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
-        Credentials credentials = credentialsManager.getCredentials(targetId);
+        Credentials credentials = credentialsManager.getCredentialsByTargetId(targetId);
         if (ctx.request().headers().contains(JMX_AUTHORIZATION_HEADER)) {
             String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
             Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);

--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -37,12 +37,10 @@
  */
 package io.cryostat.net.web.http;
 
-import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.rmi.ConnectIOException;
 import java.util.Base64;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -170,35 +168,16 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
 
     private void handleConnectionException(RoutingContext ctx, ConnectionException e) {
         Throwable cause = e.getCause();
-        try {
-            if (cause instanceof SecurityException || cause instanceof SaslException) {
-                ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
-                throw new HttpException(427, "JMX Authentication Failure", e);
-            }
-            Throwable rootCause = ExceptionUtils.getRootCause(e);
-            if (rootCause instanceof ConnectIOException) {
-                throw new HttpException(502, "Target SSL Untrusted", e);
-            }
-            if (rootCause instanceof UnknownHostException) {
-                throw new HttpException(404, "Target Not Found", e);
-            }
-        } finally {
-            this.removeCredentialsIfPresent(ctx);
+        if (cause instanceof SecurityException || cause instanceof SaslException) {
+            ctx.response().putHeader(JMX_AUTHENTICATE_HEADER, "Basic");
+            throw new HttpException(427, "JMX Authentication Failure", e);
         }
-    }
-
-    private void removeCredentialsIfPresent(RoutingContext ctx) {
-        Optional<String> targetId = Optional.ofNullable(ctx.pathParam("targetId"));
-
-        targetId.ifPresent(
-                id -> {
-                    if (credentialsManager.getCredentials(id) != null) {
-                        try {
-                            credentialsManager.removeCredentials(id);
-                        } catch (IOException ioe) {
-                            logger.error(ioe);
-                        }
-                    }
-                });
+        Throwable rootCause = ExceptionUtils.getRootCause(e);
+        if (rootCause instanceof ConnectIOException) {
+            throw new HttpException(502, "Target SSL Untrusted", e);
+        }
+        if (rootCause instanceof UnknownHostException) {
+            throw new HttpException(404, "Target Not Found", e);
+        }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
@@ -213,4 +213,8 @@ public abstract class HttpApiV2Module {
     @Binds
     @IntoSet
     abstract RequestHandler bindTargetCredentialsGetHandler(TargetCredentialsGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindCredentialsGetHandler(CredentialsGetHandler handler);
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
@@ -114,7 +114,9 @@ class TargetCredentialsDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     @Override
     public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
-        String targetId = params.getPathParams().get("targetId");
+        String targetId =
+                CredentialsManager.targetIdToMatchExpression(
+                        params.getPathParams().get("targetId"));
         try {
             boolean status = this.credentialsManager.removeCredentials(targetId);
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandler.java
@@ -37,6 +37,7 @@
  */
 package io.cryostat.net.web.http.api.v2;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -104,6 +105,6 @@ class TargetCredentialsGetHandler extends AbstractV2RequestHandler<List<ServiceR
     public IntermediateResponse<List<ServiceRef>> handle(RequestParameters requestParams)
             throws Exception {
         return new IntermediateResponse<List<ServiceRef>>()
-                .body(this.credentialsManager.getCredentialKeys());
+                .body(new ArrayList<>(this.credentialsManager.getServiceRefsWithCredentials()));
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -176,10 +176,7 @@ public class RuleProcessor extends AbstractVerticle
                 "Activating rule {} for target {}", rule.getName(), serviceRef.getServiceUri());
 
         vertx.<Credentials>executeBlocking(
-                        promise ->
-                                promise.complete(
-                                        credentialsManager.getCredentials(
-                                                serviceRef.getServiceUri().toString())))
+                        promise -> promise.complete(credentialsManager.getCredentials(serviceRef)))
                 .onSuccess(c -> logger.trace("Rule activation successful"))
                 .onSuccess(
                         credentials -> {

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -60,15 +60,20 @@ import com.google.gson.Gson;
 public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
 
     private final Path rulesDir;
-    private final RuleMatcher ruleMatcher;
+    private final MatchExpressionEvaluator matchExpressionEvaluator;
     private final FileSystem fs;
     private final Set<Rule> rules;
     private final Gson gson;
     private final Logger logger;
 
-    RuleRegistry(Path rulesDir, RuleMatcher ruleMatcher, FileSystem fs, Gson gson, Logger logger) {
+    RuleRegistry(
+            Path rulesDir,
+            MatchExpressionEvaluator matchExpressionEvaluator,
+            FileSystem fs,
+            Gson gson,
+            Logger logger) {
         this.rulesDir = rulesDir;
-        this.ruleMatcher = ruleMatcher;
+        this.matchExpressionEvaluator = matchExpressionEvaluator;
         this.fs = fs;
         this.gson = gson;
         this.logger = logger;
@@ -124,7 +129,7 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
 
     public boolean applies(Rule rule, ServiceRef serviceRef) {
         try {
-            return ruleMatcher.applies(rule, serviceRef);
+            return matchExpressionEvaluator.applies(rule.getMatchExpression(), serviceRef);
         } catch (ScriptException se) {
             logger.error(se);
             try {

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.script.ScriptEngine;
 
 import io.cryostat.configuration.ConfigurationModule;
 import io.cryostat.configuration.CredentialsManager;
@@ -81,7 +82,7 @@ public abstract class RulesModule {
     @Singleton
     static RuleRegistry provideRuleRegistry(
             @Named(ConfigurationModule.CONFIGURATION_PATH) Path confDir,
-            RuleMatcher ruleMatcher,
+            MatchExpressionEvaluator matchExpressionEvaluator,
             FileSystem fs,
             Gson gson,
             Logger logger) {
@@ -90,7 +91,7 @@ public abstract class RulesModule {
             if (!fs.isDirectory(rulesDir)) {
                 Files.createDirectory(rulesDir);
             }
-            return new RuleRegistry(rulesDir, ruleMatcher, fs, gson, logger);
+            return new RuleRegistry(rulesDir, matchExpressionEvaluator, fs, gson, logger);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -98,8 +99,8 @@ public abstract class RulesModule {
 
     @Provides
     @Singleton
-    static RuleMatcher provideRuleMatcher() {
-        return new RuleMatcher();
+    static MatchExpressionEvaluator provideMatchExpressionEvaluator(ScriptEngine scriptEngine) {
+        return new MatchExpressionEvaluator(scriptEngine);
     }
 
     @Provides

--- a/src/test/java/io/cryostat/configuration/CredentialsManagerTest.java
+++ b/src/test/java/io/cryostat/configuration/CredentialsManagerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.configuration;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.sys.FileSystem;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.rules.MatchExpressionEvaluator;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.commons.codec.binary.Base32;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsManagerTest {
+
+    CredentialsManager credentialsManager;
+    @Mock Path credentialsDir;
+    @Mock MatchExpressionEvaluator matchExpressionEvaluator;
+    @Mock FileSystem fs;
+    @Mock PlatformClient platformClient;
+    @Mock NotificationFactory notificationFactory;
+    @Mock Logger logger;
+    Base32 base32 = new Base32();
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.credentialsManager =
+                new CredentialsManager(
+                        credentialsDir,
+                        matchExpressionEvaluator,
+                        fs,
+                        platformClient,
+                        notificationFactory,
+                        gson,
+                        base32,
+                        logger);
+    }
+
+    @Nested
+    class Migration {
+
+        @Test
+        void doesNothingIfNoFiles() throws Exception {
+            Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(List.of());
+
+            Mockito.verifyNoInteractions(fs);
+
+            credentialsManager.migrate();
+
+            Mockito.verify(fs).listDirectoryChildren(credentialsDir);
+            Mockito.verifyNoMoreInteractions(fs);
+        }
+
+        @Test
+        void doesNothingIfAllFilesInNewFormat() throws Exception {
+            String matchExpression = "target.connectUrl == \"foo\"";
+            String filename =
+                    String.format(
+                            "%s.json",
+                            base32.encodeToString(
+                                    matchExpression.getBytes(StandardCharsets.UTF_8)));
+            Mockito.when(fs.listDirectoryChildren(Mockito.any())).thenReturn(List.of(filename));
+
+            Path path = Mockito.mock(Path.class);
+            Mockito.when(credentialsDir.resolve(filename)).thenReturn(path);
+
+            String contents =
+                    gson.toJson(
+                            Map.of(
+                                    "matchExpression",
+                                    matchExpression,
+                                    "credentials",
+                                    Map.of("username", "user", "password", "pass")));
+            Mockito.when(fs.readFile(path))
+                    .thenReturn(new BufferedReader(new StringReader(contents)));
+
+            credentialsManager.migrate();
+
+            InOrder inOrder = Mockito.inOrder(fs, credentialsDir);
+            inOrder.verify(fs).listDirectoryChildren(credentialsDir);
+            inOrder.verify(credentialsDir).resolve(filename);
+            inOrder.verify(fs).readFile(path);
+            Mockito.verifyNoMoreInteractions(fs);
+        }
+
+        @Test
+        void migratesOldFormatToNewFormat() throws Exception {
+            String targetId = "foo";
+            String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
+
+            String originalFilename =
+                    String.format(
+                            "%s.json",
+                            base32.encodeToString(targetId.getBytes(StandardCharsets.UTF_8)));
+            Mockito.when(fs.listDirectoryChildren(Mockito.any()))
+                    .thenReturn(List.of(originalFilename));
+
+            String newFilename =
+                    String.format(
+                            "%s.json",
+                            base32.encodeToString(
+                                    matchExpression.getBytes(StandardCharsets.UTF_8)));
+
+            Path originalPath = Mockito.mock(Path.class);
+            Path newPath = Mockito.mock(Path.class);
+            Mockito.when(credentialsDir.resolve(originalFilename)).thenReturn(originalPath);
+            Mockito.when(credentialsDir.resolve(newFilename)).thenReturn(newPath);
+
+            String username = "user";
+            String password = "pass";
+
+            String oldContents =
+                    gson.toJson(
+                            Map.of(
+                                    "targetId",
+                                    targetId,
+                                    "credentials",
+                                    Map.of("username", username, "password", password)));
+            Mockito.when(fs.readFile(originalPath))
+                    .thenReturn(new BufferedReader(new StringReader(oldContents)));
+
+            credentialsManager.migrate();
+
+            ArgumentCaptor<String> contentsCaptor = ArgumentCaptor.forClass(String.class);
+
+            Mockito.verify(fs).listDirectoryChildren(credentialsDir);
+            Mockito.verify(credentialsDir).resolve(originalFilename);
+            Mockito.verify(fs).readFile(originalPath);
+            Mockito.verify(fs)
+                    .writeString(
+                            Mockito.eq(newPath),
+                            contentsCaptor.capture(),
+                            Mockito.eq(StandardOpenOption.WRITE),
+                            Mockito.eq(StandardOpenOption.CREATE),
+                            Mockito.eq(StandardOpenOption.TRUNCATE_EXISTING));
+            Mockito.verify(fs)
+                    .setPosixFilePermissions(
+                            newPath,
+                            Set.of(
+                                    PosixFilePermission.OWNER_READ,
+                                    PosixFilePermission.OWNER_WRITE));
+            Mockito.verify(fs).deleteIfExists(originalPath);
+            Mockito.verifyNoMoreInteractions(fs);
+
+            String newContents = contentsCaptor.getValue();
+            JsonObject json = gson.fromJson(newContents, JsonObject.class);
+            MatcherAssert.assertThat(
+                    json.getAsJsonPrimitive("matchExpression").getAsString(),
+                    Matchers.equalTo(matchExpression));
+            JsonObject credentials = json.getAsJsonObject("credentials");
+            String foundUsername = credentials.getAsJsonPrimitive("username").getAsString();
+            String foundPassword = credentials.getAsJsonPrimitive("password").getAsString();
+            MatcherAssert.assertThat(foundUsername, Matchers.equalTo(username));
+            MatcherAssert.assertThat(foundPassword, Matchers.equalTo(password));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandlerTest.java
@@ -152,6 +152,7 @@ class TargetCredentialsDeleteHandlerTest {
         @Test
         void shouldRespond200OnSuccess() throws Exception {
             String targetId = "fooTarget";
+            String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
             Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
                     .thenReturn(true);
@@ -159,12 +160,12 @@ class TargetCredentialsDeleteHandlerTest {
             IntermediateResponse<Void> response = handler.handle(requestParams);
 
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
-            Mockito.verify(credentialsManager).removeCredentials(targetId);
+            Mockito.verify(credentialsManager).removeCredentials(matchExpression);
 
             Mockito.verify(notificationFactory).createBuilder();
             Mockito.verify(notificationBuilder).metaCategory("TargetCredentialsDeleted");
             Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-            Mockito.verify(notificationBuilder).message(Map.of("target", targetId));
+            Mockito.verify(notificationBuilder).message(Map.of("target", matchExpression));
             Mockito.verify(notificationBuilder).build();
             Mockito.verify(notification).send();
         }
@@ -172,6 +173,7 @@ class TargetCredentialsDeleteHandlerTest {
         @Test
         void shouldRespond404OnFailure() throws Exception {
             String targetId = "fooTarget";
+            String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
             Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
                     .thenReturn(false);
@@ -179,12 +181,13 @@ class TargetCredentialsDeleteHandlerTest {
             IntermediateResponse<Void> response = handler.handle(requestParams);
 
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(404));
-            Mockito.verify(credentialsManager).removeCredentials(targetId);
+            Mockito.verify(credentialsManager).removeCredentials(matchExpression);
         }
 
         @Test
         void shouldWrapIOExceptions() throws Exception {
             String targetId = "fooTarget";
+            String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
             Mockito.when(credentialsManager.removeCredentials(Mockito.anyString()))
                     .thenThrow(IOException.class);
@@ -195,7 +198,7 @@ class TargetCredentialsDeleteHandlerTest {
 
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(500));
             MatcherAssert.assertThat(ex.getCause(), Matchers.instanceOf(IOException.class));
-            Mockito.verify(credentialsManager).removeCredentials(targetId);
+            Mockito.verify(credentialsManager).removeCredentials(matchExpression);
         }
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandlerTest.java
@@ -143,7 +143,7 @@ class TargetCredentialsGetHandlerTest {
 
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
             MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(new ArrayList<>()));
-            Mockito.verify(credentialsManager).getCredentialKeys();
+            Mockito.verify(credentialsManager).getServiceRefsWithCredentials();
         }
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandlerTest.java
@@ -230,6 +230,7 @@ class TargetCredentialsPostHandlerTest {
         @Test
         void shouldDelegateToCredentialsManager() throws Exception {
             String targetId = "fooTarget";
+            String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
             String username = "adminuser";
             String password = "abc123";
             Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
@@ -243,12 +244,12 @@ class TargetCredentialsPostHandlerTest {
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
             MatcherAssert.assertThat(response.getBody(), Matchers.nullValue());
             Mockito.verify(credentialsManager)
-                    .addCredentials(targetId, new Credentials(username, password));
+                    .addCredentials(matchExpression, new Credentials(username, password));
 
             Mockito.verify(notificationFactory).createBuilder();
             Mockito.verify(notificationBuilder).metaCategory("TargetCredentialsStored");
             Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
-            Mockito.verify(notificationBuilder).message(Map.of("target", targetId));
+            Mockito.verify(notificationBuilder).message(Map.of("target", matchExpression));
             Mockito.verify(notificationBuilder).build();
             Mockito.verify(notification).send();
         }

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -168,7 +168,7 @@ class RuleProcessorTest {
         ServiceRef serviceRef = new ServiceRef(new URI(jmxUrl), "com.example.App");
 
         Credentials credentials = new Credentials("foouser", "barpassword");
-        Mockito.when(credentialsManager.getCredentials(jmxUrl)).thenReturn(credentials);
+        Mockito.when(credentialsManager.getCredentials(serviceRef)).thenReturn(credentials);
 
         TargetDiscoveryEvent tde = new TargetDiscoveryEvent(EventKind.FOUND, serviceRef);
 
@@ -268,7 +268,7 @@ class RuleProcessorTest {
         ServiceRef serviceRef = new ServiceRef(new URI(jmxUrl), "com.example.App");
 
         Credentials credentials = new Credentials("foouser", "barpassword");
-        Mockito.when(credentialsManager.getCredentials(jmxUrl)).thenReturn(credentials);
+        Mockito.when(credentialsManager.getCredentials(serviceRef)).thenReturn(credentials);
 
         TargetDiscoveryEvent tde = new TargetDiscoveryEvent(EventKind.FOUND, serviceRef);
 
@@ -316,7 +316,7 @@ class RuleProcessorTest {
         ServiceRef serviceRef = new ServiceRef(new URI(jmxUrl), "com.example.App");
 
         Credentials credentials = new Credentials("foouser", "barpassword");
-        Mockito.when(credentialsManager.getCredentials(jmxUrl)).thenReturn(credentials);
+        Mockito.when(credentialsManager.getCredentials(serviceRef)).thenReturn(credentials);
 
         TargetDiscoveryEvent tde = new TargetDiscoveryEvent(EventKind.FOUND, serviceRef);
 

--- a/src/test/java/io/cryostat/rules/RuleRegistryTest.java
+++ b/src/test/java/io/cryostat/rules/RuleRegistryTest.java
@@ -73,7 +73,7 @@ class RuleRegistryTest {
 
     RuleRegistry registry;
     @Mock Path rulesDir;
-    @Mock RuleMatcher ruleMatcher;
+    @Mock MatchExpressionEvaluator matchExpressionEvaluator;
     @Mock FileSystem fs;
     @Mock Logger logger;
     Gson gson = Mockito.spy(MainModule.provideGson(logger));
@@ -84,7 +84,7 @@ class RuleRegistryTest {
 
     @BeforeEach
     void setup() throws Exception {
-        this.registry = new RuleRegistry(rulesDir, ruleMatcher, fs, gson, logger);
+        this.registry = new RuleRegistry(rulesDir, matchExpressionEvaluator, fs, gson, logger);
         this.testRule =
                 new Rule.Builder()
                         .name("test rule")
@@ -240,7 +240,8 @@ class RuleRegistryTest {
         Mockito.when(fs.listDirectoryChildren(rulesDir)).thenReturn(List.of("test_rule.json"));
         Mockito.when(fs.readFile(rulePath)).thenReturn(fileReader);
 
-        Mockito.when(ruleMatcher.applies(Mockito.any(), Mockito.any())).thenReturn(true);
+        Mockito.when(matchExpressionEvaluator.applies(Mockito.any(), Mockito.any()))
+                .thenReturn(true);
 
         registry.addRule(testRule);
 

--- a/src/test/java/itest/CredentialsIT.java
+++ b/src/test/java/itest/CredentialsIT.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import io.cryostat.MainModule;
 import io.cryostat.core.log.Logger;
@@ -55,7 +54,6 @@ import io.cryostat.platform.ServiceRef.AnnotationKey;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.HttpException;
 import itest.bases.ExternalTargetsTest;
@@ -222,80 +220,6 @@ public class CredentialsIT extends ExternalTargetsTest {
         MatcherAssert.assertThat(
                 ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Bad Request"));
-    }
-
-    @Test
-    void testInvalidCredentialsRemovedOnConnectionFailure() throws Exception {
-        CONTAINERS.add(
-                Podman.run(
-                        new Podman.ImageSpec(
-                                "quay.io/andrewazores/vertx-fib-demo:0.6.0",
-                                Map.of("JMX_PORT", "9094", "USE_AUTH", "true"))));
-        CompletableFuture.allOf(
-                        CONTAINERS.stream()
-                                .map(id -> Podman.waitForContainerState(id, "running"))
-                                .collect(Collectors.toList())
-                                .toArray(new CompletableFuture[0]))
-                .join();
-        Thread.sleep(10_000L); // wait for JDP to discover new container(s)
-
-        // Post invalid credentials for the new pod
-        CompletableFuture<JsonObject> postResponse = new CompletableFuture<>();
-        MultiMap form = MultiMap.caseInsensitiveMultiMap();
-        form.add("username", "admin");
-        form.add("password", "invalidPassword");
-        webClient
-                .post(String.format("/api/v2/targets/%s/credentials", Podman.POD_NAME + ":9094"))
-                .sendForm(
-                        form,
-                        ar -> {
-                            if (assertRequestStatus(ar, postResponse)) {
-                                postResponse.complete(ar.result().bodyAsJsonObject());
-                            }
-                        });
-        JsonObject expectedResponse =
-                new JsonObject(
-                        Map.of(
-                                "meta",
-                                Map.of("type", HttpMimeType.PLAINTEXT.mime(), "status", "OK"),
-                                "data",
-                                NULL_RESULT));
-        MatcherAssert.assertThat(
-                postResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-                Matchers.equalTo(expectedResponse));
-
-        // Use the invalid stored credentials to GET recordings
-        CompletableFuture<JsonArray> response = new CompletableFuture<>();
-        webClient
-                .get(String.format("/api/v1/targets/%s/recordings", Podman.POD_NAME + ":9094"))
-                .send(
-                        ar -> {
-                            if (assertRequestStatus(ar, response)) {
-                                response.complete(ar.result().bodyAsJsonArray());
-                            }
-                        });
-        ExecutionException ee =
-                Assertions.assertThrows(
-                        ExecutionException.class,
-                        () -> response.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        MatcherAssert.assertThat(
-                ((HttpException) ee.getCause()).getStatusCode(), Matchers.equalTo(427));
-
-        // Confirm invalid credentials automatically deleted by attempting to delete them
-        CompletableFuture<JsonObject> deleteResponse = new CompletableFuture<>();
-        webClient
-                .delete(String.format("/api/v2/targets/%s/credentials", Podman.POD_NAME + ":9094"))
-                .send(
-                        ar -> {
-                            assertRequestStatus(ar, deleteResponse);
-                        });
-        ExecutionException ex =
-                Assertions.assertThrows(
-                        ExecutionException.class,
-                        () -> deleteResponse.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        MatcherAssert.assertThat(
-                ((HttpException) ex.getCause()).getStatusCode(), Matchers.equalTo(404));
-        MatcherAssert.assertThat(ex.getCause().getMessage(), Matchers.equalTo("Not Found"));
     }
 
     @Test


### PR DESCRIPTION
Related to #895
Depends on https://github.com/cryostatio/cryostat-web/pull/475

This PR enhances the existing CredentialsManager by replacing the `targetId` field of stored credentials with a `matchExpression`. This uses the same expression evaluation internal infrastructure already in place for Automated Rules, so the syntax and behaviour is exactly the same. There is a migration function that checks all stored credentials already on disk and checks if they have the `targetId` field. If they do not then they are skipped over, since they are either invalid files or conform to the new format already.

```json
{
  "targetId": "foo",
  "credentials": {
    "username": "user",
    "password": "pass"
  }
}
```

is migrated by applying a simple transformation to:

```json
{
  "matchExpression": "target.connectUrl == \"foo\"",
  "credentials": {
    "username": "user",
    "password": "pass"
  }
}
```

This allows the new expression-based system to migrate existing credentials while maintaining the same semantics, and also allows the old credentials API endpoints to continue working with the same behaviour.

Still TODO in follow-up PRs:
1. Add new API endpoints to allow clients to define and delete credentials with generalized `matchExpression`, not only the backward-compatible `target.connectUrl == "foo"` style
2. ~~Use the new `CredentialsGetHandler` on the frontend to enhance the Security view to better reflect these expression-based credentials~~ https://github.com/cryostatio/cryostat-web/issues/465

Since it is now possible for one set of credentials to match multiple targets, the `AbstractAuthenticatedRequestHandler` no longer deletes credentials if they are used for a JMX connection and the connection fails - since the credentials may apply to multiple targets, they may be valid for other targets than the one that was just checked.

It is also possible that one target may be matched by multiple sets of credentials. There is no protection against this case, so it would simply be considered a user configuration error. If this occurs then the `credentialsManager` will simply provide the "first" matching set of credentials for a given target when requested. The ordering of credentials is intentionally undefined at this time. Multiple credentials for a given target is not an expected valid configuration and so no scheme of trying each of them in order is attempted, or any other more complex behaviours.