### PR TITLE
build(pom): use different property for jasypt-hibernate5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
   <com.nimbusds.jose.jwt.version>9.16.1</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.69</org.bouncycastle.version>
   <org.jasypt.version>1.9.3</org.jasypt.version>
+  <org.jasypt-hibernate5.version>1.9.3</org.jasypt-hibernate5.version>
   <org.slf4j.version>1.7.30</org.slf4j.version>
   <com.google.code.gson.version>2.8.9</com.google.code.gson.version>
   <com.github.ben-manes.caffeine.version>3.0.1</com.github.ben-manes.caffeine.version>
@@ -195,7 +196,7 @@
   <dependency>
     <groupId>org.jasypt</groupId>
     <artifactId>jasypt-hibernate5</artifactId>
-    <version>${org.jasypt.version}</version>
+    <version>${org.jasypt-hibernate5.version}</version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
For downstream builds, we may end up with different versions of jasypt and jasypt-hibernate5. We need separate properties for them.

Related to: #1118 