### PR TITLE
feat(discovery): persistence and callback URL handling

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 function cleanup() {
-    podman pod kill cryostat-pod
+    podman pod stop cryostat-pod
     podman pod rm cryostat-pod
 }
 trap cleanup EXIT

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -61,9 +61,11 @@ function runDemoApps() {
     podman run \
         --name quarkus-test-plugin \
         --pod cryostat-pod \
+        --restart unless-stopped \
         --env org.acme.CryostatService.Authorization="Basic $(echo -n user:pass | base64)" \
         --env org.acme.CryostatService/mp-rest/url="${protocol}://localhost:${webPort}" \
-        --rm -d quay.io/andrewazores/quarkus-test:0.0.3
+        --env org.acme.CryostatService.callback-host="localhost" \
+        -d quay.io/andrewazores/quarkus-test:0.0.3
 
     # copy a jboss-client.jar into /clientlib first
     # manual entry URL: service:jmx:remote+http://localhost:9990

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -24,7 +24,7 @@ function runDemoApps() {
         --env HTTP_PORT=8081 \
         --env JMX_PORT=9093 \
         --pod cryostat-pod \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.8.0
 
     podman run \
         --name vertx-fib-demo-2 \
@@ -32,7 +32,7 @@ function runDemoApps() {
         --env JMX_PORT=9094 \
         --env USE_AUTH=true \
         --pod cryostat-pod \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.8.0
 
     podman run \
         --name vertx-fib-demo-3 \
@@ -41,7 +41,7 @@ function runDemoApps() {
         --env USE_SSL=true \
         --env USE_AUTH=true \
         --pod cryostat-pod \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.7.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.8.0
 
     podman run \
         --name quarkus-test \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -8,6 +8,8 @@ function runCryostat() {
     local host="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
     local datasourcePort="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"
     local grafanaPort="$(xpath -q -e 'project/properties/cryostat.itest.grafana.port/text()' pom.xml)"
+    # credentials `user:pass`
+    echo "user:d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1" > "./conf/cryostat-users.properties"
     GRAFANA_DATASOURCE_URL="http://${host}:${datasourcePort}" \
         GRAFANA_DASHBOARD_URL="http://${host}:${grafanaPort}" \
         CRYOSTAT_RJMX_USER=smoketest \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -150,7 +150,7 @@ function createPod() {
 }
 
 function destroyPod() {
-    podman pod kill cryostat-pod
+    podman pod stop cryostat-pod
     podman pod rm cryostat-pod
 }
 trap destroyPod EXIT

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -78,11 +78,11 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
     @Override
     public void start(Promise<Void> start) {
         try {
-            storage.addTargetDiscoveryListener(this);
-
             if (env.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY)) {
                 return;
             }
+
+            storage.addTargetDiscoveryListener(this);
 
             for (PlatformClient platform : this.platformClients) {
                 logger.info(

--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -60,6 +60,7 @@ import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
+import io.vertx.ext.web.client.WebClient;
 
 @Module
 public abstract class DiscoveryModule {
@@ -73,8 +74,9 @@ public abstract class DiscoveryModule {
             FileSystem fs,
             @Named(PERSISTENCE_PATH) Path persistencePath,
             Gson gson,
+            WebClient http,
             Logger logger) {
-        return new DiscoveryStorage(uuid, fs, persistencePath, gson, logger);
+        return new DiscoveryStorage(uuid, fs, persistencePath, gson, http, logger);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -92,6 +92,9 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
             Path p = persistencePath.resolve(s);
             try (BufferedReader br = fs.readFile(p)) {
                 PluginInfo pluginInfo = gson.fromJson(br, PluginInfo.class);
+                if (Objects.equals(pluginInfo.getCallback(), NO_CALLBACK)) {
+                    continue;
+                }
                 map.put(UUID.fromString(s), pluginInfo);
             } catch (IOException ioe) {
                 logger.error(ioe);
@@ -104,6 +107,9 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
         map.entrySet()
                 .forEach(
                         entry -> {
+                            if (Objects.equals(entry.getValue().getCallback(), NO_CALLBACK)) {
+                                return;
+                            }
                             String key = entry.getKey().toString();
                             Path path = persistencePath.resolve(key);
                             try {

--- a/src/main/java/io/cryostat/net/HttpServer.java
+++ b/src/main/java/io/cryostat/net/HttpServer.java
@@ -41,7 +41,6 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import io.cryostat.core.log.Logger;
 
@@ -135,20 +134,6 @@ public class HttpServer extends AbstractVerticle {
         if (!isAlive()) {
             return;
         }
-
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        this.server.close(
-                res -> {
-                    if (res.failed()) {
-                        future.completeExceptionally(res.cause());
-                        return;
-                    }
-
-                    future.complete(null);
-                });
-        future.join(); // wait for vertx to be closed
-        this.isAlive = false;
-
         this.shutdownListeners.forEach(Runnable::run);
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryDeregistrationHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryDeregistrationHandler.java
@@ -52,6 +52,7 @@ import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.util.StringUtil;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
@@ -110,7 +111,10 @@ class DiscoveryDeregistrationHandler extends AbstractV2RequestHandler<String> {
     @Override
     public IntermediateResponse<String> handle(RequestParameters params) throws Exception {
         try {
-            UUID id = uuidFromString.apply(params.getPathParams().get("id"));
+            String key = "id";
+            UUID id =
+                    uuidFromString.apply(
+                            StringUtil.requireNonBlank(params.getPathParams().get(key), key));
             storage.deregister(id);
             return new IntermediateResponse<String>().body(id.toString());
         } catch (IllegalArgumentException iae) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
@@ -52,6 +52,7 @@ import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.platform.discovery.AbstractNode;
+import io.cryostat.util.StringUtil;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -115,13 +116,18 @@ class DiscoveryPostHandler extends AbstractV2RequestHandler<Void> {
 
     @Override
     public IntermediateResponse<Void> handle(RequestParameters params) throws Exception {
-        String body = params.getBody();
         try {
+            String key = "id";
+            UUID id =
+                    this.uuidFromString.apply(
+                            StringUtil.requireNonBlank(params.getPathParams().get(key), key));
             Set<AbstractNode> nodes =
-                    gson.fromJson(body, new TypeToken<Set<AbstractNode>>() {}.getType());
+                    gson.fromJson(
+                            StringUtil.requireNonBlank(params.getBody(), "body"),
+                            new TypeToken<Set<AbstractNode>>() {}.getType());
             // TODO validate the nodes more thoroughly, all branches should terminate in leaves, no
             // fields should be null, etc.
-            storage.update(this.uuidFromString.apply(params.getPathParams().get("id")), nodes);
+            storage.update(id, nodes);
 
             return new IntermediateResponse<Void>().body(null);
         } catch (JsonSyntaxException | IllegalArgumentException e) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
@@ -124,8 +124,8 @@ class DiscoveryPostHandler extends AbstractV2RequestHandler<Void> {
             storage.update(this.uuidFromString.apply(params.getPathParams().get("id")), nodes);
 
             return new IntermediateResponse<Void>().body(null);
-        } catch (JsonSyntaxException jse) {
-            throw new ApiException(400, jse);
+        } catch (JsonSyntaxException | IllegalArgumentException e) {
+            throw new ApiException(400, e);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
@@ -119,6 +119,7 @@ class DiscoveryRegistrationHandler extends AbstractV2RequestHandler<Map<String, 
             // exp: ? need to determine refresh time/mechanism
             // iat: now
             return new IntermediateResponse<Map<String, String>>()
+                    .statusCode(201)
                     .addHeader(HttpHeaders.LOCATION, String.format("%s/%s", path(), id))
                     .body(Map.of("id", id, "token", "placeholder"));
         } catch (IllegalArgumentException iae) {

--- a/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
@@ -64,4 +64,9 @@ public abstract class AbstractPlatformClient implements PlatformClient {
     protected void notifyAsyncTargetDiscovery(EventKind eventKind, ServiceRef serviceRef) {
         discoveryListeners.forEach(c -> c.accept(new TargetDiscoveryEvent(eventKind, serviceRef)));
     }
+
+    @Override
+    public void stop() throws Exception {
+        this.discoveryListeners.clear();
+    }
 }

--- a/src/main/java/io/cryostat/platform/PlatformClient.java
+++ b/src/main/java/io/cryostat/platform/PlatformClient.java
@@ -45,6 +45,8 @@ import io.cryostat.platform.discovery.EnvironmentNode;
 public interface PlatformClient {
     void start() throws Exception;
 
+    void stop() throws Exception;
+
     List<ServiceRef> listDiscoverableServices();
 
     void addTargetDiscoveryListener(Consumer<TargetDiscoveryEvent> listener);

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -81,6 +81,13 @@ public class DefaultPlatformClient extends AbstractPlatformClient
     }
 
     @Override
+    public void stop() throws Exception {
+        super.stop();
+        discoveryClient.removeListener(this);
+        discoveryClient.stop();
+    }
+
+    @Override
     public void accept(JvmDiscoveryEvent evt) {
         try {
             notifyAsyncTargetDiscovery(evt.getEventKind(), convert(evt.getJvmDescriptor()));

--- a/src/main/java/io/cryostat/util/PluggableJsonDeserializer.java
+++ b/src/main/java/io/cryostat/util/PluggableJsonDeserializer.java
@@ -35,49 +35,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.platform.discovery;
+package io.cryostat.util;
 
-import java.util.Set;
+import com.google.gson.JsonDeserializer;
 
-import io.cryostat.util.PluggableJsonDeserializer;
-import io.cryostat.util.PluggableTypeAdapter;
+public abstract class PluggableJsonDeserializer<T> implements JsonDeserializer<T> {
 
-import dagger.Lazy;
-import dagger.Module;
-import dagger.Provides;
-import dagger.multibindings.IntoSet;
+    protected final Class<T> klazz;
 
-@Module
-public abstract class PlatformDiscoveryModule {
-
-    @Provides
-    @IntoSet
-    static PluggableTypeAdapter<?> provideBaseNodeTypeAdapter() {
-        return new BaseNodeTypeAdapter();
+    public PluggableJsonDeserializer(Class<T> klazz) {
+        this.klazz = klazz;
     }
 
-    @Provides
-    @IntoSet
-    static PluggableTypeAdapter<?> provideCustomTargetNodeTypeAdapter() {
-        return new CustomTargetNodeTypeAdapter();
-    }
-
-    @Provides
-    @IntoSet
-    static PluggableTypeAdapter<?> provideJDPNodeTypeAdapter() {
-        return new JDPNodeTypeAdapter();
-    }
-
-    @Provides
-    @IntoSet
-    static PluggableTypeAdapter<?> provideKubernetesNodeTypeAdapter() {
-        return new KubernetesNodeTypeAdapter();
-    }
-
-    @Provides
-    @IntoSet
-    static PluggableJsonDeserializer<?> provideNodeTypeDeserializer(
-            Lazy<Set<PluggableTypeAdapter<?>>> adapters) {
-        return new NodeTypeDeserializer(adapters);
+    public Class<T> getAdaptedType() {
+        return klazz;
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryDeregistrationHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryDeregistrationHandlerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscoveryDeregistrationHandlerTest {
+    AbstractV2RequestHandler<String> handler;
+    @Mock AuthManager auth;
+    @Mock DiscoveryStorage storage;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new DiscoveryDeregistrationHandler(auth, storage, UUID::fromString, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBeDELETEHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+        }
+
+        @Test
+        void shouldBe2_2APIVersion() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2_2));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2.2/discovery/:id"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.DELETE_TARGET)));
+        }
+
+        @Test
+        void shouldReturnJsonMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\n", "\t", "not a uuid", "1234", "abc-123"})
+        void shouldThrowIfIdParamInvalid(String id) throws Exception {
+            Map<String, String> map = new HashMap<>();
+            if (id != null) {
+                map.put("id", id);
+            }
+            Mockito.when(requestParams.getPathParams()).thenReturn(map);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @Test
+        void shouldDeregisterWithStorageAndSendResponse() throws Exception {
+            UUID uuid = UUID.randomUUID();
+            Mockito.when(storage.deregister(Mockito.any(UUID.class))).thenReturn(null);
+
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", uuid.toString()));
+
+            IntermediateResponse<String> resp = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(resp.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(resp.getBody(), Matchers.equalTo(uuid.toString()));
+
+            Mockito.verify(storage).deregister(Mockito.eq(uuid));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandlerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.platform.discovery.AbstractNode;
+import io.cryostat.platform.discovery.EnvironmentNode;
+import io.cryostat.platform.discovery.TargetNode;
+import io.cryostat.platform.internal.KubeApiPlatformClient.KubernetesNodeType;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscoveryPostHandlerTest {
+    AbstractV2RequestHandler<Void> handler;
+    @Mock AuthManager auth;
+    @Mock DiscoveryStorage storage;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new DiscoveryPostHandler(auth, storage, UUID::fromString, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBeDELETEHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+        }
+
+        @Test
+        void shouldBe2_2APIVersion() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2_2));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2.2/discovery/:id"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(
+                            Set.of(
+                                    ResourceAction.CREATE_TARGET,
+                                    ResourceAction.UPDATE_TARGET,
+                                    ResourceAction.DELETE_TARGET)));
+        }
+
+        @Test
+        void shouldReturnJsonMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\n", "\t", "not a uuid", "1234", "abc-123"})
+        void shouldThrowIfIdParamInvalid(String id) throws Exception {
+            Map<String, String> map = new HashMap<>();
+            if (id != null) {
+                map.put("id", id);
+            }
+            Mockito.when(requestParams.getPathParams()).thenReturn(map);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(
+                strings = {
+                    "not json",
+                    " some, values ",
+                    "\"foo\":\"bar\"",
+                })
+        void shouldThrowIfBodyJsonInvalid(String json) throws Exception {
+            UUID uuid = UUID.randomUUID();
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", uuid.toString()));
+            Mockito.when(requestParams.getBody()).thenReturn(json);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @Test
+        @Disabled
+        void shouldUpdateStorageAndSendResponse() throws Exception {
+            UUID uuid = UUID.randomUUID();
+            Mockito.when(storage.deregister(Mockito.any(UUID.class))).thenReturn(null);
+
+            Set<AbstractNode> children = new HashSet<>();
+            EnvironmentNode pod = new EnvironmentNode("TestEnvironment", KubernetesNodeType.POD);
+            ServiceRef serviceRef =
+                    new ServiceRef(
+                            URI.create("service:jmx:rmi:///jndi/rmi://localhost/jmxrmi"),
+                            "selftest");
+            TargetNode leaf = new TargetNode(KubernetesNodeType.ENDPOINT, serviceRef);
+            pod.addChildNode(leaf);
+            children.add(pod);
+
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", uuid.toString()));
+            Mockito.when(requestParams.getBody()).thenReturn(gson.toJson(children));
+
+            IntermediateResponse<Void> resp = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(resp.getStatusCode(), Matchers.equalTo(200));
+
+            ArgumentCaptor<Set<AbstractNode>> captor = ArgumentCaptor.forClass(Set.class);
+
+            Mockito.verify(storage).update(Mockito.eq(uuid), captor.capture());
+
+            Set<AbstractNode> update = captor.getValue();
+
+            MatcherAssert.assertThat(update, Matchers.equalTo(children));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandlerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscoveryRegistrationHandlerTest {
+    AbstractV2RequestHandler<Map<String, String>> handler;
+    @Mock AuthManager auth;
+    @Mock DiscoveryStorage storage;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new DiscoveryRegistrationHandler(auth, storage, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+        }
+
+        @Test
+        void shouldBe2_2APIVersion() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.V2_2));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(handler.path(), Matchers.equalTo("/api/v2.2/discovery"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.CREATE_TARGET)));
+        }
+
+        @Test
+        void shouldReturnJsonMimeType() {
+            MatcherAssert.assertThat(handler.mimeType(), Matchers.equalTo(HttpMimeType.JSON));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\n", "\t"})
+        void shouldThrowIfRealmAttrBlank(String realm) throws Exception {
+            Map<String, String> attrs = new HashMap<>();
+            attrs.put("callback", "some-url");
+            if (realm != null) {
+                attrs.put("realm", realm);
+            }
+            Mockito.when(requestParams.getBody()).thenReturn(gson.toJson(attrs));
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\n", "\t", "not a url"})
+        void shouldThrowIfCallbackAttrBlankOrInvalid(String callback) throws Exception {
+            Map<String, String> attrs = new HashMap<>();
+            attrs.put("realm", "test");
+            if (callback != null) {
+                attrs.put("callback", callback);
+            }
+            Mockito.when(requestParams.getBody()).thenReturn(gson.toJson(attrs));
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+
+        @Test
+        void shouldRegisterWithStorageAndSendResponse() throws Exception {
+            UUID uuid = UUID.randomUUID();
+            Mockito.when(storage.register(Mockito.anyString(), Mockito.any(URI.class)))
+                    .thenReturn(uuid);
+
+            Mockito.when(requestParams.getBody())
+                    .thenReturn(
+                            gson.toJson(
+                                    Map.of(
+                                            "callback", "http://example.com/callback",
+                                            "realm", "test-realm")));
+
+            IntermediateResponse<Map<String, String>> resp = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(resp.getStatusCode(), Matchers.equalTo(201));
+            MatcherAssert.assertThat(
+                    resp.getHeaders(),
+                    Matchers.equalTo(Map.of(HttpHeaders.LOCATION, "/api/v2.2/discovery/" + uuid)));
+            MatcherAssert.assertThat(
+                    resp.getBody(),
+                    Matchers.equalTo(Map.of("token", "placeholder", "id", uuid.toString())));
+
+            Mockito.verify(storage)
+                    .register(
+                            Mockito.eq("test-realm"),
+                            Mockito.eq(URI.create("http://example.com/callback")));
+        }
+    }
+}


### PR DESCRIPTION
Related to #1026
Related to #938
Related to #939

- feat(discovery): prepare to implement URL callback handling
- don't persist or restore plugins without callbacks
- POST plugin callback URLs on startup to check presence
- run discovery plugin with restart policy
