### PR TITLE
fix(discovery): leave Custom Targets enabled when builtins are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Cryostat can be configured via the following environment variables:
 * `CRYOSTAT_JDP_ADDRESS`: the JDP multicast address to send discovery packets. Defaults to `224.0.23.178`.
 * `CRYOSTAT_JDP_PORT`: the JDP multicast port to send discovery packets. Defaults to `7095`.
 * `CRYOSTAT_CONFIG_PATH`: the filesystem path for the configuration directory. Defaults to `/opt/cryostat.d/conf.d`.
-* `CRYOSTAT_DISABLE_BUILTIN_DISCOVERY`: set to `true` to disable built-in target discovery mechanisms (see `CRYOSTAT_PLATFORM`). This will still allow platform detection to automatically select an `AuthManager`. This is intended for use when Cryostat Discovery Plugins are the only desired mechanism for locating target applications. See #936 and [cryostat-agent](https://github.com/cryostatio/cryostat-agent). Defaults to `false`.
+* `CRYOSTAT_DISABLE_BUILTIN_DISCOVERY`: set to `true` to disable built-in target discovery mechanisms (see `CRYOSTAT_PLATFORM`). Custom Target "discovery" remains available, but discovery via JDP, Kubernetes API, or Kubernetes environment variable is disabled and ignored. This will still allow platform detection to automatically select an `AuthManager`. This is intended for use when Cryostat Discovery Plugins are the only desired mechanism for locating target applications. See #936 and [cryostat-agent](https://github.com/cryostatio/cryostat-agent). Defaults to `false`.
 
 #### Configuration for Automated Analysis Reports
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -23,14 +23,14 @@ runCryostat() {
     elif [ "$1" = "h2mem" ]; then
         JDBC_URL="jdbc:h2:mem:cryostat;DB_CLOSE_DELAY=-1;INIT=create domain if not exists jsonb as varchar"
         JDBC_DRIVER="org.h2.Driver"
-        JDBC_USERNAME="sa"
+        JDBC_USERNAME="cryostat"
         JDBC_PASSWORD=""
         HIBERNATE_DIALECT="org.hibernate.dialect.H2Dialect"
         HBM2DDL="create"
     else
         JDBC_URL="jdbc:h2:file:/opt/cryostat.d/conf.d/h2;INIT=create domain if not exists jsonb as varchar"
         JDBC_DRIVER="org.h2.Driver"
-        JDBC_USERNAME="sa"
+        JDBC_USERNAME="cryostat"
         JDBC_PASSWORD=""
         HIBERNATE_DIALECT="org.hibernate.dialect.H2Dialect"
         HBM2DDL="update"

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -51,6 +51,7 @@ import io.cryostat.platform.TargetDiscoveryEvent;
 import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.internal.CustomTargetPlatformClient;
 
+import dagger.Lazy;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 
@@ -60,7 +61,7 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
 
     private final DiscoveryStorage storage;
     private final Set<PlatformClient> platformClients;
-    private final PlatformClient customTargets;
+    private final Lazy<CustomTargetPlatformClient> customTargets;
     private final Environment env;
     private final NotificationFactory notificationFactory;
     private final Logger logger;
@@ -68,7 +69,7 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
     BuiltInDiscovery(
             DiscoveryStorage storage,
             Set<PlatformClient> platformClients,
-            CustomTargetPlatformClient customTargets,
+            Lazy<CustomTargetPlatformClient> customTargets,
             Environment env,
             NotificationFactory notificationFactory,
             Logger logger) {
@@ -83,7 +84,9 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
     @Override
     public void start(Promise<Void> start) {
         storage.addTargetDiscoveryListener(this);
-        (env.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY) ? Set.of(customTargets) : platformClients)
+        (env.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY)
+                        ? Set.of(customTargets.get())
+                        : platformClients)
                 .forEach(
                         platform -> {
                             logger.info(

--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -51,6 +51,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.discovery.AbstractNode;
+import io.cryostat.platform.internal.CustomTargetPlatformClient;
 import io.cryostat.util.PluggableTypeAdapter;
 
 import com.google.gson.Gson;
@@ -100,7 +101,7 @@ public abstract class DiscoveryModule {
     static BuiltInDiscovery provideBuiltInDiscovery(
             DiscoveryStorage storage,
             Set<PlatformClient> platformClients,
-            CustomTargetPlatformClient customTargets,
+            Lazy<CustomTargetPlatformClient> customTargets,
             Environment env,
             NotificationFactory notificationFactory,
             Logger logger) {

--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -100,10 +100,12 @@ public abstract class DiscoveryModule {
     static BuiltInDiscovery provideBuiltInDiscovery(
             DiscoveryStorage storage,
             Set<PlatformClient> platformClients,
+            CustomTargetPlatformClient customTargets,
             Environment env,
             NotificationFactory notificationFactory,
             Logger logger) {
-        return new BuiltInDiscovery(storage, platformClients, env, notificationFactory, logger);
+        return new BuiltInDiscovery(
+                storage, platformClients, customTargets, env, notificationFactory, logger);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/storage/StorageModule.java
+++ b/src/main/java/io/cryostat/storage/StorageModule.java
@@ -70,7 +70,8 @@ public abstract class StorageModule {
                         Variables.JDBC_URL,
                         "jdbc:h2:mem:cryostat;DB_CLOSE_DELAY=-1;INIT=create domain if not exists"
                                 + " jsonb as varchar"));
-        properties.put("jakarta.persistence.jdbc.user", env.getEnv(Variables.JDBC_USERNAME, "sa"));
+        properties.put("jakarta.persistence.jdbc.user", env.getEnv(Variables.JDBC_USERNAME,
+                    "cryostat"));
         properties.put(
                 "jakarta.persistence.jdbc.password", env.getEnv(Variables.JDBC_PASSWORD, ""));
         properties.put(

--- a/src/main/java/io/cryostat/storage/StorageModule.java
+++ b/src/main/java/io/cryostat/storage/StorageModule.java
@@ -70,8 +70,8 @@ public abstract class StorageModule {
                         Variables.JDBC_URL,
                         "jdbc:h2:mem:cryostat;DB_CLOSE_DELAY=-1;INIT=create domain if not exists"
                                 + " jsonb as varchar"));
-        properties.put("jakarta.persistence.jdbc.user", env.getEnv(Variables.JDBC_USERNAME,
-                    "cryostat"));
+        properties.put(
+                "jakarta.persistence.jdbc.user", env.getEnv(Variables.JDBC_USERNAME, "cryostat"));
         properties.put(
                 "jakarta.persistence.jdbc.password", env.getEnv(Variables.JDBC_PASSWORD, ""));
         properties.put(


### PR DESCRIPTION
Fixes #1113

- use non-sa user by default for h2 setups
- fix(discovery): leave Custom Targets enabled when built-ins are disabled
- refactor to clean up instanceof check

`- use non-sa user by default for h2 setups` is not directly related to this PR but comes from discussions here:
https://github.com/cryostatio/cryostat-operator/pull/474#discussion_r994036680

In describing how things worked I realized I had left `sa` (system administrator) as the default JDBC user, which was not intentional and is not necessary. Even for the H2 database scenarios,
Cryostat should not require the use of a system administrator account.

To test, try `CRYOSTAT_DISABLE_BUILTIN_DISCOVERY=true sh smoketest.sh` before and after this PR. In either case, JDP targets should not be discovered, only the quarkus-test targets that self-publish via the discovery plugin API. With this PR applied you should also be able to define custom targets either through the web-client or by API request, whereas without this PR applied this functionality will be broken and defining a custom target will appear to be a no-op (200 success status code but not notification and no custom target visible in UI).
