### PR TITLE
chore(db): upgrade h2 and postgres versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
   <com.github.ben-manes.caffeine.version>3.0.1</com.github.ben-manes.caffeine.version>
   <org.hibernate.hibernate.version>5.6.7.Final</org.hibernate.hibernate.version>
   <com.vladmihalcea.hibernate.types.version>2.17.1</com.vladmihalcea.hibernate.types.version>
-  <com.h2database.h2.version>1.4.197</com.h2database.h2.version>
-  <org.postgresql.postgresql.version>42.4.0</org.postgresql.postgresql.version>
+  <com.h2database.h2.version>2.1.214</com.h2database.h2.version>
+  <org.postgresql.postgresql.version>42.4.2</org.postgresql.postgresql.version>
 
   <com.github.spotbugs.version>4.5.3</com.github.spotbugs.version>
   <com.github.spotbugs.plugin.version>4.5.3.0</com.github.spotbugs.plugin.version>

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -19,7 +19,7 @@ function runCryostat() {
         JDBC_PASSWORD="abcd1234"
         HBM2DDL="update"
     elif [ "$1" = "h2file" ]; then
-        JDBC_URL="jdbc:h2:file:/opt/cryostat.d/conf.d/h2;INIT=create domain if not exists jsonb as other"
+        JDBC_URL="jdbc:h2:file:/opt/cryostat.d/conf.d/h2;INIT=create domain if not exists jsonb as varchar"
         HBM2DDL="update"
     fi
 

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -37,7 +37,6 @@
  */
 package io.cryostat.discovery;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -61,7 +60,6 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
 
     private final DiscoveryStorage storage;
     private final Set<PlatformClient> platformClients;
-    private final Set<UUID> ids;
     private final Environment env;
     private final NotificationFactory notificationFactory;
     private final Logger logger;
@@ -74,7 +72,6 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
             Logger logger) {
         this.storage = storage;
         this.platformClients = platformClients;
-        this.ids = new HashSet<>();
         this.env = env;
         this.notificationFactory = notificationFactory;
         this.logger = logger;
@@ -110,7 +107,6 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
                                         })
                                 .get();
 
-                ids.add(id);
                 platform.addTargetDiscoveryListener(
                         tde -> storage.update(id, platform.getDiscoveryTree().getChildren()));
                 Promise<EnvironmentNode> promise = Promise.promise();

--- a/src/main/java/io/cryostat/discovery/PluginInfo.java
+++ b/src/main/java/io/cryostat/discovery/PluginInfo.java
@@ -59,6 +59,8 @@ public class PluginInfo {
     @Id
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(columnDefinition = "uuid", updatable = false)
+    @Type(type = "org.hibernate.type.UUIDCharType")
     private UUID id;
 
     @Column(unique = true, nullable = false)

--- a/src/main/java/io/cryostat/discovery/PluginInfo.java
+++ b/src/main/java/io/cryostat/discovery/PluginInfo.java
@@ -77,9 +77,9 @@ public class PluginInfo {
     PluginInfo() {}
 
     PluginInfo(String realm, URI callback, String subtree) {
-        this.realm = realm;
+        this.realm = Objects.requireNonNull(realm, "realm");
         this.callback = callback;
-        this.subtree = subtree;
+        this.subtree = Objects.requireNonNull(subtree, "subtree");
     }
 
     public UUID getId() {
@@ -99,11 +99,11 @@ public class PluginInfo {
     }
 
     public void setId(UUID id) {
-        this.id = id;
+        this.id = Objects.requireNonNull(id);
     }
 
     public void setRealm(String realm) {
-        this.realm = realm;
+        this.realm = Objects.requireNonNull(realm);
     }
 
     public void setCallback(URI callback) {
@@ -111,7 +111,7 @@ public class PluginInfo {
     }
 
     public void setSubtree(String subtree) {
-        this.subtree = subtree;
+        this.subtree = Objects.requireNonNull(subtree);
     }
 
     @Override

--- a/src/main/java/io/cryostat/storage/StorageModule.java
+++ b/src/main/java/io/cryostat/storage/StorageModule.java
@@ -64,7 +64,8 @@ public abstract class StorageModule {
                 "jakarta.persistence.jdbc.url",
                 env.getEnv(
                         Variables.JDBC_URL,
-                        "jdbc:h2:mem:cryostat;INIT=create domain if not exists jsonb as other"));
+                        "jdbc:h2:mem:cryostat;INIT=create domain if not exists jsonb as"
+                                + " varchar"));
         properties.put("jakarta.persistence.jdbc.user", env.getEnv(Variables.JDBC_USERNAME, "sa"));
         properties.put(
                 "jakarta.persistence.jdbc.password", env.getEnv(Variables.JDBC_PASSWORD, ""));


### PR DESCRIPTION
Fixes #1053

Blocked - waiting for downstream builds of h2 2.0+ to be available.

* chore(db): upgrade dependencies
* chore(db): update h2 init and entity ID definitions
* chore(discovery): enforce field non-nullness
* chore(discovery): remove unused field