### PR TITLE
test(itest): reduce JDP wait times

### DIFF
--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -38,9 +38,6 @@ STARTFLAGS=(
     "failsafe:integration-test"
     "failsafe:verify"
     "-DfailIfNoTests=true"
-    "-Dcryostat.itest.jdp.poll.period=2500"
-    "-Dcryostat.itest.jdp.poll.count=1"
-    "-Dcryostat.itest.jdp.poll.timeout=17500"
 )
 
 if [ -n "$2" ]; then

--- a/src/test/java/itest/bases/ExternalTargetsTest.java
+++ b/src/test/java/itest/bases/ExternalTargetsTest.java
@@ -48,11 +48,11 @@ public abstract class ExternalTargetsTest extends StandardSelfTest {
     protected static final String FIB_DEMO_IMAGESPEC = "quay.io/andrewazores/vertx-fib-demo:0.8.0";
 
     static final int DISCOVERY_POLL_PERIOD_MS =
-            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.period", "7500"));
+            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.period", "2500"));
     static final int STABILITY_COUNT =
-            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.count", "3"));
+            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.count", "1"));
     static final int DISCOVERY_BASE_MS =
-            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.timeout", "30000"));
+            Integer.parseInt(System.getProperty("cryostat.itest.jdp.poll.timeout", "20000"));
     static final int DISCOVERY_TIMEOUT_MS =
             DISCOVERY_BASE_MS + (STABILITY_COUNT * DISCOVERY_POLL_PERIOD_MS);
 


### PR DESCRIPTION
Related to #1068

default values have been thoroughly tested over a long time and appear to be overly cautious. JDP "settling" doesn't seem to happen and is more likely to indicate a broken implementation than a natural effect.
