### PR TITLE
feat(graphql): granular permissions

### DIFF
--- a/src/main/java/io/cryostat/net/security/PermissionedAction.java
+++ b/src/main/java/io/cryostat/net/security/PermissionedAction.java
@@ -35,49 +35,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.web.http;
+package io.cryostat.net.security;
 
-import io.cryostat.net.security.PermissionedAction;
-import io.cryostat.net.web.http.api.ApiVersion;
+import java.util.Set;
 
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
-
-public interface RequestHandler extends Handler<RoutingContext>, PermissionedAction {
-    /** Lower number == higher priority handler */
-    static final int DEFAULT_PRIORITY = 100;
-
-    static final String ALL_PATHS = "*";
-
-    default int getPriority() {
-        return DEFAULT_PRIORITY;
-    }
-
-    ApiVersion apiVersion();
-
-    default String basePath() {
-        switch (apiVersion()) {
-            case GENERIC:
-                return "/";
-            default:
-                return "/api/" + apiVersion().getVersionString() + "/";
-        }
-    }
-
-    String path();
-
-    HttpMethod httpMethod();
-
-    default boolean isAvailable() {
-        return true;
-    }
-
-    default boolean isAsync() {
-        return true;
-    }
-
-    default boolean isOrdered() {
-        return true;
-    }
+public interface PermissionedAction {
+    Set<ResourceAction> resourceActions();
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/AbstractPermissionedDataFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/AbstractPermissionedDataFetcher.java
@@ -37,12 +37,13 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
-import graphql.GraphQLContext;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.AuthorizationErrorException;
 import io.cryostat.net.security.PermissionedAction;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
@@ -58,8 +59,11 @@ abstract class AbstractPermissionedDataFetcher<T> implements DataFetcher<T>, Per
     public final T get(DataFetchingEnvironment environment) throws Exception {
         GraphQLContext graphCtx = environment.getGraphQlContext();
         RoutingContext ctx = graphCtx.get(RoutingContext.class);
-        boolean authenticated = auth.validateHttpHeader(
-                () -> ctx.request().getHeader(HttpHeaders.AUTHORIZATION), resourceActions()).get();
+        boolean authenticated =
+                auth.validateHttpHeader(
+                                () -> ctx.request().getHeader(HttpHeaders.AUTHORIZATION),
+                                resourceActions())
+                        .get();
         if (!authenticated) {
             throw new AuthorizationErrorException("Unauthorized");
         }
@@ -67,5 +71,4 @@ abstract class AbstractPermissionedDataFetcher<T> implements DataFetcher<T>, Per
     }
 
     abstract T getAuthenticated(DataFetchingEnvironment environment) throws Exception;
-
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
@@ -38,22 +38,34 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class ActiveRecordingsFetcher implements DataFetcher<List<GraphRecordingDescriptor>> {
+class ActiveRecordingsFetcher
+        implements DataFetcher<List<GraphRecordingDescriptor>>, PermissionedAction {
 
     @Inject
     ActiveRecordingsFetcher() {}
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(ResourceAction.READ_RECORDING, ResourceAction.READ_TARGET);
+        return actions;
+    }
 
     public List<GraphRecordingDescriptor> get(DataFetchingEnvironment environment)
             throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
@@ -46,13 +46,15 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 
-class ActiveRecordingsFetcher extends AbstractPermissionedDataFetcher<List<GraphRecordingDescriptor>> {
+import graphql.schema.DataFetchingEnvironment;
+
+class ActiveRecordingsFetcher
+        extends AbstractPermissionedDataFetcher<List<GraphRecordingDescriptor>> {
 
     @Inject
     ActiveRecordingsFetcher(AuthManager auth) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
@@ -63,9 +63,7 @@ class ActiveRecordingsFetcher
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(ResourceAction.READ_RECORDING, ResourceAction.READ_TARGET);
-        return actions;
+        return EnumSet.of(ResourceAction.READ_RECORDING, ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
@@ -46,19 +46,18 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class ActiveRecordingsFetcher
-        implements DataFetcher<List<GraphRecordingDescriptor>>, PermissionedAction {
+class ActiveRecordingsFetcher extends AbstractPermissionedDataFetcher<List<GraphRecordingDescriptor>> {
 
     @Inject
-    ActiveRecordingsFetcher() {}
+    ActiveRecordingsFetcher(AuthManager auth) {
+        super(auth);
+    }
 
     @Override
     public Set<ResourceAction> resourceActions() {
@@ -67,7 +66,8 @@ class ActiveRecordingsFetcher
         return actions;
     }
 
-    public List<GraphRecordingDescriptor> get(DataFetchingEnvironment environment)
+    @Override
+    public List<GraphRecordingDescriptor> getAuthenticated(DataFetchingEnvironment environment)
             throws Exception {
         Recordings source = environment.getSource();
         List<GraphRecordingDescriptor> result = new ArrayList<>(source.active);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
@@ -42,25 +42,24 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.security.PermissionedAction;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class ArchiveRecordingMutator implements DataFetcher<ArchivedRecordingInfo>, PermissionedAction {
+class ArchiveRecordingMutator extends AbstractPermissionedDataFetcher<ArchivedRecordingInfo> {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
     private final CredentialsManager credentialsManager;
 
     @Inject
     ArchiveRecordingMutator(
-            RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
+            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
+        super(auth);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.credentialsManager = credentialsManager;
     }
@@ -77,7 +76,7 @@ class ArchiveRecordingMutator implements DataFetcher<ArchivedRecordingInfo>, Per
     }
 
     @Override
-    public ArchivedRecordingInfo get(DataFetchingEnvironment environment) throws Exception {
+    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         GraphRecordingDescriptor source = environment.getSource();
         ServiceRef target = source.target;
         String uri = target.getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
@@ -69,13 +69,11 @@ class ArchiveRecordingMutator extends AbstractPermissionedDataFetcher<ArchivedRe
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.CREATE_RECORDING,
-                        ResourceAction.READ_RECORDING,
-                        ResourceAction.READ_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.READ_TARGET,
+                ResourceAction.CREATE_RECORDING,
+                ResourceAction.READ_RECORDING,
+                ResourceAction.READ_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
@@ -42,7 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -51,6 +50,8 @@ import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
+import graphql.schema.DataFetchingEnvironment;
+
 class ArchiveRecordingMutator extends AbstractPermissionedDataFetcher<ArchivedRecordingInfo> {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
@@ -58,7 +59,9 @@ class ArchiveRecordingMutator extends AbstractPermissionedDataFetcher<ArchivedRe
 
     @Inject
     ArchiveRecordingMutator(
-            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
+            AuthManager auth,
+            RecordingArchiveHelper recordingArchiveHelper,
+            CredentialsManager credentialsManager) {
         super(auth);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.credentialsManager = credentialsManager;
@@ -76,7 +79,8 @@ class ArchiveRecordingMutator extends AbstractPermissionedDataFetcher<ArchivedRe
     }
 
     @Override
-    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         GraphRecordingDescriptor source = environment.getSource();
         ServiceRef target = source.target;
         String uri = target.getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchiveRecordingMutator.java
@@ -37,10 +37,15 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
@@ -48,7 +53,7 @@ import io.cryostat.rules.ArchivedRecordingInfo;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class ArchiveRecordingMutator implements DataFetcher<ArchivedRecordingInfo> {
+class ArchiveRecordingMutator implements DataFetcher<ArchivedRecordingInfo>, PermissionedAction {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
     private final CredentialsManager credentialsManager;
@@ -58,6 +63,17 @@ class ArchiveRecordingMutator implements DataFetcher<ArchivedRecordingInfo> {
             RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.credentialsManager = credentialsManager;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.CREATE_RECORDING,
+                        ResourceAction.READ_RECORDING,
+                        ResourceAction.READ_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -38,12 +38,16 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.ArchivedRecordingsFetcher.Archived;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
@@ -58,10 +62,16 @@ import graphql.schema.DataFetchingEnvironment;
         justification =
                 "The Archived and AggregateInfo fields are serialized and returned to the client by"
                         + " the GraphQL engine")
-class ArchivedRecordingsFetcher implements DataFetcher<Archived> {
+class ArchivedRecordingsFetcher implements DataFetcher<Archived>, PermissionedAction {
 
     @Inject
     ArchivedRecordingsFetcher() {}
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_RECORDING);
+        return actions;
+    }
 
     public Archived get(DataFetchingEnvironment environment) throws Exception {
         Recordings source = environment.getSource();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -46,7 +46,8 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.ArchivedRecordingsFetcher.Archived;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
@@ -62,10 +63,12 @@ import graphql.schema.DataFetchingEnvironment;
         justification =
                 "The Archived and AggregateInfo fields are serialized and returned to the client by"
                         + " the GraphQL engine")
-class ArchivedRecordingsFetcher implements DataFetcher<Archived>, PermissionedAction {
+class ArchivedRecordingsFetcher extends AbstractPermissionedDataFetcher<Archived> {
 
     @Inject
-    ArchivedRecordingsFetcher() {}
+    ArchivedRecordingsFetcher(AuthManager auth) {
+        super(auth);
+    }
 
     @Override
     public Set<ResourceAction> resourceActions() {
@@ -73,7 +76,7 @@ class ArchivedRecordingsFetcher implements DataFetcher<Archived>, PermissionedAc
         return actions;
     }
 
-    public Archived get(DataFetchingEnvironment environment) throws Exception {
+    public Archived getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         Recordings source = environment.getSource();
         FilterInput filter = FilterInput.from(environment);
         List<ArchivedRecordingInfo> recordings = new ArrayList<>(source.archived);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -61,8 +61,7 @@ import graphql.schema.DataFetchingEnvironment;
         justification =
                 "The Archived and AggregateInfo fields are serialized and returned to the client by"
                         + " the GraphQL engine")
-class ArchivedRecordingsFetcher
-        extends AbstractPermissionedDataFetcher<Archived> {
+class ArchivedRecordingsFetcher extends AbstractPermissionedDataFetcher<Archived> {
 
     @Inject
     ArchivedRecordingsFetcher(AuthManager auth) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.ArchivedRecordingsFetcher.Archived;
@@ -55,7 +54,6 @@ import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
 @SuppressFBWarnings(
@@ -63,7 +61,8 @@ import graphql.schema.DataFetchingEnvironment;
         justification =
                 "The Archived and AggregateInfo fields are serialized and returned to the client by"
                         + " the GraphQL engine")
-class ArchivedRecordingsFetcher extends AbstractPermissionedDataFetcher<Archived> {
+class ArchivedRecordingsFetcher
+        extends AbstractPermissionedDataFetcher<Archived> {
 
     @Inject
     ArchivedRecordingsFetcher(AuthManager auth) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -71,8 +71,7 @@ class ArchivedRecordingsFetcher
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_RECORDING);
-        return actions;
+        return EnumSet.of(ResourceAction.READ_RECORDING);
     }
 
     public Archived getAuthenticated(DataFetchingEnvironment environment) throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
@@ -37,17 +37,23 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingTargetHelper;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class DeleteActiveRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
+class DeleteActiveRecordingMutator
+        implements DataFetcher<GraphRecordingDescriptor>, PermissionedAction {
 
     private final RecordingTargetHelper recordingTargetHelper;
     private final CredentialsManager credentialsManager;
@@ -57,6 +63,17 @@ class DeleteActiveRecordingMutator implements DataFetcher<GraphRecordingDescript
             RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.DELETE_RECORDING,
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.UPDATE_TARGET,
+                        ResourceAction.DELETE_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
@@ -69,13 +69,11 @@ class DeleteActiveRecordingMutator
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.DELETE_RECORDING,
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.UPDATE_TARGET,
-                        ResourceAction.DELETE_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.DELETE_RECORDING,
+                ResourceAction.READ_TARGET,
+                ResourceAction.UPDATE_TARGET,
+                ResourceAction.DELETE_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteActiveRecordingMutator.java
@@ -42,7 +42,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -50,15 +49,19 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingTargetHelper;
 
+import graphql.schema.DataFetchingEnvironment;
+
 class DeleteActiveRecordingMutator
-    extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
+        extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
 
     private final RecordingTargetHelper recordingTargetHelper;
     private final CredentialsManager credentialsManager;
 
     @Inject
     DeleteActiveRecordingMutator(
-            AuthManager auth, RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+            AuthManager auth,
+            RecordingTargetHelper recordingTargetHelper,
+            CredentialsManager credentialsManager) {
         super(auth);
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
@@ -76,7 +79,8 @@ class DeleteActiveRecordingMutator
     }
 
     @Override
-    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         GraphRecordingDescriptor source = environment.getSource();
         ServiceRef target = source.target;
         String uri = target.getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
@@ -37,21 +37,33 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class DeleteArchivedRecordingMutator implements DataFetcher<ArchivedRecordingInfo> {
+class DeleteArchivedRecordingMutator
+        implements DataFetcher<ArchivedRecordingInfo>, PermissionedAction {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
     DeleteArchivedRecordingMutator(RecordingArchiveHelper recordingArchiveHelper) {
         this.recordingArchiveHelper = recordingArchiveHelper;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.DELETE_RECORDING);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
@@ -42,19 +42,21 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
+import graphql.schema.DataFetchingEnvironment;
+
 class DeleteArchivedRecordingMutator
-    extends AbstractPermissionedDataFetcher<ArchivedRecordingInfo> {
+        extends AbstractPermissionedDataFetcher<ArchivedRecordingInfo> {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
-    DeleteArchivedRecordingMutator(AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
+    DeleteArchivedRecordingMutator(
+            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
         super(auth);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
@@ -66,7 +68,8 @@ class DeleteArchivedRecordingMutator
     }
 
     @Override
-    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         ArchivedRecordingInfo source = environment.getSource();
         return recordingArchiveHelper.deleteRecording(source.getName()).get();
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
@@ -63,8 +63,7 @@ class DeleteArchivedRecordingMutator
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.DELETE_RECORDING);
-        return actions;
+        return EnumSet.of(ResourceAction.DELETE_RECORDING);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/DeleteArchivedRecordingMutator.java
@@ -42,21 +42,20 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.rules.ArchivedRecordingInfo;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
 class DeleteArchivedRecordingMutator
-        implements DataFetcher<ArchivedRecordingInfo>, PermissionedAction {
+    extends AbstractPermissionedDataFetcher<ArchivedRecordingInfo> {
 
     private final RecordingArchiveHelper recordingArchiveHelper;
 
     @Inject
-    DeleteArchivedRecordingMutator(RecordingArchiveHelper recordingArchiveHelper) {
+    DeleteArchivedRecordingMutator(AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 
@@ -67,7 +66,7 @@ class DeleteArchivedRecordingMutator
     }
 
     @Override
-    public ArchivedRecordingInfo get(DataFetchingEnvironment environment) throws Exception {
+    public ArchivedRecordingInfo getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         ArchivedRecordingInfo source = environment.getSource();
         return recordingArchiveHelper.deleteRecording(source.getName()).get();
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
@@ -42,16 +42,20 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import io.cryostat.net.security.PermissionedAction;
+import javax.inject.Inject;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
+class EnvironmentNodeChildrenFetcher extends AbstractPermissionedDataFetcher<List<AbstractNode>> {
 
-class EnvironmentNodeChildrenFetcher
-        implements DataFetcher<List<AbstractNode>>, PermissionedAction {
+    @Inject
+    EnvironmentNodeChildrenFetcher(AuthManager auth) {
+        super(auth);
+    }
 
     @Override
     public Set<ResourceAction> resourceActions() {
@@ -60,7 +64,7 @@ class EnvironmentNodeChildrenFetcher
     }
 
     @Override
-    public List<AbstractNode> get(DataFetchingEnvironment environment) throws Exception {
+    public List<AbstractNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         EnvironmentNode node = environment.getSource();
         return new ArrayList<>(node.getChildren());
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
@@ -60,8 +60,7 @@ class EnvironmentNodeChildrenFetcher extends AbstractPermissionedDataFetcher<Lis
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
@@ -38,15 +38,26 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class EnvironmentNodeChildrenFetcher implements DataFetcher<List<AbstractNode>> {
+class EnvironmentNodeChildrenFetcher
+        implements DataFetcher<List<AbstractNode>>, PermissionedAction {
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        return actions;
+    }
 
     @Override
     public List<AbstractNode> get(DataFetchingEnvironment environment) throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeChildrenFetcher.java
@@ -44,11 +44,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class EnvironmentNodeChildrenFetcher extends AbstractPermissionedDataFetcher<List<AbstractNode>> {
 
@@ -64,7 +65,8 @@ class EnvironmentNodeChildrenFetcher extends AbstractPermissionedDataFetcher<Lis
     }
 
     @Override
-    public List<AbstractNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public List<AbstractNode> getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         EnvironmentNode node = environment.getSource();
         return new ArrayList<>(node.getChildren());
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
@@ -62,8 +62,7 @@ class EnvironmentNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
@@ -42,18 +42,22 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import io.cryostat.net.security.PermissionedAction;
+import javax.inject.Inject;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
+class EnvironmentNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<EnvironmentNode>> {
 
-class EnvironmentNodeRecurseFetcher
-        implements DataFetcher<List<EnvironmentNode>>, PermissionedAction {
+    @Inject
+    EnvironmentNodeRecurseFetcher(AuthManager auth) {
+        super(auth);
+    }
 
     @Override
     public Set<ResourceAction> resourceActions() {
@@ -62,7 +66,7 @@ class EnvironmentNodeRecurseFetcher
     }
 
     @Override
-    public List<EnvironmentNode> get(DataFetchingEnvironment environment) throws Exception {
+    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         AbstractNode node = environment.getSource();
         if (node instanceof TargetNode) {
             return List.of();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
@@ -76,7 +76,7 @@ class EnvironmentNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List
             result.add(environmentNode);
             for (AbstractNode child : environmentNode.getChildren()) {
                 DataFetchingEnvironment newEnv =
-                        DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                        DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
                                 .source(child)
                                 .build();
                 result.addAll(get(newEnv));

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
@@ -44,13 +44,14 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
 
 class EnvironmentNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<EnvironmentNode>> {
 
@@ -66,7 +67,8 @@ class EnvironmentNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List
     }
 
     @Override
-    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         AbstractNode node = environment.getSource();
         if (node instanceof TargetNode) {
             return List.of();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodeRecurseFetcher.java
@@ -38,8 +38,12 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
@@ -48,7 +52,14 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 
-class EnvironmentNodeRecurseFetcher implements DataFetcher<List<EnvironmentNode>> {
+class EnvironmentNodeRecurseFetcher
+        implements DataFetcher<List<EnvironmentNode>>, PermissionedAction {
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        return actions;
+    }
 
     @Override
     public List<EnvironmentNode> get(DataFetchingEnvironment environment) throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -48,21 +48,20 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>>, PermissionedAction {
+class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<EnvironmentNode>> {
 
     private final RootNodeFetcher rootNodeFetcher;
 
     @Inject
-    EnvironmentNodesFetcher(RootNodeFetcher rootNodeFetcher) {
+    EnvironmentNodesFetcher(AuthManager auth, RootNodeFetcher rootNodeFetcher) {
+        super(auth);
         this.rootNodeFetcher = rootNodeFetcher;
     }
 
@@ -74,7 +73,7 @@ class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>>, Per
     }
 
     @Override
-    public List<EnvironmentNode> get(DataFetchingEnvironment environment) throws Exception {
+    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         FilterInput filter = FilterInput.from(environment);
         EnvironmentNode root = rootNodeFetcher.get(environment);
         Set<EnvironmentNode> nodes = flattenEnvNodes(root);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -48,12 +48,13 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<EnvironmentNode>> {
 
@@ -73,7 +74,8 @@ class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<Envir
     }
 
     @Override
-    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public List<EnvironmentNode> getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         FilterInput filter = FilterInput.from(environment);
         EnvironmentNode root = rootNodeFetcher.get(environment);
         Set<EnvironmentNode> nodes = flattenEnvNodes(root);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -68,9 +68,7 @@ class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<Envir
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        actions.addAll(rootNodeFetcher.resourceActions());
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -39,6 +39,7 @@ package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -47,6 +48,8 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
@@ -54,13 +57,20 @@ import io.cryostat.platform.discovery.EnvironmentNode;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>> {
+class EnvironmentNodesFetcher implements DataFetcher<List<EnvironmentNode>>, PermissionedAction {
 
     private final RootNodeFetcher rootNodeFetcher;
 
     @Inject
     EnvironmentNodesFetcher(RootNodeFetcher rootNodeFetcher) {
         this.rootNodeFetcher = rootNodeFetcher;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        actions.addAll(rootNodeFetcher.resourceActions());
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
@@ -44,17 +44,6 @@ import java.util.List;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import io.cryostat.configuration.CredentialsManager;
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.RequestHandler;
-import io.cryostat.platform.PlatformClient;
-import io.cryostat.recordings.RecordingArchiveHelper;
-import io.cryostat.recordings.RecordingMetadataManager;
-import io.cryostat.recordings.RecordingOptionsBuilderFactory;
-import io.cryostat.recordings.RecordingTargetHelper;
-
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -67,6 +56,17 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.RequestHandler;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingOptionsBuilderFactory;
+import io.cryostat.recordings.RecordingTargetHelper;
 
 @Module
 public abstract class GraphModule {
@@ -190,12 +190,12 @@ public abstract class GraphModule {
     }
 
     @Provides
-    static RootNodeFetcher provideRootNodeFetcher(PlatformClient client) {
-        return new RootNodeFetcher(client);
+    static RootNodeFetcher provideRootNodeFetcher(AuthManager auth, PlatformClient client) {
+        return new RootNodeFetcher(auth, client);
     }
 
     @Provides
-    static RecordingsFetcher provideRecordingsFetcher(
+    static RecordingsFetcher provideRecordingsFetcher(AuthManager auth,
             TargetConnectionManager tcm,
             RecordingArchiveHelper archiveHelper,
             CredentialsManager credentialsManager,
@@ -203,58 +203,60 @@ public abstract class GraphModule {
             Provider<WebServer> webServer,
             Logger logger) {
         return new RecordingsFetcher(
-                tcm, archiveHelper, credentialsManager, metadataManager, webServer, logger);
+                auth, tcm, archiveHelper, credentialsManager, metadataManager, webServer, logger);
     }
 
     @Provides
-    static ActiveRecordingsFetcher provideActiveRecordingsFetcher() {
-        return new ActiveRecordingsFetcher();
+    static ActiveRecordingsFetcher provideActiveRecordingsFetcher(AuthManager auth) {
+        return new ActiveRecordingsFetcher(auth);
     }
 
     @Provides
-    static ArchivedRecordingsFetcher provideArchivedRecordingsFetcher() {
-        return new ArchivedRecordingsFetcher();
+    static ArchivedRecordingsFetcher provideArchivedRecordingsFetcher(AuthManager auth) {
+        return new ArchivedRecordingsFetcher(auth);
     }
 
     @Provides
-    static EnvironmentNodeChildrenFetcher provideEnvironmentNodeChildrenFetcher() {
-        return new EnvironmentNodeChildrenFetcher();
+    static EnvironmentNodeChildrenFetcher provideEnvironmentNodeChildrenFetcher(AuthManager auth) {
+        return new EnvironmentNodeChildrenFetcher(auth);
     }
 
     @Provides
-    static TargetNodeRecurseFetcher provideTargetNodeRecurseFetcher() {
-        return new TargetNodeRecurseFetcher();
+    static TargetNodeRecurseFetcher provideTargetNodeRecurseFetcher(AuthManager auth) {
+        return new TargetNodeRecurseFetcher(auth);
     }
 
     @Provides
-    static EnvironmentNodeRecurseFetcher provideEnvironmentNodeRecurseFetcher() {
-        return new EnvironmentNodeRecurseFetcher();
+    static EnvironmentNodeRecurseFetcher provideEnvironmentNodeRecurseFetcher(AuthManager auth) {
+        return new EnvironmentNodeRecurseFetcher(auth);
     }
 
     @Provides
-    static NodeFetcher provideNodeFetcher(RootNodeFetcher rootNodeFetcher) {
-        return new NodeFetcher(rootNodeFetcher);
+    static NodeFetcher provideNodeFetcher(AuthManager auth, RootNodeFetcher rootNodeFetcher) {
+        return new NodeFetcher(auth, rootNodeFetcher);
     }
 
     @Provides
-    static EnvironmentNodesFetcher provideEnvironmentNodesFetcher(RootNodeFetcher rootNodeFetcher) {
-        return new EnvironmentNodesFetcher(rootNodeFetcher);
+    static EnvironmentNodesFetcher provideEnvironmentNodesFetcher(AuthManager auth, RootNodeFetcher rootNodeFetcher) {
+        return new EnvironmentNodesFetcher(auth, rootNodeFetcher);
     }
 
     @Provides
     static TargetNodesFetcher provideTargetNodesFetcher(
-            RootNodeFetcher rootNodeFetcher, TargetNodeRecurseFetcher recurseFetcher) {
-        return new TargetNodesFetcher(rootNodeFetcher, recurseFetcher);
+            AuthManager auth, RootNodeFetcher rootNodeFetcher, TargetNodeRecurseFetcher recurseFetcher) {
+        return new TargetNodesFetcher(auth, rootNodeFetcher, recurseFetcher);
     }
 
     @Provides
     static StartRecordingOnTargetMutator provideStartRecordingOnTargetMutator(
+            AuthManager auth,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             CredentialsManager credentialsManager,
             Provider<WebServer> webServer) {
         return new StartRecordingOnTargetMutator(
+                auth,
                 targetConnectionManager,
                 recordingTargetHelper,
                 recordingOptionsBuilderFactory,
@@ -264,24 +266,26 @@ public abstract class GraphModule {
 
     @Provides
     static SnapshotOnTargetMutator provideSnapshotOnTargetMutator(
-            RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
-        return new SnapshotOnTargetMutator(recordingTargetHelper, credentialsManager);
+            AuthManager auth, RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+        return new SnapshotOnTargetMutator(auth, recordingTargetHelper, credentialsManager);
     }
 
     @Provides
     static ArchiveRecordingMutator provideArchiveRecordingMutator(
-            RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
-        return new ArchiveRecordingMutator(recordingArchiveHelper, credentialsManager);
+            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
+        return new ArchiveRecordingMutator(auth, recordingArchiveHelper, credentialsManager);
     }
 
     @Provides
     static StopRecordingMutator provideStopRecordingsOnTargetMutator(
+            AuthManager auth,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             CredentialsManager credentialsManager,
             RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer) {
         return new StopRecordingMutator(
+                auth,
                 targetConnectionManager,
                 recordingTargetHelper,
                 credentialsManager,
@@ -291,13 +295,14 @@ public abstract class GraphModule {
 
     @Provides
     static DeleteActiveRecordingMutator provideDeleteActiveRecordingMutator(
+            AuthManager auth,
             RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
-        return new DeleteActiveRecordingMutator(recordingTargetHelper, credentialsManager);
+        return new DeleteActiveRecordingMutator(auth, recordingTargetHelper, credentialsManager);
     }
 
     @Provides
     static DeleteArchivedRecordingMutator provideDeleteArchivedRecordingMutator(
-            RecordingArchiveHelper recordingArchiveHelper) {
-        return new DeleteArchivedRecordingMutator(recordingArchiveHelper);
+            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper) {
+        return new DeleteArchivedRecordingMutator(auth, recordingArchiveHelper);
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphModule.java
@@ -44,6 +44,18 @@ import java.util.List;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.RequestHandler;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.recordings.RecordingArchiveHelper;
+import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.recordings.RecordingOptionsBuilderFactory;
+import io.cryostat.recordings.RecordingTargetHelper;
+
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -56,17 +68,6 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
-import io.cryostat.configuration.CredentialsManager;
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.AuthManager;
-import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.web.WebServer;
-import io.cryostat.net.web.http.RequestHandler;
-import io.cryostat.platform.PlatformClient;
-import io.cryostat.recordings.RecordingArchiveHelper;
-import io.cryostat.recordings.RecordingMetadataManager;
-import io.cryostat.recordings.RecordingOptionsBuilderFactory;
-import io.cryostat.recordings.RecordingTargetHelper;
 
 @Module
 public abstract class GraphModule {
@@ -195,7 +196,8 @@ public abstract class GraphModule {
     }
 
     @Provides
-    static RecordingsFetcher provideRecordingsFetcher(AuthManager auth,
+    static RecordingsFetcher provideRecordingsFetcher(
+            AuthManager auth,
             TargetConnectionManager tcm,
             RecordingArchiveHelper archiveHelper,
             CredentialsManager credentialsManager,
@@ -237,13 +239,16 @@ public abstract class GraphModule {
     }
 
     @Provides
-    static EnvironmentNodesFetcher provideEnvironmentNodesFetcher(AuthManager auth, RootNodeFetcher rootNodeFetcher) {
+    static EnvironmentNodesFetcher provideEnvironmentNodesFetcher(
+            AuthManager auth, RootNodeFetcher rootNodeFetcher) {
         return new EnvironmentNodesFetcher(auth, rootNodeFetcher);
     }
 
     @Provides
     static TargetNodesFetcher provideTargetNodesFetcher(
-            AuthManager auth, RootNodeFetcher rootNodeFetcher, TargetNodeRecurseFetcher recurseFetcher) {
+            AuthManager auth,
+            RootNodeFetcher rootNodeFetcher,
+            TargetNodeRecurseFetcher recurseFetcher) {
         return new TargetNodesFetcher(auth, rootNodeFetcher, recurseFetcher);
     }
 
@@ -266,13 +271,17 @@ public abstract class GraphModule {
 
     @Provides
     static SnapshotOnTargetMutator provideSnapshotOnTargetMutator(
-            AuthManager auth, RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+            AuthManager auth,
+            RecordingTargetHelper recordingTargetHelper,
+            CredentialsManager credentialsManager) {
         return new SnapshotOnTargetMutator(auth, recordingTargetHelper, credentialsManager);
     }
 
     @Provides
     static ArchiveRecordingMutator provideArchiveRecordingMutator(
-            AuthManager auth, RecordingArchiveHelper recordingArchiveHelper, CredentialsManager credentialsManager) {
+            AuthManager auth,
+            RecordingArchiveHelper recordingArchiveHelper,
+            CredentialsManager credentialsManager) {
         return new ArchiveRecordingMutator(auth, recordingArchiveHelper, credentialsManager);
     }
 
@@ -296,7 +305,8 @@ public abstract class GraphModule {
     @Provides
     static DeleteActiveRecordingMutator provideDeleteActiveRecordingMutator(
             AuthManager auth,
-            RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+            RecordingTargetHelper recordingTargetHelper,
+            CredentialsManager credentialsManager) {
         return new DeleteActiveRecordingMutator(auth, recordingTargetHelper, credentialsManager);
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
@@ -80,14 +80,9 @@ class GraphQLPostHandler implements RequestHandler {
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        return EnumSet.of(
-                ResourceAction.READ_TARGET,
-                ResourceAction.CREATE_RECORDING,
-                ResourceAction.READ_RECORDING,
-                ResourceAction.UPDATE_RECORDING,
-                ResourceAction.DELETE_RECORDING,
-                ResourceAction.READ_TEMPLATE,
-                ResourceAction.READ_CREDENTIALS);
+        // no permissions directly required here. Specific permissions may be required by fetchers
+        // and mutators that we invoke - see AbstractPermissionedDataFetcher
+        return EnumSet.noneOf(ResourceAction.class);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -82,7 +81,7 @@ class GraphQLPostHandler implements RequestHandler {
     public Set<ResourceAction> resourceActions() {
         // no permissions directly required here. Specific permissions may be required by fetchers
         // and mutators that we invoke - see AbstractPermissionedDataFetcher
-        return EnumSet.noneOf(ResourceAction.class);
+        return ResourceAction.NONE;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
@@ -37,24 +37,35 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class NodeFetcher implements DataFetcher<AbstractNode> {
+class NodeFetcher implements DataFetcher<AbstractNode>, PermissionedAction {
 
     private final RootNodeFetcher rootNodeFetcher;
 
     @Inject
     NodeFetcher(RootNodeFetcher rootNodeFetcher) {
         this.rootNodeFetcher = rootNodeFetcher;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        actions.addAll(rootNodeFetcher.resourceActions());
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
@@ -44,11 +44,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class NodeFetcher extends AbstractPermissionedDataFetcher<AbstractNode> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
@@ -63,9 +63,7 @@ class NodeFetcher extends AbstractPermissionedDataFetcher<AbstractNode> {
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        actions.addAll(rootNodeFetcher.resourceActions());
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/NodeFetcher.java
@@ -44,20 +44,19 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class NodeFetcher implements DataFetcher<AbstractNode>, PermissionedAction {
+class NodeFetcher extends AbstractPermissionedDataFetcher<AbstractNode> {
 
     private final RootNodeFetcher rootNodeFetcher;
 
     @Inject
-    NodeFetcher(RootNodeFetcher rootNodeFetcher) {
+    NodeFetcher(AuthManager auth, RootNodeFetcher rootNodeFetcher) {
+        super(auth);
         this.rootNodeFetcher = rootNodeFetcher;
     }
 
@@ -69,7 +68,7 @@ class NodeFetcher implements DataFetcher<AbstractNode>, PermissionedAction {
     }
 
     @Override
-    public AbstractNode get(DataFetchingEnvironment environment) throws Exception {
+    public AbstractNode getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         EnvironmentNode root = rootNodeFetcher.get(environment);
         String name = environment.getArgument("name");
         String nodeType = environment.getArgument("nodeType");

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
@@ -50,8 +50,6 @@ import javax.inject.Provider;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
@@ -66,6 +64,9 @@ import io.cryostat.recordings.RecordingArchiveHelper;
 import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.rules.ArchivedRecordingInfo;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import graphql.schema.DataFetchingEnvironment;
 
 class RecordingsFetcher extends AbstractPermissionedDataFetcher<Recordings> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
@@ -97,12 +97,10 @@ class RecordingsFetcher extends AbstractPermissionedDataFetcher<Recordings> {
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.READ_RECORDING,
-                        ResourceAction.READ_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.READ_TARGET,
+                ResourceAction.READ_RECORDING,
+                ResourceAction.READ_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RecordingsFetcher.java
@@ -39,8 +39,10 @@ package io.cryostat.net.web.http.api.v2.graph;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -52,6 +54,8 @@ import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.api.v2.graph.RecordingsFetcher.Recordings;
 import io.cryostat.platform.ServiceRef;
@@ -65,7 +69,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class RecordingsFetcher implements DataFetcher<Recordings> {
+class RecordingsFetcher implements DataFetcher<Recordings>, PermissionedAction {
 
     private final TargetConnectionManager tcm;
     private final RecordingArchiveHelper archiveHelper;
@@ -88,6 +92,16 @@ class RecordingsFetcher implements DataFetcher<Recordings> {
         this.metadataManager = metadataManager;
         this.webServer = webServer;
         this.logger = logger;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.READ_RECORDING,
+                        ResourceAction.READ_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
@@ -42,11 +42,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.discovery.EnvironmentNode;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class RootNodeFetcher extends AbstractPermissionedDataFetcher<EnvironmentNode> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
@@ -42,20 +42,19 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class RootNodeFetcher implements DataFetcher<EnvironmentNode>, PermissionedAction {
+class RootNodeFetcher extends AbstractPermissionedDataFetcher<EnvironmentNode> {
 
     private final PlatformClient client;
 
     @Inject
-    RootNodeFetcher(PlatformClient client) {
+    RootNodeFetcher(AuthManager auth, PlatformClient client) {
+        super(auth);
         this.client = client;
     }
 
@@ -65,7 +64,7 @@ class RootNodeFetcher implements DataFetcher<EnvironmentNode>, PermissionedActio
     }
 
     @Override
-    public EnvironmentNode get(DataFetchingEnvironment environment) throws Exception {
+    public EnvironmentNode getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         return client.getDiscoveryTree();
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/RootNodeFetcher.java
@@ -37,21 +37,31 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.discovery.EnvironmentNode;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class RootNodeFetcher implements DataFetcher<EnvironmentNode> {
+class RootNodeFetcher implements DataFetcher<EnvironmentNode>, PermissionedAction {
 
     private final PlatformClient client;
 
     @Inject
     RootNodeFetcher(PlatformClient client) {
         this.client = client;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
@@ -42,24 +42,23 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
-import io.cryostat.net.security.PermissionedAction;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingTargetHelper;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class SnapshotOnTargetMutator implements DataFetcher<GraphRecordingDescriptor>, PermissionedAction {
+class SnapshotOnTargetMutator extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
 
     private final RecordingTargetHelper recordingTargetHelper;
     private final CredentialsManager credentialsManager;
 
     @Inject
     SnapshotOnTargetMutator(
-            RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+            AuthManager auth, RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+        super(auth);
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
     }
@@ -78,7 +77,7 @@ class SnapshotOnTargetMutator implements DataFetcher<GraphRecordingDescriptor>, 
     }
 
     @Override
-    public GraphRecordingDescriptor get(DataFetchingEnvironment environment) throws Exception {
+    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         TargetNode node = environment.getSource();
 
         String uri = node.getTarget().getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
@@ -68,15 +68,13 @@ class SnapshotOnTargetMutator extends AbstractPermissionedDataFetcher<GraphRecor
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.READ_RECORDING,
-                        ResourceAction.UPDATE_RECORDING,
-                        ResourceAction.CREATE_RECORDING,
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.UPDATE_TARGET,
-                        ResourceAction.READ_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.READ_RECORDING,
+                ResourceAction.UPDATE_RECORDING,
+                ResourceAction.CREATE_RECORDING,
+                ResourceAction.READ_TARGET,
+                ResourceAction.UPDATE_TARGET,
+                ResourceAction.READ_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
@@ -42,13 +42,14 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingTargetHelper;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class SnapshotOnTargetMutator extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
 
@@ -57,7 +58,9 @@ class SnapshotOnTargetMutator extends AbstractPermissionedDataFetcher<GraphRecor
 
     @Inject
     SnapshotOnTargetMutator(
-            AuthManager auth, RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
+            AuthManager auth,
+            RecordingTargetHelper recordingTargetHelper,
+            CredentialsManager credentialsManager) {
         super(auth);
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
@@ -77,7 +80,8 @@ class SnapshotOnTargetMutator extends AbstractPermissionedDataFetcher<GraphRecor
     }
 
     @Override
-    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         TargetNode node = environment.getSource();
 
         String uri = node.getTarget().getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/SnapshotOnTargetMutator.java
@@ -37,17 +37,22 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingTargetHelper;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class SnapshotOnTargetMutator implements DataFetcher<GraphRecordingDescriptor> {
+class SnapshotOnTargetMutator implements DataFetcher<GraphRecordingDescriptor>, PermissionedAction {
 
     private final RecordingTargetHelper recordingTargetHelper;
     private final CredentialsManager credentialsManager;
@@ -57,6 +62,19 @@ class SnapshotOnTargetMutator implements DataFetcher<GraphRecordingDescriptor> {
             RecordingTargetHelper recordingTargetHelper, CredentialsManager credentialsManager) {
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.READ_RECORDING,
+                        ResourceAction.UPDATE_RECORDING,
+                        ResourceAction.CREATE_RECORDING,
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.UPDATE_TARGET,
+                        ResourceAction.READ_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -48,23 +48,21 @@ import javax.inject.Provider;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.security.PermissionedAction;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
 class StartRecordingOnTargetMutator
-        implements DataFetcher<HyperlinkedSerializableRecordingDescriptor>, PermissionedAction {
+    extends AbstractPermissionedDataFetcher<HyperlinkedSerializableRecordingDescriptor> {
 
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
@@ -74,11 +72,13 @@ class StartRecordingOnTargetMutator
 
     @Inject
     StartRecordingOnTargetMutator(
+            AuthManager auth,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             RecordingOptionsBuilderFactory recordingOptionsBuilderFactory,
             CredentialsManager credentialsManager,
             Provider<WebServer> webServer) {
+        super(auth);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;
@@ -99,7 +99,7 @@ class StartRecordingOnTargetMutator
     }
 
     @Override
-    public HyperlinkedSerializableRecordingDescriptor get(DataFetchingEnvironment environment)
+    public HyperlinkedSerializableRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment)
             throws Exception {
         TargetNode node = environment.getSource();
         Map<String, Object> settings = environment.getArgument("recording");

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -89,14 +89,12 @@ class StartRecordingOnTargetMutator
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.READ_RECORDING,
-                        ResourceAction.CREATE_RECORDING,
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.UPDATE_TARGET,
-                        ResourceAction.READ_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.READ_RECORDING,
+                ResourceAction.CREATE_RECORDING,
+                ResourceAction.READ_TARGET,
+                ResourceAction.UPDATE_TARGET,
+                ResourceAction.READ_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -48,7 +48,6 @@ import javax.inject.Provider;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -61,8 +60,10 @@ import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 
+import graphql.schema.DataFetchingEnvironment;
+
 class StartRecordingOnTargetMutator
-    extends AbstractPermissionedDataFetcher<HyperlinkedSerializableRecordingDescriptor> {
+        extends AbstractPermissionedDataFetcher<HyperlinkedSerializableRecordingDescriptor> {
 
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
@@ -99,8 +100,8 @@ class StartRecordingOnTargetMutator
     }
 
     @Override
-    public HyperlinkedSerializableRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment)
-            throws Exception {
+    public HyperlinkedSerializableRecordingDescriptor getAuthenticated(
+            DataFetchingEnvironment environment) throws Exception {
         TargetNode node = environment.getSource();
         Map<String, Object> settings = environment.getArgument("recording");
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -37,7 +37,9 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -51,6 +53,8 @@ import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
@@ -60,7 +64,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
 class StartRecordingOnTargetMutator
-        implements DataFetcher<HyperlinkedSerializableRecordingDescriptor> {
+        implements DataFetcher<HyperlinkedSerializableRecordingDescriptor>, PermissionedAction {
 
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
@@ -80,6 +84,18 @@ class StartRecordingOnTargetMutator
         this.recordingOptionsBuilderFactory = recordingOptionsBuilderFactory;
         this.credentialsManager = credentialsManager;
         this.webServer = webServer;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.READ_RECORDING,
+                        ResourceAction.CREATE_RECORDING,
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.UPDATE_TARGET,
+                        ResourceAction.READ_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
@@ -84,13 +84,11 @@ class StopRecordingMutator extends AbstractPermissionedDataFetcher<GraphRecordin
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions =
-                EnumSet.of(
-                        ResourceAction.READ_RECORDING,
-                        ResourceAction.UPDATE_RECORDING,
-                        ResourceAction.READ_TARGET,
-                        ResourceAction.READ_CREDENTIALS);
-        return actions;
+        return EnumSet.of(
+                ResourceAction.READ_RECORDING,
+                ResourceAction.UPDATE_RECORDING,
+                ResourceAction.READ_TARGET,
+                ResourceAction.READ_CREDENTIALS);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
@@ -45,10 +45,11 @@ import javax.inject.Provider;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
-import io.cryostat.net.security.PermissionedAction;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.platform.ServiceRef;
@@ -56,10 +57,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-
-class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor>, PermissionedAction {
+class StopRecordingMutator extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
 
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
@@ -69,11 +67,13 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor>, Per
 
     @Inject
     StopRecordingMutator(
+            AuthManager auth,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             CredentialsManager credentialsManager,
             RecordingMetadataManager metadataManager,
             Provider<WebServer> webServer) {
+        super(auth);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.credentialsManager = credentialsManager;
@@ -93,7 +93,7 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor>, Per
     }
 
     @Override
-    public GraphRecordingDescriptor get(DataFetchingEnvironment environment) throws Exception {
+    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         GraphRecordingDescriptor source = environment.getSource();
         ServiceRef target = source.target;
         String uri = target.getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
@@ -37,6 +37,9 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 import javax.inject.Provider;
 
@@ -45,6 +48,8 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingMetadataManager;
@@ -54,7 +59,7 @@ import io.cryostat.recordings.RecordingTargetHelper;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
-class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
+class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor>, PermissionedAction {
 
     private final TargetConnectionManager targetConnectionManager;
     private final RecordingTargetHelper recordingTargetHelper;
@@ -74,6 +79,17 @@ class StopRecordingMutator implements DataFetcher<GraphRecordingDescriptor> {
         this.credentialsManager = credentialsManager;
         this.metadataManager = metadataManager;
         this.webServer = webServer;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions =
+                EnumSet.of(
+                        ResourceAction.READ_RECORDING,
+                        ResourceAction.UPDATE_RECORDING,
+                        ResourceAction.READ_TARGET,
+                        ResourceAction.READ_CREDENTIALS);
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StopRecordingMutator.java
@@ -45,7 +45,6 @@ import javax.inject.Provider;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -56,6 +55,8 @@ import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper;
+
+import graphql.schema.DataFetchingEnvironment;
 
 class StopRecordingMutator extends AbstractPermissionedDataFetcher<GraphRecordingDescriptor> {
 
@@ -93,7 +94,8 @@ class StopRecordingMutator extends AbstractPermissionedDataFetcher<GraphRecordin
     }
 
     @Override
-    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment) throws Exception {
+    public GraphRecordingDescriptor getAuthenticated(DataFetchingEnvironment environment)
+            throws Exception {
         GraphRecordingDescriptor source = environment.getSource();
         ServiceRef target = source.target;
         String uri = target.getServiceUri().toString();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -38,13 +38,17 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
@@ -54,7 +58,13 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 
-class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>> {
+class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>>, PermissionedAction {
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        return actions;
+    }
 
     @Override
     public List<TargetNode> get(DataFetchingEnvironment environment) throws Exception {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -81,7 +81,7 @@ class TargetNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<Targ
         } else if (node instanceof EnvironmentNode) {
             for (AbstractNode child : ((EnvironmentNode) node).getChildren()) {
                 DataFetchingEnvironment newEnv =
-                        DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                        DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
                                 .source(child)
                                 .build();
                 result.addAll(get(newEnv));

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -68,8 +68,7 @@ class TargetNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<Targ
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -47,18 +47,23 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import io.cryostat.net.security.PermissionedAction;
+import javax.inject.Inject;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
+class TargetNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<TargetNode>> {
 
-class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>>, PermissionedAction {
+    @Inject
+    TargetNodeRecurseFetcher(AuthManager auth) {
+        super(auth);
+    }
 
     @Override
     public Set<ResourceAction> resourceActions() {
@@ -67,7 +72,7 @@ class TargetNodeRecurseFetcher implements DataFetcher<List<TargetNode>>, Permiss
     }
 
     @Override
-    public List<TargetNode> get(DataFetchingEnvironment environment) throws Exception {
+    public List<TargetNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         AbstractNode node = environment.getSource();
         FilterInput filter = FilterInput.from(environment);
         List<TargetNode> result = new ArrayList<>();

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -49,14 +49,15 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.AbstractNode;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.TargetNode;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
 
 class TargetNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<TargetNode>> {
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -37,15 +37,19 @@
  */
 package io.cryostat.net.web.http.api.v2.graph;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.net.security.PermissionedAction;
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.TargetNode;
 
@@ -53,7 +57,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 
-class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
+class TargetNodesFetcher implements DataFetcher<List<TargetNode>>, PermissionedAction {
 
     private final RootNodeFetcher rootNodeFetcher;
     private final TargetNodeRecurseFetcher recurseFetcher;
@@ -62,6 +66,14 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>> {
     TargetNodesFetcher(RootNodeFetcher rootNodefetcher, TargetNodeRecurseFetcher recurseFetcher) {
         this.rootNodeFetcher = rootNodefetcher;
         this.recurseFetcher = recurseFetcher;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
+        actions.addAll(rootNodeFetcher.resourceActions());
+        actions.addAll(recurseFetcher.resourceActions());
+        return actions;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -48,22 +48,21 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import io.cryostat.net.security.PermissionedAction;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.TargetNode;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
-
-class TargetNodesFetcher implements DataFetcher<List<TargetNode>>, PermissionedAction {
+class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode>> {
 
     private final RootNodeFetcher rootNodeFetcher;
     private final TargetNodeRecurseFetcher recurseFetcher;
 
     @Inject
-    TargetNodesFetcher(RootNodeFetcher rootNodefetcher, TargetNodeRecurseFetcher recurseFetcher) {
+    TargetNodesFetcher(AuthManager auth, RootNodeFetcher rootNodefetcher, TargetNodeRecurseFetcher recurseFetcher) {
+        super(auth);
         this.rootNodeFetcher = rootNodefetcher;
         this.recurseFetcher = recurseFetcher;
     }
@@ -77,7 +76,7 @@ class TargetNodesFetcher implements DataFetcher<List<TargetNode>>, PermissionedA
     }
 
     @Override
-    public List<TargetNode> get(DataFetchingEnvironment environment) throws Exception {
+    public List<TargetNode> getAuthenticated(DataFetchingEnvironment environment) throws Exception {
         FilterInput filter = FilterInput.from(environment);
         List<TargetNode> result =
                 recurseFetcher.get(

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -73,10 +73,7 @@ class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode
 
     @Override
     public Set<ResourceAction> resourceActions() {
-        EnumSet<ResourceAction> actions = EnumSet.of(ResourceAction.READ_TARGET);
-        actions.addAll(rootNodeFetcher.resourceActions());
-        actions.addAll(recurseFetcher.resourceActions());
-        return actions;
+        return EnumSet.of(ResourceAction.READ_TARGET);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -48,12 +48,13 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.api.v2.graph.labels.LabelSelectorMatcher;
 import io.cryostat.platform.discovery.TargetNode;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
 
 class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode>> {
 
@@ -61,7 +62,10 @@ class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode
     private final TargetNodeRecurseFetcher recurseFetcher;
 
     @Inject
-    TargetNodesFetcher(AuthManager auth, RootNodeFetcher rootNodefetcher, TargetNodeRecurseFetcher recurseFetcher) {
+    TargetNodesFetcher(
+            AuthManager auth,
+            RootNodeFetcher rootNodefetcher,
+            TargetNodeRecurseFetcher recurseFetcher) {
         super(auth);
         this.rootNodeFetcher = rootNodefetcher;
         this.recurseFetcher = recurseFetcher;


### PR DESCRIPTION
Fixes #1021

- chore(permissions): extract PermissionedAction interface
- chore(graphql): mark all fetchers/mutators with resource actions
- feat(graphql): implement permissions check for each graphql fetcher/mutator
- fix(graphql): ensure GraphQLContext is not null by copying DataFetchingEnvironment
- chore(graphql): apply spotless formatting

This implements granular permissions for each `fetcher`/`mutator` within the GraphQL endpoint implementation. This is achieved by removing the endpoint-level resource actions set union - by default, only a basic "token is valid" check will be performed - and delegating further permissions checks to each subsequent or nested `fetcher`/`mutator` that is executed afterward. In this implementation, each such subquery that is performed will result in a permissions check being performed, checking that the contextual user has the required permissions for the subquery's action. For complex GraphQL queries with deep nesting, this might add noticeable overall request latency since there is an authentication server request round-trip-time at each level of nested query. This might be something to optimize in the future by pre-computing the set union by recursing through the nested queries up front and performing a single permissions check all at once before actually executing the queries, but this needs either some deeper knowledge of GraphQL to pull off or a more complex implementation of `AbstractPermissionedDataFetcher` that encodes the nested query relationships.

Overall this ends up implementing something very similar to how our HTTP API permissions checks work with the `AbstractAuthenticatedRequestHandler`/`AbstractV2RequestHandler`, but on the `DataFetcher`s.

Unit tests are still overall sorely lacking - see #947. There is some basic integration test coverage, at least, which caught an error during implementation where the `DataFetchingEnvironment` passed to subqueries contained a `null` `GraphQLContext`.
