### PR TITLE
build(jib): upgrade jib plugin to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   <org.codehaus.mojo.build.helper.plugin.version>3.3.0</org.codehaus.mojo.build.helper.plugin.version>
   <com.mycila.license.maven.plugin.version>4.0</com.mycila.license.maven.plugin.version>
   <org.owasp.dependency.check.version>6.1.5</org.owasp.dependency.check.version>
-  <com.google.cloud.tools.jib.maven.plugin.version>3.1.1</com.google.cloud.tools.jib.maven.plugin.version>
+  <com.google.cloud.tools.jib.maven.plugin.version>3.3.0</com.google.cloud.tools.jib.maven.plugin.version>
 
   <com.google.dagger.version>2.34.1</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>


### PR DESCRIPTION
Fixes #1128 

Upgraded `jib` to latest version (i.e. `3.3.0`). There is a new [feature](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/CHANGELOG.md#added-3) specified multi-platform build, which is pretty interesting but not sure we need it.