### PR TITLE
ci(submodule): use fetch-depth 0 to fetch all refs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
     - uses: actions/setup-java@v2
       with:
         java-version: '17'


### PR DESCRIPTION
Using `fetch-depth: 0` checks out history for all branches and tags: https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches

Related to: #1007 