### PR TITLE
fix(archives): metadata labels may be set during upload

### DIFF
--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingsPostHandlerTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -157,8 +156,6 @@ class RecordingsPostHandlerTest {
         String basename = "localhost_test_20191219T213834Z";
         String filename = basename + ".jfr";
         String savePath = "/some/path/";
-        Map<String, String> labels = new HashMap<>();
-        Metadata metadata = new Metadata(labels);
 
         RoutingContext ctx = mock(RoutingContext.class);
 
@@ -304,7 +301,7 @@ class RecordingsPostHandlerTest {
 
         InOrder inOrder = Mockito.inOrder(rep);
         inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
-        inOrder.verify(rep).end(gson.toJson(Map.of("name", filename, "metadata", metadata)));
+        inOrder.verify(rep).end(gson.toJson(Map.of("name", filename, "metadata", new Metadata())));
 
         ArchivedRecordingInfo recordingInfo =
                 new ArchivedRecordingInfo(
@@ -312,6 +309,193 @@ class RecordingsPostHandlerTest {
                         filename,
                         "/some/download/path/" + filename,
                         "/some/report/path/" + filename);
+        ArgumentCaptor<Map<String, Object>> messageCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(notificationFactory).createBuilder();
+        Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingCreated");
+        Mockito.verify(notificationBuilder).metaType(HttpMimeType.JSON);
+        Mockito.verify(notificationBuilder).message(messageCaptor.capture());
+        Mockito.verify(notificationBuilder).build();
+        Mockito.verify(notification).send();
+
+        MatcherAssert.assertThat(
+                messageCaptor.getValue(),
+                Matchers.equalTo(
+                        Map.of(
+                                "recording",
+                                recordingInfo,
+                                "target",
+                                RecordingArchiveHelper.UPLOADED_RECORDINGS_SUBDIRECTORY)));
+    }
+
+    @Test
+    void shouldHandleRecordingUploadRequestWithLabels() throws Exception {
+        String basename = "localhost_test_20191219T213834Z";
+        String filename = basename + ".jfr";
+        String savePath = "/some/path/";
+        Map<String, String> labels = Map.of("key", "value", "key1", "value1");
+        Metadata metadata = new Metadata(labels);
+
+        RoutingContext ctx = mock(RoutingContext.class);
+
+        when(authManager.validateHttpHeader(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        attrs.add("labels", labels.toString());
+        Mockito.when(req.formAttributes()).thenReturn(attrs);
+
+        Mockito.when(recordingMetadataManager.parseRecordingLabels(labels.toString()))
+                .thenReturn(labels);
+
+        when(ctx.request()).thenReturn(req);
+
+        when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
+
+        FileUpload upload = mock(FileUpload.class);
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        when(upload.name()).thenReturn("recording");
+        when(upload.fileName()).thenReturn(filename);
+        when(upload.uploadedFileName()).thenReturn("foo");
+
+        Path filePath = mock(Path.class);
+        when(filePath.toString()).thenReturn(savePath + filename);
+        Path specificRecordingsPath = mock(Path.class);
+        when(recordingsPath.resolve(Mockito.anyString())).thenReturn(specificRecordingsPath);
+        when(specificRecordingsPath.resolve(filename)).thenReturn(filePath);
+
+        io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(vertxFs);
+
+        doAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        })
+                .when(vertx)
+                .executeBlocking(any(Handler.class), any(Handler.class));
+
+        when(cryoFs.exists(specificRecordingsPath)).thenReturn(true);
+
+        when(vertxFs.exists(Mockito.eq(savePath + filename), any(Handler.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(1);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return false;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        });
+
+        when(vertxFs.move(Mockito.eq("foo"), Mockito.eq(savePath + filename), any(Handler.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Handler<AsyncResult<Boolean>> handler = invocation.getArgument(2);
+                            handler.handle(
+                                    new AsyncResult<>() {
+                                        @Override
+                                        public Boolean result() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public Throwable cause() {
+                                            return null;
+                                        }
+
+                                        @Override
+                                        public boolean succeeded() {
+                                            return true;
+                                        }
+
+                                        @Override
+                                        public boolean failed() {
+                                            return false;
+                                        }
+                                    });
+
+                            return null;
+                        });
+
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+        when(rep.putHeader(Mockito.any(CharSequence.class), Mockito.anyString())).thenReturn(rep);
+
+        when(webServer.getArchivedDownloadURL(Mockito.anyString()))
+                .then(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return "/some/download/path/" + invocation.getArgument(0);
+                            }
+                        });
+        when(webServer.getArchivedReportURL(Mockito.anyString()))
+                .then(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return "/some/report/path/" + invocation.getArgument(0);
+                            }
+                        });
+
+        Mockito.when(recordingMetadataManager.setRecordingMetadata(filename, metadata))
+                .thenReturn(CompletableFuture.completedFuture(metadata));
+
+        handler.handle(ctx);
+
+        InOrder inOrder = Mockito.inOrder(rep);
+        inOrder.verify(rep).putHeader(HttpHeaders.CONTENT_TYPE, HttpMimeType.JSON.mime());
+        inOrder.verify(rep).end(gson.toJson(Map.of("name", filename, "metadata", metadata)));
+
+        ArchivedRecordingInfo recordingInfo =
+                new ArchivedRecordingInfo(
+                        "archive",
+                        filename,
+                        "/some/download/path/" + filename,
+                        "/some/report/path/" + filename,
+                        metadata);
         ArgumentCaptor<Map<String, Object>> messageCaptor = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("ArchivedRecordingCreated");
@@ -452,6 +636,52 @@ class RecordingsPostHandlerTest {
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
         MatcherAssert.assertThat(
                 ex.getPayload(), Matchers.equalTo("Incorrect recording file name pattern"));
+
+        verify(vertxFs).deleteBlocking(Path.of(savePath, "file-uploads", "foo").toString());
+    }
+
+    @Test
+    void shouldHandleInvalidLabels() {
+
+        String basename = "localhost_test_20191219T213834Z";
+        String filename = basename + ".jfr";
+        String savePath = "/some/path/";
+        String labels = "invalid";
+
+        RoutingContext ctx = mock(RoutingContext.class);
+
+        when(authManager.validateHttpHeader(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(req);
+        HttpServerResponse rep = mock(HttpServerResponse.class);
+        when(ctx.response()).thenReturn(rep);
+        when(rep.putHeader(Mockito.any(CharSequence.class), Mockito.anyString())).thenReturn(rep);
+
+        when(cryoFs.isDirectory(recordingsPath)).thenReturn(true);
+
+        FileUpload upload = mock(FileUpload.class);
+        when(ctx.fileUploads()).thenReturn(Set.of(upload));
+        when(upload.name()).thenReturn("recording");
+        when(upload.fileName()).thenReturn(filename);
+        when(upload.uploadedFileName()).thenReturn("foo");
+
+        when(recordingsPath.resolve("file-uploads")).thenReturn(Path.of(savePath, "file-uploads"));
+
+        io.vertx.core.file.FileSystem vertxFs = mock(io.vertx.core.file.FileSystem.class);
+        when(vertx.fileSystem()).thenReturn(vertxFs);
+
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        attrs.add("labels", labels);
+        Mockito.when(req.formAttributes()).thenReturn(attrs);
+
+        Mockito.doThrow(new IllegalArgumentException())
+                .when(recordingMetadataManager)
+                .parseRecordingLabels(labels);
+
+        HttpException ex = Assertions.assertThrows(HttpException.class, () -> handler.handle(ctx));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        MatcherAssert.assertThat(ex.getPayload(), Matchers.equalTo("Invalid labels"));
 
         verify(vertxFs).deleteBlocking(Path.of(savePath, "file-uploads", "foo").toString());
     }


### PR DESCRIPTION
Fixes [#1045](https://github.com/cryostatio/cryostat/issues/1045)

The labels are set to the archived recording when "metadata" in JSON (e.g.: `{"reason":"test","reason1":"test1"}`) containing the labels is sent along to the uploaded file. 


