### PR TITLE
fix(k8s-rbac): update permission mapping between k8s and cryostat

### DIFF
--- a/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
+++ b/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
@@ -9,5 +9,5 @@
 # ResourceType to Kubernetes resource kind mapping:
 TARGET=pods,services
 RECORDING=pods,pods/exec,cryostats.operator.cryostat.io
-CERTIFICATE=pods,cryostats.operator.cryostat.io
-CREDENTIALS=pods,cryostats.operator.cryostat.io
+CERTIFICATE=pods,secrets,cryostats.operator.cryostat.io
+CREDENTIALS=pods,secrets,cryostats.operator.cryostat.io

--- a/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
+++ b/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
@@ -9,5 +9,5 @@
 # ResourceType to Kubernetes resource kind mapping:
 TARGET=pods,services
 RECORDING=pods,pods/exec,cryostats.operator.cryostat.io
-CERTIFICATE=pods,secrets,cryostats.operator.cryostat.io
-CREDENTIALS=pods,secrets,cryostats.operator.cryostat.io
+CERTIFICATE=pods,cryostats.operator.cryostat.io
+CREDENTIALS=pods,cryostats.operator.cryostat.io

--- a/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
+++ b/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
@@ -3,12 +3,11 @@
 # Kubernetes resource kinds:
 # DEPLOYMENTS="deployments.apps"
 # PODS="pods"
+# SERVICES="services"
 # CRYOSTATS="cryostats.operator.cryostat.io"
-# FLIGHTRECORDERS="flightrecorders.operator.cryostat.io"
-# RECORDINGS="recordings.operator.cryostat.io"
 
 # ResourceType to Kubernetes resource kind mapping:
-TARGET=pods,endpoints,deployments.apps
-RECORDING=pods,pods/exec
-CERTIFICATE=deployments.apps,pods,cryostats.operator.cryostat.io
-CREDENTIALS=cryostats.operator.cryostat.io
+TARGET=pods,services
+RECORDING=pods,pods/exec,cryostats.operator.cryostat.io
+CERTIFICATE=pods,cryostats.operator.cryostat.io
+CREDENTIALS=pods,cryostats.operator.cryostat.io

--- a/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
+++ b/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
@@ -8,7 +8,7 @@
 # RECORDINGS="recordings.operator.cryostat.io"
 
 # ResourceType to Kubernetes resource kind mapping:
-TARGET=flightrecorders.operator.cryostat.io
-RECORDING=recordings.operator.cryostat.io
+TARGET=pods,deployments.apps
+RECORDING=pods,pods/exec
 CERTIFICATE=deployments.apps,pods,cryostats.operator.cryostat.io
 CREDENTIALS=cryostats.operator.cryostat.io

--- a/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
+++ b/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties
@@ -8,7 +8,7 @@
 # RECORDINGS="recordings.operator.cryostat.io"
 
 # ResourceType to Kubernetes resource kind mapping:
-TARGET=pods,deployments.apps
+TARGET=pods,endpoints,deployments.apps
 RECORDING=pods,pods/exec
 CERTIFICATE=deployments.apps,pods,cryostats.operator.cryostat.io
 CREDENTIALS=cryostats.operator.cryostat.io

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -147,14 +147,12 @@ class OpenShiftAuthManagerTest {
     void setup() throws IOException {
         client = Mockito.spy(client);
         tokenProvider = new TokenProvider(client);
-        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-        headers.set(HttpHeaders.AUTHORIZATION, "abcd1234==");
         Mockito.lenient()
                 .when(classPropertiesLoader.loadAsMap(Mockito.any()))
                 .thenReturn(
                         Map.of(
                                 "RECORDING",
-                                "recordings.operator.cryostat.io",
+                                "pods",
                                 "CERTIFICATE",
                                 "deployments.apps,pods"));
         mgr =
@@ -194,13 +192,13 @@ class OpenShiftAuthManagerTest {
                 Map.of("expected", Map.of()),
                 Map.of(
                         ResourceType.RECORDING.name(),
-                        "recordings.operator.cryostat.io",
+                        "cryostats.operator.cryostat.io",
                         "expected",
                         Map.of(
                                 ResourceType.RECORDING,
                                 Set.of(
                                         new GroupResource(
-                                                "operator.cryostat.io", "recordings", null)))),
+                                                "operator.cryostat.io", "cryostats", null)))),
                 Map.of(
                         ResourceType.RECORDING.name(),
                         "deployments.apps/scale",
@@ -220,13 +218,13 @@ class OpenShiftAuthManagerTest {
                         Map.of(ResourceType.RECORDING, Set.<String>of())),
                 Map.of(
                         ResourceType.RECORDING.name(),
-                        "recordings.operator.cryostat.io, deployments.apps",
+                        "pods/exec, deployments.apps",
                         "expected",
                         Map.of(
                                 ResourceType.RECORDING,
                                 Set.of(
                                         new GroupResource(
-                                                "operator.cryostat.io", "recordings", null),
+                                                "", "pods", "exec"),
                                         new GroupResource("apps", "deployments", null)))));
     }
 
@@ -349,7 +347,7 @@ class OpenShiftAuthManagerTest {
         PermissionDeniedException pde = (PermissionDeniedException) ExceptionUtils.getRootCause(ee);
         MatcherAssert.assertThat(pde.getNamespace(), Matchers.equalTo(NAMESPACE));
         MatcherAssert.assertThat(
-                pde.getResourceType(), Matchers.equalTo("recordings.operator.cryostat.io"));
+                pde.getResourceType(), Matchers.equalTo("pods"));
         MatcherAssert.assertThat(pde.getVerb(), Matchers.equalTo("get"));
     }
 
@@ -540,8 +538,8 @@ class OpenShiftAuthManagerTest {
         Set<String> expectedGroups;
         Set<String> expectedResources;
         if (resourceAction.getResource() == ResourceType.RECORDING) {
-            expectedGroups = Set.of("operator.cryostat.io");
-            expectedResources = Set.of("recordings");
+            expectedGroups = Set.of("");
+            expectedResources = Set.of("pods");
         } else if (resourceAction.getResource() == ResourceType.CERTIFICATE) {
             expectedGroups = Set.of("apps", "");
             expectedResources = Set.of("deployments", "pods");

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -147,7 +147,8 @@ class OpenShiftAuthManagerTest {
         tokenProvider = new TokenProvider(client);
         Mockito.lenient()
                 .when(classPropertiesLoader.loadAsMap(Mockito.any()))
-                .thenReturn(Map.of("RECORDING", "pods/exec", "CERTIFICATE", "deployments.apps,pods"));
+                .thenReturn(
+                        Map.of("RECORDING", "pods/exec", "CERTIFICATE", "deployments.apps,pods"));
         mgr =
                 new OpenShiftAuthManager(
                         env,

--- a/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
+++ b/src/test/java/io/cryostat/net/openshift/OpenShiftAuthManagerTest.java
@@ -82,8 +82,6 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServerExtension;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -149,12 +147,7 @@ class OpenShiftAuthManagerTest {
         tokenProvider = new TokenProvider(client);
         Mockito.lenient()
                 .when(classPropertiesLoader.loadAsMap(Mockito.any()))
-                .thenReturn(
-                        Map.of(
-                                "RECORDING",
-                                "pods",
-                                "CERTIFICATE",
-                                "deployments.apps,pods"));
+                .thenReturn(Map.of("RECORDING", "pods", "CERTIFICATE", "deployments.apps,pods"));
         mgr =
                 new OpenShiftAuthManager(
                         env,
@@ -223,8 +216,7 @@ class OpenShiftAuthManagerTest {
                         Map.of(
                                 ResourceType.RECORDING,
                                 Set.of(
-                                        new GroupResource(
-                                                "", "pods", "exec"),
+                                        new GroupResource("", "pods", "exec"),
                                         new GroupResource("apps", "deployments", null)))));
     }
 
@@ -346,8 +338,7 @@ class OpenShiftAuthManagerTest {
                 Matchers.instanceOf(PermissionDeniedException.class));
         PermissionDeniedException pde = (PermissionDeniedException) ExceptionUtils.getRootCause(ee);
         MatcherAssert.assertThat(pde.getNamespace(), Matchers.equalTo(NAMESPACE));
-        MatcherAssert.assertThat(
-                pde.getResourceType(), Matchers.equalTo("pods"));
+        MatcherAssert.assertThat(pde.getResourceType(), Matchers.equalTo("pods"));
         MatcherAssert.assertThat(pde.getVerb(), Matchers.equalTo("get"));
     }
 


### PR DESCRIPTION
Fixes #979 
Related to https://github.com/cryostatio/cryostat-operator/pull/440

Use alternatives for mapping between k8s resource to cryostat since flightRecorder/Recordings are deprecated.