### PR TITLE
fix(rules): correct archive scanning on startup

### DIFF
--- a/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
+++ b/src/main/java/io/cryostat/rules/PeriodicArchiverFactory.java
@@ -44,7 +44,6 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.recordings.RecordingArchiveHelper;
 
-import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.lang3.tuple.Pair;
 
 class PeriodicArchiverFactory {
@@ -60,15 +59,13 @@ class PeriodicArchiverFactory {
             CredentialsManager credentialsManager,
             Rule rule,
             RecordingArchiveHelper recordingArchiveHelper,
-            Function<Pair<ServiceRef, Rule>, Void> failureNotifier,
-            Base32 base32) {
+            Function<Pair<ServiceRef, Rule>, Void> failureNotifier) {
         return new PeriodicArchiver(
                 serviceRef,
                 credentialsManager,
                 rule,
                 recordingArchiveHelper,
                 failureNotifier,
-                logger,
-                base32);
+                logger);
     }
 }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -76,7 +76,6 @@ import io.cryostat.util.events.EventListener;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
-import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDiscoveryEvent> {
@@ -91,7 +90,6 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
     private final RecordingMetadataManager metadataManager;
     private final PeriodicArchiverFactory periodicArchiverFactory;
     private final Logger logger;
-    private final Base32 base32;
 
     private final Map<Pair<ServiceRef, Rule>, Set<Long>> tasks;
 
@@ -106,8 +104,7 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
             RecordingTargetHelper recordingTargetHelper,
             RecordingMetadataManager metadataManager,
             PeriodicArchiverFactory periodicArchiverFactory,
-            Logger logger,
-            Base32 base32) {
+            Logger logger) {
         this.vertx = vertx;
         this.platformClient = platformClient;
         this.registry = registry;
@@ -119,7 +116,6 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
         this.metadataManager = metadataManager;
         this.periodicArchiverFactory = periodicArchiverFactory;
         this.logger = logger;
-        this.base32 = base32;
         this.tasks = new HashMap<>();
 
         this.registry.addListener(this.ruleListener());
@@ -250,8 +246,7 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                                                 credentialsManager,
                                                 rule,
                                                 recordingArchiveHelper,
-                                                this::archivalFailureHandler,
-                                                base32);
+                                                this::archivalFailureHandler);
                                 Pair<ServiceRef, Rule> key = Pair.of(serviceRef, rule);
                                 Set<Long> ids = tasks.computeIfAbsent(key, k -> new HashSet<>());
                                 long initialTask =

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -69,7 +69,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
-import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
 
 @Module
@@ -122,8 +121,7 @@ public abstract class RulesModule {
             RecordingTargetHelper recordingTargetHelper,
             RecordingMetadataManager metadataManager,
             PeriodicArchiverFactory periodicArchiverFactory,
-            Logger logger,
-            Base32 base32) {
+            Logger logger) {
         return new RuleProcessor(
                 vertx,
                 storage,
@@ -135,8 +133,7 @@ public abstract class RulesModule {
                 recordingTargetHelper,
                 metadataManager,
                 periodicArchiverFactory,
-                logger,
-                base32);
+                logger);
     }
 
     @Provides

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -70,7 +70,6 @@ import io.cryostat.util.events.EventListener;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -101,7 +100,6 @@ class RuleProcessorTest {
     @Mock RecordingMetadataManager metadataManager;
     @Mock PeriodicArchiverFactory periodicArchiverFactory;
     @Mock Logger logger;
-    @Mock Base32 base32;
 
     @Mock JFRConnection connection;
     @Mock IFlightRecorderService service;
@@ -121,8 +119,7 @@ class RuleProcessorTest {
                         recordingTargetHelper,
                         metadataManager,
                         periodicArchiverFactory,
-                        logger,
-                        base32);
+                        logger);
     }
 
     @Test
@@ -197,7 +194,6 @@ class RuleProcessorTest {
         PeriodicArchiver periodicArchiver = Mockito.mock(PeriodicArchiver.class);
         Mockito.when(
                         periodicArchiverFactory.create(
-                                Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -361,7 +357,6 @@ class RuleProcessorTest {
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
-                                Mockito.any(),
                                 Mockito.any()))
                 .thenReturn(periodicArchiver);
 
@@ -377,8 +372,7 @@ class RuleProcessorTest {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
-                        functionCaptor.capture(),
-                        Mockito.any());
+                        functionCaptor.capture());
         Function<Pair<ServiceRef, Rule>, Void> failureFunction = functionCaptor.getValue();
         Mockito.verify(vertx, Mockito.never()).cancelTimer(MockVertx.TIMER_ID);
 


### PR DESCRIPTION
Fixes #1087

I think this bug occurred in #1047 , looking at context like this: https://github.com/cryostatio/cryostat/pull/1047/files#diff-763906edf56f8525d84844f8e2b01a98e15bf4afe7cb959159b3a378e448fd17L275

but I haven't bisected the commit history to verify this. Just a hunch, but the fix seems simple enough anyway.