### PR TITLE
fix(archives): fixed archive migration and metadata handling from all-archives view

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingsModule.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsModule.java
@@ -216,6 +216,7 @@ public abstract class RecordingsModule {
             @Named(Variables.JMX_CONNECTION_TIMEOUT) long connectionTimeoutSeconds,
             CredentialsManager credentialsManager,
             DiscoveryStorage storage,
+            Base32 base32,
             Logger logger) {
         return new JvmIdHelper(
                 targetConnectionManager,
@@ -224,6 +225,7 @@ public abstract class RecordingsModule {
                 connectionTimeoutSeconds,
                 ForkJoinPool.commonPool(),
                 Scheduler.systemScheduler(),
+                base32,
                 logger);
     }
 }

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -131,6 +131,25 @@ class RecordingArchiveHelperTest {
                 .thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
+        lenient()
+                .when(jvmIdHelper.jvmIdToSubdirectoryName(Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return invocation.getArgument(0);
+                            }
+                        });
+        lenient()
+                .when(jvmIdHelper.subdirectoryNameToJvmId(Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return invocation.getArgument(0);
+                            }
+                        });
+
         this.recordingArchiveHelper =
                 new RecordingArchiveHelper(
                         fs,
@@ -226,7 +245,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
 
         Instant now = Instant.now();
         Mockito.when(clock.now()).thenReturn(now);
@@ -304,7 +322,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
 
         Instant now = Instant.now();
         Mockito.when(clock.now()).thenReturn(now);
@@ -399,7 +416,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
         Mockito.when(connection.getHost()).thenReturn("some-hostname.local");
 
         Instant now = Instant.now();
@@ -479,7 +495,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
         Mockito.when(connection.getHost()).thenReturn("some-hostname.local");
 
         Instant now = Instant.now();
@@ -566,7 +581,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
 
         Instant now = Instant.now();
         Mockito.when(clock.now()).thenReturn(now);
@@ -636,7 +650,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
 
         Instant now = Instant.now();
         Mockito.when(clock.now()).thenReturn(now);
@@ -703,7 +716,6 @@ class RecordingArchiveHelperTest {
         Mockito.when(connection.getJMXURL())
                 .thenReturn(
                         (new JMXServiceURL("service:jmx:rmi:///jndi/rmi://cryostat:9092/jmxrmi")));
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn("encodedServiceUri");
 
         Instant now = Instant.now();
         Mockito.when(clock.now()).thenReturn(now);
@@ -985,7 +997,6 @@ class RecordingArchiveHelperTest {
                 .when(jvmIdHelper.getJvmId(Mockito.eq(targetIdUploads)))
                 .thenReturn(targetIdUploads);
         lenient().when(jvmIdHelper.getJvmId(Mockito.eq(targetIdTarget))).thenReturn(targetIdTarget);
-        Mockito.when(base32.encodeAsString(Mockito.any())).thenReturn(targetIdTarget);
         Path specificRecordingsPath = Path.of("/some/path/");
         Mockito.when(archivedRecordingsPath.resolve(Mockito.anyString()))
                 .thenReturn(specificRecordingsPath);
@@ -1013,6 +1024,15 @@ class RecordingArchiveHelperTest {
 
         Mockito.when(recordingMetadataManager.getMetadata(Mockito.any(), Mockito.anyString()))
                 .thenReturn(new Metadata());
+
+        Mockito.when(jvmIdHelper.jvmIdToSubdirectoryName(Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return invocation.getArgument(0);
+                            }
+                        });
 
         // Test get recordings from uploads
         List<ArchivedRecordingInfo> result =
@@ -1064,10 +1084,6 @@ class RecordingArchiveHelperTest {
                 .thenReturn(Path.of(subdirectories.get(1)));
         Mockito.when(fs.listDirectoryChildren(Path.of(subdirectories.get(1))))
                 .thenReturn(List.of("123recording", "connectUrl"));
-
-        Mockito.when(base32.decode(Mockito.anyString()))
-                .thenReturn("encodedJvmIdA".getBytes())
-                .thenReturn("encodedJvmId123".getBytes());
 
         BufferedReader reader = Mockito.mock(BufferedReader.class);
         Mockito.when(fs.readFile(Mockito.any(Path.class))).thenReturn(reader);

--- a/src/test/java/io/cryostat/recordings/RecordingMetadataManagerTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingMetadataManagerTest.java
@@ -79,7 +79,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingMetadataManagerTest {
@@ -121,6 +123,15 @@ public class RecordingMetadataManagerTest {
                 .thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
+        lenient()
+                .when(jvmIdHelper.jvmIdToSubdirectoryName(Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<String>() {
+                            @Override
+                            public String answer(InvocationOnMock invocation) throws Throwable {
+                                return invocation.getArgument(0);
+                            }
+                        });
 
         this.recordingMetadataManager =
                 new RecordingMetadataManager(


### PR DESCRIPTION
Fixes #1135

I think this needs documentation since users will wonder where their recordings went after migrating from 2.1.0 to 2.2.0.