### PR TITLE
fix(rules): automatically start rules on jmx credentials change

### DIFF
--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -424,8 +424,6 @@ public class CredentialsManager
     }
 
     public enum CredentialsEvent implements EventType {
-        ADDED,
-        REMOVED,
-        ;
+        ADDED;
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -178,9 +178,8 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                 switch (event.getEventType()) {
                     case ADDED:
                         try {
-                            Set<ServiceRef> servicesSet =
-                                    credentialsManager.resolveMatchingTargets(event.getPayload());
-                            for (ServiceRef servicesRef : servicesSet) {
+                            for (ServiceRef servicesRef :
+                                    credentialsManager.resolveMatchingTargets(event.getPayload())) {
                                 registry.getRules(servicesRef)
                                         .forEach(rule -> activate(rule, servicesRef));
                             }


### PR DESCRIPTION
Fixes [#1041](https://github.com/cryostatio/cryostat/issues/1041)

Created a new event listener in the `RuleProcessor` to activate the rules of the targets that matches the expression of the JMX auth credential. 