### PR TITLE
fix(discovery): discovery plugin register/update errors respond 4xx

### DIFF
--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -63,6 +63,8 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.client.WebClient;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hibernate.exception.ConstraintViolationException;
 
 public class DiscoveryStorage extends AbstractPlatformClientVerticle {
 
@@ -154,7 +156,10 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
             logger.trace("Discovery Registration: \"{}\" [{}]", realm, id);
             return id;
         } catch (Exception e) {
-            throw new RegistrationException(realm, callback, e);
+            if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
+                throw new RegistrationException(realm, callback, e);
+            }
+            throw e;
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -154,7 +154,7 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
             logger.trace("Discovery Registration: \"{}\" [{}]", realm, id);
             return id;
         } catch (Exception e) {
-            throw new RegistrationException(e);
+            throw new RegistrationException(realm, callback, e);
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/PluginInfo.java
+++ b/src/main/java/io/cryostat/discovery/PluginInfo.java
@@ -38,6 +38,7 @@
 package io.cryostat.discovery;
 
 import java.net.URI;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -113,29 +114,24 @@ public class PluginInfo {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((callback == null) ? 0 : callback.hashCode());
-        result = prime * result + ((realm == null) ? 0 : realm.hashCode());
-        result = prime * result + ((subtree == null) ? 0 : subtree.hashCode());
-        return result;
+        return Objects.hash(callback, id, realm, subtree);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null) return false;
-        if (getClass() != obj.getClass()) return false;
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
         PluginInfo other = (PluginInfo) obj;
-        if (callback == null) {
-            if (other.callback != null) return false;
-        } else if (!callback.equals(other.callback)) return false;
-        if (realm == null) {
-            if (other.realm != null) return false;
-        } else if (!realm.equals(other.realm)) return false;
-        if (subtree == null) {
-            if (other.subtree != null) return false;
-        } else if (!subtree.equals(other.subtree)) return false;
-        return true;
+        return Objects.equals(callback, other.callback)
+                && Objects.equals(id, other.id)
+                && Objects.equals(realm, other.realm)
+                && Objects.equals(subtree, other.subtree);
     }
 }

--- a/src/main/java/io/cryostat/discovery/RegistrationException.java
+++ b/src/main/java/io/cryostat/discovery/RegistrationException.java
@@ -37,12 +37,16 @@
  */
 package io.cryostat.discovery;
 
+import java.net.URI;
+
 public class RegistrationException extends Exception {
-    public RegistrationException(String realm) {
+    public RegistrationException(String realm, URI callback, Exception cause) {
         super(
                 String.format(
-                        "Failed to register new provider for \"%s\": provider already present",
-                        realm));
+                        "Failed to register new provider for \"%s\" @ \"%s\": provider already"
+                                + " present",
+                        realm, callback),
+                cause);
     }
 
     public RegistrationException(Exception cause) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
@@ -47,6 +47,7 @@ import javax.inject.Named;
 
 import io.cryostat.MainModule;
 import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.discovery.DiscoveryStorage.NotFoundException;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -131,6 +132,8 @@ class DiscoveryPostHandler extends AbstractV2RequestHandler<Void> {
             return new IntermediateResponse<Void>().body(null);
         } catch (JsonSyntaxException | IllegalArgumentException e) {
             throw new ApiException(400, e);
+        } catch (NotFoundException e) {
+            throw new ApiException(404, e);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.discovery.RegistrationException;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -122,10 +123,8 @@ class DiscoveryRegistrationHandler extends AbstractV2RequestHandler<Map<String, 
                     .statusCode(201)
                     .addHeader(HttpHeaders.LOCATION, String.format("%s/%s", path(), id))
                     .body(Map.of("id", id, "token", "placeholder"));
-        } catch (IllegalArgumentException iae) {
-            throw new ApiException(400, iae);
-        } catch (URISyntaxException use) {
-            throw new ApiException(400, use);
+        } catch (IllegalArgumentException | URISyntaxException | RegistrationException e) {
+            throw new ApiException(400, e);
         }
     }
 }

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -47,7 +47,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Singleton;
-import javax.persistence.EntityExistsException;
 
 import io.cryostat.MainModule;
 import io.cryostat.MockVertx;
@@ -74,6 +73,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -268,14 +268,15 @@ class DiscoveryStorageTest {
                                     Mockito.anyString(),
                                     Mockito.any(URI.class),
                                     Mockito.any(EnvironmentNode.class)))
-                    .thenThrow(EntityExistsException.class);
+                    .thenThrow(ConstraintViolationException.class);
 
             Exception ex =
                     Assertions.assertThrows(
                             Exception.class,
                             () -> storage.register("test-realm", URI.create("http://example.com")));
             MatcherAssert.assertThat(ex, Matchers.isA(RegistrationException.class));
-            MatcherAssert.assertThat(ex.getCause(), Matchers.isA(EntityExistsException.class));
+            MatcherAssert.assertThat(
+                    ex.getCause(), Matchers.isA(ConstraintViolationException.class));
         }
 
         @Test

--- a/src/test/java/itest/DiscoveryPluginIT.java
+++ b/src/test/java/itest/DiscoveryPluginIT.java
@@ -44,10 +44,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import io.cryostat.platform.discovery.NodeType;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -61,22 +57,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 @TestMethodOrder(OrderAnnotation.class)
 class DiscoveryPluginIT extends StandardSelfTest {
-
-    private static final Gson gson =
-            new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-
-    static final NodeType NODE_TYPE =
-            new NodeType() {
-                @Override
-                public String getKind() {
-                    return "JVM";
-                }
-
-                @Override
-                public int ordinal() {
-                    return 0;
-                }
-            };
 
     final String realm = getClass().getSimpleName();
     final URI callback = URI.create("http://localhost:8181/");

--- a/src/test/java/itest/DiscoveryPluginIT.java
+++ b/src/test/java/itest/DiscoveryPluginIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package itest;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import io.cryostat.platform.discovery.NodeType;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.StandardSelfTest;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@TestMethodOrder(OrderAnnotation.class)
+class DiscoveryPluginIT extends StandardSelfTest {
+
+    private static final Gson gson =
+            new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+
+    static final NodeType NODE_TYPE =
+            new NodeType() {
+                @Override
+                public String getKind() {
+                    return "JVM";
+                }
+
+                @Override
+                public int ordinal() {
+                    return 0;
+                }
+            };
+
+    final String realm = getClass().getSimpleName();
+    final URI callback = URI.create("http://localhost:8181/");
+    private static volatile String id;
+
+    @Test
+    @Order(1)
+    void shouldBeAbleToRegister() throws InterruptedException, ExecutionException {
+        JsonObject body = new JsonObject(Map.of("realm", realm, "callback", callback));
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .post("/api/v2.2/discovery")
+                .sendJson(
+                        body,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                            response.complete(ar.result().bodyAsJsonObject());
+                        });
+        JsonObject resp = response.get();
+        JsonObject info = resp.getJsonObject("data").getJsonObject("result");
+        DiscoveryPluginIT.id = info.getString("id");
+        MatcherAssert.assertThat(id, Matchers.notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void shouldBeAbleToUpdate() throws InterruptedException, ExecutionException {
+        JsonObject service = new JsonObject(Map.of("connectUrl", callback, "alias", "mynode"));
+        JsonObject target =
+                new JsonObject(
+                        Map.of(
+                                "target",
+                                service,
+                                "name",
+                                getClass().getSimpleName(),
+                                "nodeType",
+                                "JVM"));
+        JsonArray subtree = new JsonArray(List.of(target));
+
+        CompletableFuture<Buffer> response = new CompletableFuture<>();
+        webClient
+                .post("/api/v2.2/discovery/" + id)
+                .sendJson(
+                        subtree,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                            response.complete(ar.result().body());
+                        });
+        response.get();
+    }
+
+    @Test
+    @Order(3)
+    void shouldFailToReregister() throws InterruptedException, ExecutionException {
+        JsonObject body = new JsonObject(Map.of("realm", realm, "callback", callback));
+
+        CompletableFuture<Integer> response = new CompletableFuture<>();
+        webClient
+                .post("/api/v2.2/discovery")
+                .sendJson(
+                        body,
+                        ar -> {
+                            response.complete(ar.result().statusCode());
+                        });
+        int code = response.get();
+        MatcherAssert.assertThat(code, Matchers.equalTo(400));
+    }
+
+    @Test
+    @Order(4)
+    void shouldBeAbleToDeregister() throws InterruptedException, ExecutionException {
+        CompletableFuture<Integer> response = new CompletableFuture<>();
+        webClient
+                .delete("/api/v2.2/discovery/" + id)
+                .send(
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                            response.complete(ar.result().statusCode());
+                        });
+        int code = response.get();
+        MatcherAssert.assertThat(code, Matchers.equalTo(200));
+    }
+
+    @Test
+    @Order(5)
+    void shouldFailToDoubleDeregister() throws InterruptedException, ExecutionException {
+        CompletableFuture<Integer> response = new CompletableFuture<>();
+        webClient
+                .delete("/api/v2.2/discovery/" + id)
+                .send(
+                        ar -> {
+                            response.complete(ar.result().statusCode());
+                        });
+        int code = response.get();
+        MatcherAssert.assertThat(code, Matchers.equalTo(404));
+    }
+
+    @Test
+    @Order(6)
+    void shouldFailToUpdateUnregisteredPluginID() throws InterruptedException, ExecutionException {
+        JsonObject service = new JsonObject(Map.of("connectUrl", callback, "alias", "mynode"));
+        JsonObject target =
+                new JsonObject(
+                        Map.of(
+                                "target",
+                                service,
+                                "name",
+                                getClass().getSimpleName(),
+                                "nodeType",
+                                "JVM"));
+        JsonArray subtree = new JsonArray(List.of(target));
+
+        CompletableFuture<Integer> response = new CompletableFuture<>();
+        webClient
+                .post("/api/v2.2/discovery/" + UUID.randomUUID())
+                .sendJson(
+                        subtree,
+                        ar -> {
+                            response.complete(ar.result().statusCode());
+                        });
+        int code = response.get();
+        MatcherAssert.assertThat(code, Matchers.equalTo(404));
+    }
+}

--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -60,8 +60,6 @@ import io.vertx.ext.web.handler.HttpException;
 import itest.util.Podman;
 import itest.util.Utils;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 
 public abstract class StandardSelfTest {
 
@@ -104,14 +102,6 @@ public abstract class StandardSelfTest {
                 });
 
         return future.orTimeout(timeout, unit);
-    }
-
-    public static void assertResponseStatus(JsonObject response) {
-        assertResponseStatus(response, 0);
-    }
-
-    public static void assertResponseStatus(JsonObject response, int status) {
-        MatcherAssert.assertThat(response.getInteger("status"), Matchers.equalTo(status));
     }
 
     public static boolean assertRequestStatus(


### PR DESCRIPTION
Fixes #1054

- test(discovery): add discovery plugin itest
- fix(discovery): respond 400 on duplicate registration attempt
- fix(discovery): respond 400 on update unregistered ID attempt
- chore(itest): remove unused command-response methods

Result from `bash repeated-integration-tests.bash 1 DiscoveryPluginIT` with only the first commit applied (test addition, no fixes):

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running itest.DiscoveryPluginIT
[ERROR] Tests run: 6, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.465 s <<< FAILURE! - in itest.DiscoveryPluginIT
[ERROR] shouldFailToReregister  Time elapsed: 0.016 s  <<< FAILURE!
java.lang.AssertionError:

Expected: <400>
     but: was <500>
	at itest.DiscoveryPluginIT.shouldFailToReregister(DiscoveryPluginIT.java:146)
[ERROR] shouldFailToUpdateUnregisteredPluginID  Time elapsed: 0.005 s  <<< FAILURE!
java.lang.AssertionError:

Expected: <404>
     but: was <500>
	at itest.DiscoveryPluginIT.shouldFailToUpdateUnregisteredPluginID(DiscoveryPluginIT.java:202)
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   DiscoveryPluginIT.shouldFailToReregister:146
Expected: <400>
     but: was <500>
[ERROR]   DiscoveryPluginIT.shouldFailToUpdateUnregisteredPluginID:202
Expected: <404>
     but: was <500>
[INFO]
[ERROR] Tests run: 6, Failures: 2, Errors: 0, Skipped: 0
```

With the fixes applied, the test cases all pass.
