### PR TITLE
fix(rules): handle deletion async

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandler.java
@@ -177,7 +177,7 @@ class RuleDeleteHandler extends AbstractV2RequestHandler<List<RuleDeleteHandler.
                                 return null;
                             });
                 } catch (Exception e) {
-                    logger.error(new ApiException(500, e));
+                    logger.error(e);
                     CleanupFailure failure = new CleanupFailure();
                     failure.ref = ref;
                     failure.message = e.getMessage();
@@ -185,11 +185,7 @@ class RuleDeleteHandler extends AbstractV2RequestHandler<List<RuleDeleteHandler.
                 }
             }
         }
-        if (failures.size() == 0) {
-            return new IntermediateResponse<List<CleanupFailure>>().body(null);
-        } else {
-            return new IntermediateResponse<List<CleanupFailure>>().statusCode(500).body(failures);
-        }
+        return new IntermediateResponse<List<CleanupFailure>>().body(null);
     }
 
     @SuppressFBWarnings("URF_UNREAD_FIELD")

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
@@ -47,6 +47,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.MainModule;
+import io.cryostat.MockVertx;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.log.Logger;
@@ -65,6 +66,7 @@ import io.cryostat.rules.RuleRegistry;
 
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -81,6 +83,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RuleDeleteHandlerTest {
 
     RuleDeleteHandler handler;
+    Vertx vertx = MockVertx.vertx();
     @Mock AuthManager auth;
     @Mock RuleRegistry registry;
     @Mock TargetConnectionManager targetConnectionManager;
@@ -110,6 +113,7 @@ class RuleDeleteHandlerTest {
         Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new RuleDeleteHandler(
+                        vertx,
                         auth,
                         registry,
                         targetConnectionManager,

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
@@ -43,24 +43,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
-import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
-
 import io.cryostat.MainModule;
 import io.cryostat.MockVertx;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnection;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
-import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.platform.ServiceRef;
+import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.rules.Rule;
 import io.cryostat.rules.RuleRegistry;
 
@@ -86,7 +82,7 @@ class RuleDeleteHandlerTest {
     Vertx vertx = MockVertx.vertx();
     @Mock AuthManager auth;
     @Mock RuleRegistry registry;
-    @Mock TargetConnectionManager targetConnectionManager;
+    @Mock RecordingTargetHelper recordingTargetHelper;
     @Mock DiscoveryStorage storage;
     @Mock CredentialsManager credentialsManager;
     @Mock NotificationFactory notificationFactory;
@@ -116,7 +112,7 @@ class RuleDeleteHandlerTest {
                         vertx,
                         auth,
                         registry,
-                        targetConnectionManager,
+                        recordingTargetHelper,
                         storage,
                         credentialsManager,
                         notificationFactory,
@@ -206,6 +202,13 @@ class RuleDeleteHandlerTest {
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
             MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(404));
+
+            Mockito.verify(vertx, Mockito.never()).executeBlocking(Mockito.any());
+            Mockito.verify(registry, Mockito.never()).deleteRule(Mockito.any(Rule.class));
+            Mockito.verify(registry, Mockito.never()).deleteRule(Mockito.anyString());
+            Mockito.verify(registry, Mockito.never()).applies(Mockito.any(), Mockito.any());
+            Mockito.verify(recordingTargetHelper, Mockito.never())
+                    .stopRecording(Mockito.any(), Mockito.any());
         }
 
         @Test
@@ -233,12 +236,17 @@ class RuleDeleteHandlerTest {
 
             FlightRecorderException exception =
                     new FlightRecorderException(new Exception("test message"));
-            Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
+            Mockito.when(recordingTargetHelper.stopRecording(Mockito.any(), Mockito.any()))
                     .thenThrow(exception);
 
             IntermediateResponse<Void> response = handler.handle(params);
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
 
+            Mockito.verify(vertx, Mockito.times(2)).executeBlocking(Mockito.any());
+            Mockito.verify(registry).deleteRule(rule);
+            Mockito.verify(registry).applies(rule, serviceRef);
+            Mockito.verify(recordingTargetHelper)
+                    .stopRecording(Mockito.any(), Mockito.eq(rule.getRecordingName()));
             Mockito.verify(logger).error(exception);
         }
 
@@ -257,29 +265,17 @@ class RuleDeleteHandlerTest {
                             .build();
             Mockito.when(registry.hasRuleByName(testRuleName)).thenReturn(true);
             Mockito.when(registry.getRule(testRuleName)).thenReturn(Optional.of(rule));
-            Mockito.when(registry.applies(Mockito.any(), Mockito.any())).thenReturn(true);
 
-            ServiceRef serviceRef =
-                    new ServiceRef(
-                            new URI("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
-                            "io.cryostat.Cryostat");
-            Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of(serviceRef));
-
-            JFRConnection connection = Mockito.mock(JFRConnection.class);
-            Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
-                    .thenAnswer(
-                            arg0 ->
-                                    ((TargetConnectionManager.ConnectedTask<Object>)
-                                                    arg0.getArgument(1))
-                                            .execute(connection));
-
-            IFlightRecorderService service = Mockito.mock(IFlightRecorderService.class);
-            Mockito.when(connection.getService()).thenReturn(service);
-
-            Mockito.when(service.getAvailableRecordings()).thenReturn(List.of());
+            Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
 
             IntermediateResponse<Void> response = handler.handle(params);
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+            Mockito.verify(vertx, Mockito.times(1)).executeBlocking(Mockito.any());
+            Mockito.verify(registry).deleteRule(rule);
+            Mockito.verify(registry, Mockito.never()).applies(Mockito.any(), Mockito.any());
+            Mockito.verify(recordingTargetHelper, Mockito.never())
+                    .stopRecording(Mockito.any(), Mockito.eq(rule.getRecordingName()));
         }
 
         @Test
@@ -305,74 +301,14 @@ class RuleDeleteHandlerTest {
                             "io.cryostat.Cryostat");
             Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of(serviceRef));
 
-            JFRConnection connection = Mockito.mock(JFRConnection.class);
-            Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
-                    .thenAnswer(
-                            arg0 ->
-                                    ((TargetConnectionManager.ConnectedTask<Object>)
-                                                    arg0.getArgument(1))
-                                            .execute(connection));
-
-            IFlightRecorderService service = Mockito.mock(IFlightRecorderService.class);
-            Mockito.when(connection.getService()).thenReturn(service);
-
-            IRecordingDescriptor recording = Mockito.mock(IRecordingDescriptor.class);
-            Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(recording));
-            Mockito.when(recording.getName()).thenReturn(rule.getRecordingName());
-
             IntermediateResponse<Void> response = handler.handle(params);
             MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
 
-            Mockito.verify(service).stop(recording);
-            Mockito.verify(service, Mockito.never()).close(recording);
-        }
-
-        @Test
-        void shouldRespondWith200AfterUnsuccessfulCleanup() throws Exception {
-            Mockito.when(params.getPathParams()).thenReturn(Map.of("name", testRuleName));
-            MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
-            queryParams.set("clean", "true");
-            Mockito.when(params.getQueryParams()).thenReturn(queryParams);
-
-            Rule rule =
-                    new Rule.Builder()
-                            .name(testRuleName)
-                            .matchExpression("true")
-                            .eventSpecifier("template=Continuous")
-                            .build();
-            Mockito.when(registry.hasRuleByName(testRuleName)).thenReturn(true);
-            Mockito.when(registry.getRule(testRuleName)).thenReturn(Optional.of(rule));
-            Mockito.when(registry.applies(Mockito.any(), Mockito.any())).thenReturn(true);
-
-            ServiceRef serviceRef =
-                    new ServiceRef(
-                            new URI("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
-                            "io.cryostat.Cryostat");
-            Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of(serviceRef));
-
-            JFRConnection connection = Mockito.mock(JFRConnection.class);
-            Mockito.when(targetConnectionManager.executeConnectedTask(Mockito.any(), Mockito.any()))
-                    .thenAnswer(
-                            arg0 ->
-                                    ((TargetConnectionManager.ConnectedTask<Object>)
-                                                    arg0.getArgument(1))
-                                            .execute(connection));
-
-            IFlightRecorderService service = Mockito.mock(IFlightRecorderService.class);
-            Mockito.when(connection.getService()).thenReturn(service);
-
-            org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException exception =
-                    new org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException("test message");
-            Mockito.doThrow(exception).when(service).stop(Mockito.any());
-
-            IRecordingDescriptor recording = Mockito.mock(IRecordingDescriptor.class);
-            Mockito.when(service.getAvailableRecordings()).thenReturn(List.of(recording));
-            Mockito.when(recording.getName()).thenReturn(rule.getRecordingName());
-
-            IntermediateResponse<Void> response = handler.handle(params);
-            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
-
-            Mockito.verify(logger).error(exception);
+            Mockito.verify(vertx, Mockito.times(2)).executeBlocking(Mockito.any());
+            Mockito.verify(registry).deleteRule(rule);
+            Mockito.verify(registry).applies(Mockito.any(), Mockito.any());
+            Mockito.verify(recordingTargetHelper)
+                    .stopRecording(Mockito.any(), Mockito.eq(rule.getRecordingName()));
         }
     }
 }


### PR DESCRIPTION
Fixes #1093

- ignore cleanup failures, always respond 200
- do not include cleanup failures in response body
- handle deletion cleanup async
- use RecordingTargetHelper to clean up

This change makes Automated Rule deletion happen asynchronously, similar to how Automated Rule activation is also asynchronous.

Prior to this change, creating an enabled Rule definition was a fast request that simply defined the Rule and returned. Any
recordings created by that rule were processed asynchronously and separately from the original request. Deleting a rule, on
the other hand, was synchronous - all matching targets would be tested again for rule applicability, and recordings would be
stopped on any matching targets. When all of those tasks were completed the deletion response would finally be sent back to the
requesting client, with a 500 status code indicating that at least one of those tasks failed and a 200 if everything succeeded.

With this change the deletion acts the same way as creation/activation. The rule definition deletion is the only thing blocked on
before the API response is sent to the client. If clean up is required then this is handled asynchronously in the background.

(Worth noting: Rule creation also used to be a synchronous request but was made async some time ago, and deletion was never updated the same way)