### PR TITLE
fix(k8s): replace Watch with Informer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
   <org.apache.commons.validator.version>1.7</org.apache.commons.validator.version>
   <org.apache.commons.io.version>2.8.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
-  <io.fabric8.client.version>5.12.3</io.fabric8.client.version>
+  <io.fabric8.client.version>5.12.2</io.fabric8.client.version>
   <io.vertx.web.version>4.2.5</io.vertx.web.version>
   <com.nimbusds.jose.jwt.version>9.16.1</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.69</org.bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
   <org.apache.commons.validator.version>1.7</org.apache.commons.validator.version>
   <org.apache.commons.io.version>2.8.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
-  <io.fabric8.client.version>5.4.1</io.fabric8.client.version>
+  <io.fabric8.client.version>5.12.3</io.fabric8.client.version>
   <io.vertx.web.version>4.2.5</io.vertx.web.version>
   <com.nimbusds.jose.jwt.version>9.16.1</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.69</org.bouncycastle.version>

--- a/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
@@ -38,6 +38,7 @@
 package io.cryostat.platform.discovery;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -51,10 +52,14 @@ public abstract class AbstractNode implements Comparable<AbstractNode> {
 
     protected final Map<String, String> labels;
 
+    protected AbstractNode(AbstractNode other) {
+        this(other.name, other.nodeType, other.labels);
+    }
+
     protected AbstractNode(String name, NodeType nodeType, Map<String, String> labels) {
         this.name = name;
         this.nodeType = nodeType;
-        this.labels = labels;
+        this.labels = new HashMap<>(labels);
     }
 
     public String getName() {
@@ -62,7 +67,7 @@ public abstract class AbstractNode implements Comparable<AbstractNode> {
     }
 
     public NodeType getNodeType() {
-        return this.nodeType;
+        return nodeType;
     }
 
     public Map<String, String> getLabels() {

--- a/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
@@ -41,7 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -68,7 +68,7 @@ public class EnvironmentNode extends AbstractNode {
             Map<String, String> labels,
             Collection<? extends AbstractNode> children) {
         super(name, nodeType, labels);
-        this.children = new TreeSet<>(children);
+        this.children = new ConcurrentSkipListSet<>(children);
     }
 
     public SortedSet<AbstractNode> getChildren() {

--- a/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
@@ -66,7 +66,7 @@ public class EnvironmentNode extends AbstractNode {
             String name,
             NodeType nodeType,
             Map<String, String> labels,
-            Collection<AbstractNode> children) {
+            Collection<? extends AbstractNode> children) {
         super(name, nodeType, labels);
         this.children = new TreeSet<>(children);
     }

--- a/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
@@ -49,6 +49,11 @@ public class EnvironmentNode extends AbstractNode {
 
     private final SortedSet<AbstractNode> children;
 
+    public EnvironmentNode(EnvironmentNode other) {
+        this(other.getName(), other.getNodeType(), other.getLabels());
+        other.getChildren().forEach(this::addChildNode);
+    }
+
     public EnvironmentNode(String name, NodeType nodeType) {
         this(name, nodeType, Collections.emptyMap());
     }

--- a/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
@@ -37,10 +37,11 @@
  */
 package io.cryostat.platform.discovery;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.TreeSet;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -50,8 +51,7 @@ public class EnvironmentNode extends AbstractNode {
     private final SortedSet<AbstractNode> children;
 
     public EnvironmentNode(EnvironmentNode other) {
-        this(other.getName(), other.getNodeType(), other.getLabels());
-        other.getChildren().forEach(this::addChildNode);
+        this(other.name, other.nodeType, other.labels, other.children);
     }
 
     public EnvironmentNode(String name, NodeType nodeType) {
@@ -59,8 +59,16 @@ public class EnvironmentNode extends AbstractNode {
     }
 
     public EnvironmentNode(String name, NodeType nodeType, Map<String, String> labels) {
+        this(name, nodeType, labels, Collections.emptySortedSet());
+    }
+
+    public EnvironmentNode(
+            String name,
+            NodeType nodeType,
+            Map<String, String> labels,
+            Collection<AbstractNode> children) {
         super(name, nodeType, labels);
-        this.children = new ConcurrentSkipListSet<>();
+        this.children = new TreeSet<>(children);
     }
 
     public SortedSet<AbstractNode> getChildren() {

--- a/src/main/java/io/cryostat/platform/discovery/TargetNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/TargetNode.java
@@ -46,7 +46,12 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class TargetNode extends AbstractNode {
+
     private final ServiceRef target;
+
+    public TargetNode(TargetNode other) {
+        this(other.nodeType, other.target, other.labels);
+    }
 
     public TargetNode(NodeType nodeType, ServiceRef target) {
         super(target.getServiceUri().toString(), nodeType, Collections.emptyMap());

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
@@ -136,10 +137,10 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
 
     @Override
     public EnvironmentNode getDiscoveryTree() {
-        EnvironmentNode customTargetsNode =
-                new EnvironmentNode("Custom Targets", BaseNodeType.REALM);
-        targets.forEach(sr -> customTargetsNode.addChildNode(new TargetNode(NODE_TYPE, sr)));
-        return customTargetsNode;
+        List<TargetNode> children =
+                targets.stream().map(sr -> new TargetNode(NODE_TYPE, sr)).toList();
+        return new EnvironmentNode(
+                "Custom Targets", BaseNodeType.REALM, Collections.emptyMap(), children);
     }
 
     public enum CustomTargetNodeType implements NodeType {

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -119,13 +120,11 @@ public class DefaultPlatformClient extends AbstractPlatformClient
 
     @Override
     public EnvironmentNode getDiscoveryTree() {
-        EnvironmentNode root = new EnvironmentNode("JDP", BaseNodeType.REALM);
-        List<ServiceRef> targets = listDiscoverableServices();
-        for (ServiceRef target : targets) {
-            TargetNode targetNode = new TargetNode(NODE_TYPE, target);
-            root.addChildNode(targetNode);
-        }
-        return root;
+        List<TargetNode> targets =
+                listDiscoverableServices().stream()
+                        .map(sr -> new TargetNode(NODE_TYPE, sr))
+                        .toList();
+        return new EnvironmentNode("JDP", BaseNodeType.REALM, Collections.emptyMap(), targets);
     }
 
     public enum JDPNodeType implements NodeType {

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -205,8 +205,8 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
         }
         memoHash = store.hashCode();
         EnvironmentNode nsNode = new EnvironmentNode(namespace, KubernetesNodeType.NAMESPACE);
-        EnvironmentNode realmNode = new EnvironmentNode("KubernetesApi", BaseNodeType.REALM);
-        realmNode.addChildNode(nsNode);
+        EnvironmentNode realmNode = new EnvironmentNode("KubernetesApi", BaseNodeType.REALM,
+                Collections.emptyMap(), Set.of(nsNode));
         try {
             store.stream()
                     .flatMap(endpoints -> getTargetTuples(endpoints).stream())

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -199,7 +199,7 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
     @Override
     public EnvironmentNode getDiscoveryTree() {
         List<Endpoints> store = getInformer().getStore().list();
-        if (Integer.valueOf(store.hashCode()) == memoHash) {
+        if (Objects.equals(memoHash, store.hashCode())) {
             logger.trace("Using memoized discovery tree");
             return memoTree;
         }

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -201,7 +201,7 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
         List<Endpoints> store = getInformer().getStore().list();
         if (Objects.equals(memoHash, store.hashCode())) {
             logger.trace("Using memoized discovery tree");
-            return memoTree;
+            return new EnvironmentNode(memoTree);
         }
         memoHash = store.hashCode();
         EnvironmentNode nsNode = new EnvironmentNode(namespace, KubernetesNodeType.NAMESPACE);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -205,8 +205,12 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
         }
         memoHash = store.hashCode();
         EnvironmentNode nsNode = new EnvironmentNode(namespace, KubernetesNodeType.NAMESPACE);
-        EnvironmentNode realmNode = new EnvironmentNode("KubernetesApi", BaseNodeType.REALM,
-                Collections.emptyMap(), Set.of(nsNode));
+        EnvironmentNode realmNode =
+                new EnvironmentNode(
+                        "KubernetesApi",
+                        BaseNodeType.REALM,
+                        Collections.emptyMap(),
+                        Set.of(nsNode));
         try {
             store.stream()
                     .flatMap(endpoints -> getTargetTuples(endpoints).stream())

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -38,6 +38,7 @@
 package io.cryostat.platform.internal;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -86,12 +87,12 @@ class KubeEnvPlatformClient extends AbstractPlatformClient {
     @Override
     public EnvironmentNode getDiscoveryTree() {
         EnvironmentNode root = new EnvironmentNode("KubernetesEnv", BaseNodeType.REALM);
-        List<ServiceRef> targets = listDiscoverableServices();
-        for (ServiceRef target : targets) {
-            TargetNode targetNode = new TargetNode(KubernetesNodeType.SERVICE, target);
-            root.addChildNode(targetNode);
-        }
-        return root;
+        List<TargetNode> targets =
+                listDiscoverableServices().stream()
+                        .map(sr -> new TargetNode(KubernetesNodeType.SERVICE, sr))
+                        .toList();
+        return new EnvironmentNode(
+                "KubernetesEnv", BaseNodeType.REALM, Collections.emptyMap(), targets);
     }
 
     private ServiceRef envToServiceRef(Map.Entry<String, String> entry) {

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformClient.java
@@ -86,7 +86,6 @@ class KubeEnvPlatformClient extends AbstractPlatformClient {
 
     @Override
     public EnvironmentNode getDiscoveryTree() {
-        EnvironmentNode root = new EnvironmentNode("KubernetesEnv", BaseNodeType.REALM);
         List<TargetNode> targets =
                 listDiscoverableServices().stream()
                         .map(sr -> new TargetNode(KubernetesNodeType.SERVICE, sr))

--- a/src/main/java/io/cryostat/platform/internal/MergingPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/MergingPlatformClient.java
@@ -40,6 +40,7 @@ package io.cryostat.platform.internal;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -120,8 +121,9 @@ public class MergingPlatformClient implements PlatformClient, Consumer<TargetDis
 
     @Override
     public EnvironmentNode getDiscoveryTree() {
-        EnvironmentNode universe = new EnvironmentNode("Universe", BaseNodeType.UNIVERSE);
-        this.clients.forEach(client -> universe.addChildNode(client.getDiscoveryTree()));
-        return universe;
+        List<EnvironmentNode> realms =
+                clients.stream().map(PlatformClient::getDiscoveryTree).toList();
+        return new EnvironmentNode(
+                "Universe", BaseNodeType.UNIVERSE, Collections.emptyMap(), realms);
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
@@ -64,7 +64,7 @@ import io.cryostat.recordings.RecordingNotFoundException;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
@@ -66,7 +66,7 @@ import io.cryostat.recordings.RecordingTargetHelper;
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandlerTest.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Set;
 
 import io.cryostat.MainModule;
@@ -131,19 +132,27 @@ class DiscoveryGetHandlerTest {
 
         @BeforeEach
         void setup() throws Exception {
-            EnvironmentNode project =
-                    new EnvironmentNode("myProject", KubernetesNodeType.NAMESPACE);
-            EnvironmentNode deployment =
-                    new EnvironmentNode("appDeployment", KubernetesNodeType.DEPLOYMENT);
-            project.addChildNode(deployment);
             EnvironmentNode pod = new EnvironmentNode("appPod-1", KubernetesNodeType.POD);
-            deployment.addChildNode(pod);
+
             ServiceRef serviceRef =
                     new ServiceRef(
                             new URI("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
                             "appReplica-1-1");
             TargetNode endpoint = new TargetNode(KubernetesNodeType.ENDPOINT, serviceRef);
-            deployment.addChildNode(endpoint);
+
+            EnvironmentNode deployment =
+                    new EnvironmentNode(
+                            "appDeployment",
+                            KubernetesNodeType.DEPLOYMENT,
+                            Collections.emptyMap(),
+                            Set.of(pod, endpoint));
+
+            EnvironmentNode project =
+                    new EnvironmentNode(
+                            "myProject",
+                            KubernetesNodeType.NAMESPACE,
+                            Collections.emptyMap(),
+                            Set.of(deployment));
 
             expected = project;
         }

--- a/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/MergingPlatformClientTest.java
@@ -40,6 +40,7 @@ package io.cryostat.platform.internal;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -121,8 +122,9 @@ class MergingPlatformClientTest {
                                         "service:jmx:rmi:///jndi/rmi://cryostat:9098/jmxrmi")),
                         "ServiceA");
         TargetNode nodeA = new TargetNode(DefaultPlatformClient.NODE_TYPE, serviceA);
-        EnvironmentNode envA = new EnvironmentNode("EnvA", BaseNodeType.REALM);
-        envA.addChildNode(nodeA);
+        EnvironmentNode envA =
+                new EnvironmentNode(
+                        "EnvA", BaseNodeType.REALM, Collections.emptyMap(), Set.of(nodeA));
         ServiceRef serviceB =
                 new ServiceRef(
                         URIUtil.convert(
@@ -130,8 +132,9 @@ class MergingPlatformClientTest {
                                         "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi")),
                         "ServiceB");
         TargetNode nodeB = new TargetNode(DefaultPlatformClient.NODE_TYPE, serviceB);
-        EnvironmentNode envB = new EnvironmentNode("EnvB", BaseNodeType.REALM);
-        envB.addChildNode(nodeB);
+        EnvironmentNode envB =
+                new EnvironmentNode(
+                        "EnvB", BaseNodeType.REALM, Collections.emptyMap(), Set.of(nodeB));
 
         Mockito.when(clientA.getDiscoveryTree()).thenReturn(envA);
         Mockito.when(clientB.getDiscoveryTree()).thenReturn(envB);


### PR DESCRIPTION
Fixes #1036

update fabric8 kubernetes-client from 5.4.1 to 5.12.3 (latest 5.x) and replace direct Watch implementation with a fabric8 Informer. The Informer handles reconnecting the Watch on connection failures or when the API server responds with HTTP 410 (GONE), which can happen when too much time has elapsed between update notifications (such as during API server outages). The Informer also maintains an internal Store modelling the resource, in this case Endpoints, and resynchronizes this againt the API server periodically. This allows us to compute the list of ServiceRefs or the DiscoveryTree by constructing the result from the Informer's Store, rather than making an API call every time. Finally, the Informer's logic for added/updated/removed events is improved over the plain Watch and allows us to detect Pod scaling events correctly, as well as creation/deletion events.

For ease of testing, images are available at `quay.io/andrewazores/cryostat:k8s-rewatch-13` and `quay.io/andrewazores/cryostat-operator:k8s-rewatch-13`.
