### PR TITLE
fix(credentials): automatically use stored JMX credentials in V2 API handlers

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/AbstractAuthenticatedRequestHandler.java
@@ -121,7 +121,7 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
     protected ConnectionDescriptor getConnectionDescriptorFromContext(RoutingContext ctx) {
         String targetId = ctx.pathParam("targetId");
         try {
-            Credentials credentials = credentialsManager.getCredentialsByTargetId(targetId);
+            Credentials credentials;
             if (ctx.request().headers().contains(JMX_AUTHORIZATION_HEADER)) {
                 String proxyAuth = ctx.request().getHeader(JMX_AUTHORIZATION_HEADER);
                 Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
@@ -156,6 +156,8 @@ public abstract class AbstractAuthenticatedRequestHandler implements RequestHand
                             427, "Unrecognized " + JMX_AUTHORIZATION_HEADER + " credential format");
                 }
                 credentials = new Credentials(parts[0], parts[1]);
+            } else {
+                credentials = credentialsManager.getCredentialsByTargetId(targetId);
             }
             return new ConnectionDescriptor(targetId, credentials);
         } catch (ScriptException e) {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/JvmIdGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/JvmIdGetHandler.java
@@ -62,7 +62,6 @@ class JvmIdGetHandler extends AbstractV2RequestHandler<String> {
     static final String PATH = "targets/:targetId";
 
     private final TargetConnectionManager targetConnectionManager;
-    private final CredentialsManager credentialsManager;
 
     @Inject
     JvmIdGetHandler(
@@ -70,8 +69,7 @@ class JvmIdGetHandler extends AbstractV2RequestHandler<String> {
             Gson gson,
             CredentialsManager credentialsManager,
             TargetConnectionManager targetConnectionManager) {
-        super(auth, gson);
-        this.credentialsManager = credentialsManager;
+        super(auth, credentialsManager, gson);
         this.targetConnectionManager = targetConnectionManager;
     }
 
@@ -109,12 +107,6 @@ class JvmIdGetHandler extends AbstractV2RequestHandler<String> {
     public IntermediateResponse<String> handle(RequestParameters params) throws Exception {
         ConnectionDescriptor cd = getConnectionDescriptorFromParams(params);
         try {
-            if (cd.getCredentials().isEmpty()) {
-                cd =
-                        new ConnectionDescriptor(
-                                cd.getTargetId(),
-                                credentialsManager.getCredentialsByTargetId(cd.getTargetId()));
-            }
             String jvmId =
                     this.targetConnectionManager.executeConnectedTask(
                             cd,

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ProbeTemplateGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeTemplate;
 import io.cryostat.core.sys.FileSystem;
@@ -68,10 +69,11 @@ public class ProbeTemplateGetHandler extends AbstractV2RequestHandler<List<Probe
     @Inject
     ProbeTemplateGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             LocalProbeTemplateService probeTemplateService,
             FileSystem fs,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.probeTemplateService = probeTemplateService;
         this.fs = fs;
         this.gson = gson;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingDeleteFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingDeleteFromPathHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -67,8 +68,11 @@ public class RecordingDeleteFromPathHandler extends AbstractV2RequestHandler<Voi
 
     @Inject
     RecordingDeleteFromPathHandler(
-            AuthManager auth, Gson gson, RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            Gson gson,
+            RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth, credentialsManager, gson);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingDeleteHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -66,8 +67,11 @@ public class RecordingDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     @Inject
     RecordingDeleteHandler(
-            AuthManager auth, Gson gson, RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            Gson gson,
+            RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth, credentialsManager, gson);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingGetHandler.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -68,8 +69,11 @@ public class RecordingGetHandler extends AbstractV2RequestHandler<Path> {
 
     @Inject
     RecordingGetHandler(
-            AuthManager auth, Gson gson, RecordingArchiveHelper recordingArchiveHelper) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            Gson gson,
+            RecordingArchiveHelper recordingArchiveHelper) {
+        super(auth, credentialsManager, gson);
         this.recordingArchiveHelper = recordingArchiveHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostFromPathHandler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -70,10 +71,11 @@ public class RecordingMetadataLabelsPostFromPathHandler extends AbstractV2Reques
     @Inject
     RecordingMetadataLabelsPostFromPathHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             RecordingArchiveHelper recordingArchiveHelper,
             RecordingMetadataManager recordingMetadataManager) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.recordingMetadataManager = recordingMetadataManager;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.security.ResourceAction;
@@ -70,10 +71,11 @@ public class RecordingMetadataLabelsPostHandler extends AbstractV2RequestHandler
     @Inject
     RecordingMetadataLabelsPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             RecordingArchiveHelper recordingArchiveHelper,
             RecordingMetadataManager recordingMetadataManager) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.recordingMetadataManager = recordingMetadataManager;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
@@ -86,12 +87,13 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
     @Inject
     RecordingUploadPostFromPathHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.env = env;
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
@@ -86,12 +87,13 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
     @Inject
     RecordingUploadPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.env = env;
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathHandler.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportGenerationException;
 import io.cryostat.net.reports.ReportService;
@@ -76,11 +77,12 @@ public class ReportGetFromPathHandler extends AbstractV2RequestHandler<Path> {
     @Inject
     ReportGetFromPathHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             ReportService reportService,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.reportService = reportService;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetHandler.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportGenerationException;
 import io.cryostat.net.reports.ReportService;
@@ -78,12 +79,13 @@ public class ReportGetHandler extends AbstractV2RequestHandler<Path> {
     @Inject
     ReportGetHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             ReportService reportService,
             RecordingArchiveHelper recordingArchiveHelper,
             @Named(ReportsModule.REPORT_GENERATION_TIMEOUT_SECONDS)
                     long reportGenerationTimeoutSeconds) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.reportService = reportService;
         this.recordingArchiveHelper = recordingArchiveHelper;
         this.reportGenerationTimeoutSeconds = reportGenerationTimeoutSeconds;

--- a/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandler.java
@@ -46,6 +46,7 @@ import javax.inject.Inject;
 
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
@@ -75,11 +76,12 @@ public class TargetRecordingMetadataLabelsPostHandler extends AbstractV2RequestH
     @Inject
     TargetRecordingMetadataLabelsPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             TargetConnectionManager targetConnectionManager,
             RecordingTargetHelper recordingTargetHelper,
             RecordingMetadataManager recordingMetadataManager) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.targetConnectionManager = targetConnectionManager;
         this.recordingTargetHelper = recordingTargetHelper;
         this.recordingMetadataManager = recordingMetadataManager;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AbstractAssetJwtConsumingHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AbstractAssetJwtConsumingHandler.java
@@ -167,13 +167,14 @@ public abstract class AbstractAssetJwtConsumingHandler implements RequestHandler
             throws ParseException {
         String targetId = ctx.pathParam("targetId");
         Credentials credentials = null;
-        try {
-            credentials = credentialsManager.getCredentialsByTargetId(targetId);
-        } catch (ScriptException e) {
-            logger.error(e);
-        }
         String jmxauth = jwt.getJWTClaimsSet().getStringClaim(AssetJwtHelper.JMXAUTH_CLAIM);
-        if (jmxauth != null) {
+        if (jmxauth == null) {
+            try {
+                credentials = credentialsManager.getCredentialsByTargetId(targetId);
+            } catch (ScriptException e) {
+                logger.error(e);
+            }
+        } else {
             String c;
             try {
                 Matcher m =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandler.java
@@ -126,7 +126,7 @@ public abstract class AbstractV2RequestHandler<T> implements RequestHandler {
     protected ConnectionDescriptor getConnectionDescriptorFromParams(RequestParameters params) {
         String targetId = params.getPathParams().get("targetId");
         try {
-            Credentials credentials = credentialsManager.getCredentialsByTargetId(targetId);
+            Credentials credentials;
             if (params.getHeaders().contains(JMX_AUTHORIZATION_HEADER)) {
                 String proxyAuth = params.getHeaders().get(JMX_AUTHORIZATION_HEADER);
                 Matcher m = AUTH_HEADER_PATTERN.matcher(proxyAuth);
@@ -166,6 +166,8 @@ public abstract class AbstractV2RequestHandler<T> implements RequestHandler {
                         credentials = new Credentials(parts[0], parts[1]);
                     }
                 }
+            } else {
+                credentials = credentialsManager.getCredentialsByTargetId(targetId);
             }
             return new ConnectionDescriptor(targetId, credentials);
         } catch (ScriptException e) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
@@ -69,8 +70,9 @@ class ApiGetHandler extends AbstractV2RequestHandler<ApiGetHandler.ApiResponse> 
             Lazy<WebServer> webServer,
             Lazy<Set<RequestHandler>> handlers,
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.webServer = webServer;
         this.handlers = handlers;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AuthPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AuthPostHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.UnknownUserException;
 import io.cryostat.net.UserInfo;
@@ -59,8 +60,8 @@ import io.vertx.core.http.HttpMethod;
 class AuthPostHandler extends AbstractV2RequestHandler<UserInfo> {
 
     @Inject
-    protected AuthPostHandler(AuthManager auth, Gson gson) {
-        super(auth, gson);
+    protected AuthPostHandler(AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+        super(auth, credentialsManager, gson);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AuthTokenPostHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -70,11 +71,12 @@ class AuthTokenPostHandler extends AbstractV2RequestHandler<Map<String, String>>
     @Inject
     AuthTokenPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             AssetJwtHelper jwt,
             Lazy<WebServer> webServer,
             Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.jwt = jwt;
         this.webServer = webServer;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CertificatePostHandler.java
@@ -54,6 +54,7 @@ import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
@@ -81,12 +82,13 @@ class CertificatePostHandler extends AbstractV2RequestHandler<Path> {
     @Inject
     CertificatePostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Environment env,
             FileSystem fs,
             Gson gson,
             @Named("OutputStreamFunction") Function<File, FileOutputStream> outputStreamFunction,
             CertificateValidator certValidator) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.env = env;
         this.fs = fs;
         this.outputStreamFunction = outputStreamFunction;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CredentialDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CredentialDeleteHandler.java
@@ -57,7 +57,6 @@ import io.vertx.core.http.HttpMethod;
 
 class CredentialDeleteHandler extends AbstractV2RequestHandler<Void> {
 
-    private final CredentialsManager credentialsManager;
     private final NotificationFactory notificationFactory;
 
     @Inject
@@ -66,8 +65,7 @@ class CredentialDeleteHandler extends AbstractV2RequestHandler<Void> {
             CredentialsManager credentialsManager,
             NotificationFactory notificationFactory,
             Gson gson) {
-        super(auth, gson);
-        this.credentialsManager = credentialsManager;
+        super(auth, credentialsManager, gson);
         this.notificationFactory = notificationFactory;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CredentialGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CredentialGetHandler.java
@@ -57,12 +57,9 @@ import io.vertx.core.http.HttpMethod;
 
 class CredentialGetHandler extends AbstractV2RequestHandler<MatchedCredentials> {
 
-    private final CredentialsManager credentialsManager;
-
     @Inject
     CredentialGetHandler(AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
-        super(auth, gson);
-        this.credentialsManager = credentialsManager;
+        super(auth, credentialsManager, gson);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsGetHandler.java
@@ -60,13 +60,10 @@ import io.vertx.core.http.HttpMethod;
 
 class CredentialsGetHandler extends AbstractV2RequestHandler<List<Cred>> {
 
-    private final CredentialsManager credentialsManager;
-
     @Inject
     CredentialsGetHandler(
             AuthManager auth, CredentialsManager credentialsManager, Gson gson, Logger logger) {
-        super(auth, gson);
-        this.credentialsManager = credentialsManager;
+        super(auth, credentialsManager, gson);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsPostHandler.java
@@ -65,7 +65,6 @@ class CredentialsPostHandler extends AbstractV2RequestHandler<Void> {
 
     static final String PATH = "credentials";
 
-    private final CredentialsManager credentialsManager;
     private final NotificationFactory notificationFactory;
 
     @Inject
@@ -74,8 +73,7 @@ class CredentialsPostHandler extends AbstractV2RequestHandler<Void> {
             CredentialsManager credentialsManager,
             NotificationFactory notificationFactory,
             Gson gson) {
-        super(auth, gson);
-        this.credentialsManager = credentialsManager;
+        super(auth, credentialsManager, gson);
         this.notificationFactory = notificationFactory;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -58,8 +59,12 @@ class DiscoveryGetHandler extends AbstractV2RequestHandler<EnvironmentNode> {
     private final DiscoveryStorage storage;
 
     @Inject
-    DiscoveryGetHandler(AuthManager auth, DiscoveryStorage storage, Gson gson) {
-        super(auth, gson);
+    DiscoveryGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            DiscoveryStorage storage,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
         this.storage = storage;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandler.java
@@ -54,6 +54,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.discovery.PluginInfo;
@@ -88,13 +89,14 @@ class DiscoveryRegistrationHandler extends AbstractV2RequestHandler<Map<String, 
     @Inject
     DiscoveryRegistrationHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             DiscoveryStorage storage,
             Lazy<WebServer> webServer,
             DiscoveryJwtHelper jwt,
             @Named(MainModule.UUID_FROM_STRING) Function<String, UUID> uuidFromString,
             Gson gson,
             Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.storage = storage;
         this.webServer = webServer;
         this.jwtFactory = jwt;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/LogoutPostHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -55,8 +56,9 @@ import io.vertx.core.http.HttpMethod;
 class LogoutPostHandler extends AbstractV2RequestHandler<Void> {
 
     @Inject
-    protected LogoutPostHandler(AuthManager auth, Gson gson) {
-        super(auth, gson);
+    protected LogoutPostHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+        super(auth, credentialsManager, gson);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandler.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
@@ -69,12 +70,13 @@ class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
     @Inject
     ProbeTemplateDeleteHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             NotificationFactory notificationFactory,
             LocalProbeTemplateService probeTemplateService,
             Logger logger,
             FileSystem fs,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.notificationFactory = notificationFactory;
         this.logger = logger;
         this.probeTemplateService = probeTemplateService;
@@ -126,7 +128,7 @@ class ProbeTemplateDeleteHandler extends AbstractV2RequestHandler<Void> {
         } catch (Exception e) {
             throw new ApiException(400, e.getMessage(), e);
         }
-        return new IntermediateResponse().body(null);
+        return new IntermediateResponse<Void>().body(null);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
 import io.cryostat.core.log.Logger;
@@ -73,12 +74,13 @@ class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
     @Inject
     ProbeTemplateUploadHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             NotificationFactory notificationFactory,
             LocalProbeTemplateService probeTemplateService,
             Logger logger,
             FileSystem fs,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.notificationFactory = notificationFactory;
         this.logger = logger;
         this.probeTemplateService = probeTemplateService;
@@ -121,7 +123,7 @@ class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
     }
 
     @Override
-    public IntermediateResponse handle(RequestParameters requestParams) throws Exception {
+    public IntermediateResponse<Void> handle(RequestParameters requestParams) throws Exception {
         try {
             for (FileUpload u : requestParams.getFileUploads()) {
                 String templateName = requestParams.getPathParams().get("probetemplateName");
@@ -150,7 +152,7 @@ class ProbeTemplateUploadHandler extends AbstractV2RequestHandler<Void> {
             logger.error(e.getMessage());
             throw new ApiException(500, e.getMessage(), e);
         }
-        return new IntermediateResponse().body(null);
+        return new IntermediateResponse<Void>().body(null);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RuleGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RuleGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -62,8 +63,13 @@ class RuleGetHandler extends AbstractV2RequestHandler<Rule> {
     private final Logger logger;
 
     @Inject
-    RuleGetHandler(AuthManager auth, RuleRegistry ruleRegistry, Gson gson, Logger logger) {
-        super(auth, gson);
+    RuleGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RuleRegistry ruleRegistry,
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, gson);
         this.ruleRegistry = ruleRegistry;
         this.logger = logger;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulePatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulePatchHandler.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
@@ -69,11 +70,12 @@ class RulePatchHandler extends AbstractV2RequestHandler<Void> {
     @Inject
     RulePatchHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             RuleRegistry ruleRegistry,
             NotificationFactory notificationFactory,
             Gson gson,
             Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.ruleRegistry = ruleRegistry;
         this.notificationFactory = notificationFactory;
         this.logger = logger;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesGetHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -62,8 +63,13 @@ class RulesGetHandler extends AbstractV2RequestHandler<Set<Rule>> {
     private final Logger logger;
 
     @Inject
-    RulesGetHandler(AuthManager auth, RuleRegistry ruleRegistry, Gson gson, Logger logger) {
-        super(auth, gson);
+    RulesGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RuleRegistry ruleRegistry,
+            Gson gson,
+            Logger logger) {
+        super(auth, credentialsManager, gson);
         this.ruleRegistry = ruleRegistry;
         this.logger = logger;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RulesPostHandler.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
@@ -72,11 +73,12 @@ class RulesPostHandler extends AbstractV2RequestHandler<String> {
     @Inject
     RulesPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             RuleRegistry ruleRegistry,
             NotificationFactory notificationFactory,
             Gson gson,
             Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.ruleRegistry = ruleRegistry;
         this.notificationFactory = notificationFactory;
         this.logger = logger;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsDeleteHandler.java
@@ -72,7 +72,7 @@ class TargetCredentialsDeleteHandler extends AbstractV2RequestHandler<Void> {
             CredentialsManager credentialsManager,
             NotificationFactory notificationFactory,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.credentialsManager = credentialsManager;
         this.notificationFactory = notificationFactory;
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsGetHandler.java
@@ -66,7 +66,7 @@ class TargetCredentialsGetHandler extends AbstractV2RequestHandler<List<ServiceR
     @Inject
     TargetCredentialsGetHandler(
             AuthManager auth, CredentialsManager credentialsManager, Gson gson, Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.credentialsManager = credentialsManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetCredentialsPostHandler.java
@@ -80,7 +80,7 @@ class TargetCredentialsPostHandler extends AbstractV2RequestHandler<Void> {
             NotificationFactory notificationFactory,
             Gson gson,
             Logger logger) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.credentialsManager = credentialsManager;
         this.notificationFactory = notificationFactory;
         this.logger = logger;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -63,8 +64,11 @@ class TargetDeleteHandler extends AbstractV2RequestHandler<Void> {
 
     @Inject
     TargetDeleteHandler(
-            AuthManager auth, Gson gson, CustomTargetPlatformClient customTargetPlatformClient) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            Gson gson,
+            CustomTargetPlatformClient customTargetPlatformClient) {
+        super(auth, credentialsManager, gson);
         this.customTargetPlatformClient = customTargetPlatformClient;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetEventsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetEventsGetHandler.java
@@ -48,6 +48,7 @@ import javax.inject.Inject;
 
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.SerializableEventTypeInfo;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -65,8 +66,11 @@ class TargetEventsGetHandler extends AbstractV2RequestHandler<List<SerializableE
 
     @Inject
     TargetEventsGetHandler(
-            AuthManager auth, TargetConnectionManager targetConnectionManager, Gson gson) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager targetConnectionManager,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
         this.targetConnectionManager = targetConnectionManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
@@ -75,10 +76,11 @@ class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
             NotificationFactory notificationFactory,
             FileSystem fs,
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
             Environment env,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.logger = logger;
         this.notificationFactory = notificationFactory;
         this.connectionManager = connectionManager;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
@@ -103,10 +104,11 @@ class TargetProbePostHandler extends AbstractV2RequestHandler<Void> {
             LocalProbeTemplateService service,
             FileSystem fs,
             AuthManager auth,
+            CredentialsManager credentialsManager,
             TargetConnectionManager connectionManager,
             Environment env,
             Gson gson) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.logger = logger;
         this.notificationFactory = notificationFactory;
         this.probeTemplateService = service;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbesGetHandler.java
@@ -46,6 +46,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.AgentJMXHelper;
 import io.cryostat.core.agent.Event;
 import io.cryostat.core.agent.ProbeTemplate;
@@ -66,8 +67,12 @@ class TargetProbesGetHandler extends AbstractV2RequestHandler<List<Event>> {
     private final TargetConnectionManager connectionManager;
 
     @Inject
-    TargetProbesGetHandler(AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
-        super(auth, gson);
+    TargetProbesGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager connectionManager,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
         this.connectionManager = connectionManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandler.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 
 import org.openjdk.jmc.common.unit.IOptionDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.SerializableOptionDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
@@ -64,8 +65,11 @@ class TargetRecordingOptionsListGetHandler
 
     @Inject
     TargetRecordingOptionsListGetHandler(
-            AuthManager auth, TargetConnectionManager connectionManager, Gson gson) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            TargetConnectionManager connectionManager,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
         this.connectionManager = connectionManager;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandler.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -65,8 +66,11 @@ class TargetSnapshotPostHandler
 
     @Inject
     TargetSnapshotPostHandler(
-            AuthManager auth, RecordingTargetHelper recordingTargetHelper, Gson gson) {
-        super(auth, gson);
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            RecordingTargetHelper recordingTargetHelper,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
         this.recordingTargetHelper = recordingTargetHelper;
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -49,6 +49,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -74,10 +75,11 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
     @Inject
     TargetsPostHandler(
             AuthManager auth,
+            CredentialsManager credentialsManager,
             Gson gson,
             DiscoveryStorage storage,
             CustomTargetPlatformClient customTargetPlatformClient) {
-        super(auth, gson);
+        super(auth, credentialsManager, gson);
         this.storage = storage;
         this.customTargetPlatformClient = customTargetPlatformClient;
     }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ProbeTemplateGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ProbeTemplateGetHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeTemplate;
 import io.cryostat.core.log.Logger;
@@ -70,6 +71,7 @@ public class ProbeTemplateGetHandlerTest {
 
     ProbeTemplateGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -79,7 +81,8 @@ public class ProbeTemplateGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new ProbeTemplateGetHandler(auth, templateService, fs, gson);
+        this.handler =
+                new ProbeTemplateGetHandler(auth, credentialsManager, templateService, fs, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingDeleteFromPathHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingDeleteFromPathHandlerTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -75,12 +76,15 @@ class RecordingDeleteFromPathHandlerTest {
 
     RecordingDeleteFromPathHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingDeleteFromPathHandler(auth, gson, recordingArchiveHelper);
+        this.handler =
+                new RecordingDeleteFromPathHandler(
+                        auth, credentialsManager, gson, recordingArchiveHelper);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingDeleteHandlerTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -75,12 +76,14 @@ class RecordingDeleteHandlerTest {
 
     RecordingDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingDeleteHandler(auth, gson, recordingArchiveHelper);
+        this.handler =
+                new RecordingDeleteHandler(auth, credentialsManager, gson, recordingArchiveHelper);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingGetHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -75,12 +76,15 @@ class RecordingGetHandlerTest {
 
     RecordingGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
 
     @BeforeEach
     void setup() {
-        this.handler = new RecordingGetHandler(authManager, gson, recordingArchiveHelper);
+        this.handler =
+                new RecordingGetHandler(
+                        authManager, credentialsManager, gson, recordingArchiveHelper);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostFromPathHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostFromPathHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -81,6 +82,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RecordingMetadataLabelsPostFromPathHandlerTest {
     RecordingMetadataLabelsPostFromPathHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
     @Mock RecordingMetadataManager recordingMetadataManager;
@@ -95,7 +97,11 @@ public class RecordingMetadataLabelsPostFromPathHandlerTest {
     void setup() {
         this.handler =
                 new RecordingMetadataLabelsPostFromPathHandler(
-                        authManager, gson, recordingArchiveHelper, recordingMetadataManager);
+                        authManager,
+                        credentialsManager,
+                        gson,
+                        recordingArchiveHelper,
+                        recordingMetadataManager);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingMetadataLabelsPostHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -81,6 +82,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RecordingMetadataLabelsPostHandlerTest {
     RecordingMetadataLabelsPostHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
     @Mock RecordingMetadataManager recordingMetadataManager;
@@ -95,7 +97,11 @@ public class RecordingMetadataLabelsPostHandlerTest {
     void setup() {
         this.handler =
                 new RecordingMetadataLabelsPostHandler(
-                        authManager, gson, recordingArchiveHelper, recordingMetadataManager);
+                        authManager,
+                        credentialsManager,
+                        gson,
+                        recordingArchiveHelper,
+                        recordingMetadataManager);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -88,6 +89,7 @@ class RecordingUploadPostFromPathHandlerTest {
 
     RecordingUploadPostFromPathHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Environment env;
     @Mock WebClient webClient;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
@@ -102,7 +104,7 @@ class RecordingUploadPostFromPathHandlerTest {
     void setup() {
         this.handler =
                 new RecordingUploadPostFromPathHandler(
-                        auth, env, 30, webClient, recordingArchiveHelper, gson);
+                        auth, credentialsManager, env, 30, webClient, recordingArchiveHelper, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -88,6 +89,7 @@ class RecordingUploadPostHandlerTest {
 
     RecordingUploadPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Environment env;
     @Mock WebClient webClient;
     @Mock RecordingArchiveHelper recordingArchiveHelper;
@@ -102,7 +104,7 @@ class RecordingUploadPostHandlerTest {
     void setup() {
         this.handler =
                 new RecordingUploadPostHandler(
-                        auth, env, 30, webClient, recordingArchiveHelper, gson);
+                        auth, credentialsManager, env, 30, webClient, recordingArchiveHelper, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.security.ResourceAction;
@@ -76,12 +77,15 @@ class ReportGetFromPathHandlerTest {
 
     ReportGetFromPathHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock ReportService reportService;
 
     @BeforeEach
     void setup() {
-        this.handler = new ReportGetFromPathHandler(authManager, gson, reportService, 30);
+        this.handler =
+                new ReportGetFromPathHandler(
+                        authManager, credentialsManager, gson, reportService, 30);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.security.ResourceAction;
@@ -77,13 +78,16 @@ class ReportGetHandlerTest {
 
     ReportGetHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock ReportService reportService;
     @Mock RecordingArchiveHelper archiveHelper;
 
     @BeforeEach
     void setup() {
-        this.handler = new ReportGetHandler(authManager, gson, reportService, archiveHelper, 30);
+        this.handler =
+                new ReportGetHandler(
+                        authManager, credentialsManager, gson, reportService, archiveHelper, 30);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/TargetRecordingMetadataLabelsPostHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -83,6 +84,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class TargetRecordingMetadataLabelsPostHandlerTest {
     TargetRecordingMetadataLabelsPostHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock Gson gson;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
@@ -97,6 +99,7 @@ public class TargetRecordingMetadataLabelsPostHandlerTest {
         this.handler =
                 new TargetRecordingMetadataLabelsPostHandler(
                         authManager,
+                        credentialsManager,
                         gson,
                         targetConnectionManager,
                         recordingTargetHelper,

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -317,9 +317,6 @@ class AbstractV2RequestHandlerTest {
                     "Basic " + Base64.getEncoder().encodeToString("jmxuser:jmxpass".getBytes()));
             Mockito.when(ctx.request().headers()).thenReturn(headers);
 
-            Credentials creds = new Credentials("a user", "thepass");
-            Mockito.when(credentialsManager.getCredentialsByTargetId(targetId)).thenReturn(creds);
-
             handler.handle(ctx);
             ConnectionDescriptor desc = handler.desc;
 
@@ -328,6 +325,8 @@ class AbstractV2RequestHandlerTest {
             MatcherAssert.assertThat(
                     desc.getCredentials().get(),
                     Matchers.equalTo(new Credentials("jmxuser", "jmxpass")));
+
+            Mockito.verifyNoInteractions(credentialsManager);
         }
 
         @ParameterizedTest

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture;
 import org.openjdk.jmc.rjmx.ConnectionException;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -88,6 +89,7 @@ class AbstractV2RequestHandlerTest {
     @Mock HttpServerRequest req;
     @Mock HttpServerResponse resp;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
@@ -104,7 +106,7 @@ class AbstractV2RequestHandlerTest {
         Mockito.lenient().when(ctx.request()).thenReturn(req);
         Mockito.lenient().when(ctx.response()).thenReturn(resp);
 
-        this.handler = new AuthenticatedHandler(auth, gson);
+        this.handler = new AuthenticatedHandler(auth, credentialsManager, gson);
     }
 
     @Test
@@ -132,7 +134,8 @@ class AbstractV2RequestHandlerTest {
 
     @Test
     void shouldSendRawResponseForNonJsonPlaintextMimetype() {
-        AbstractV2RequestHandler<String> handler = new RawResponseHandler(auth, gson);
+        AbstractV2RequestHandler<String> handler =
+                new RawResponseHandler(auth, credentialsManager, gson);
 
         handler.handle(ctx);
 
@@ -143,7 +146,8 @@ class AbstractV2RequestHandlerTest {
 
     @Test
     void shouldSendFileResponseIfHandlerProvidesFileLocation() {
-        AbstractV2RequestHandler<Path> handler = new FileResponseHandler(auth, gson);
+        AbstractV2RequestHandler<Path> handler =
+                new FileResponseHandler(auth, credentialsManager, gson);
 
         handler.handle(ctx);
 
@@ -164,7 +168,9 @@ class AbstractV2RequestHandlerTest {
         @Test
         void shouldPropagateIfHandlerThrowsApiException() {
             Exception expectedException = new ApiException(200);
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -174,7 +180,9 @@ class AbstractV2RequestHandlerTest {
         @Test
         void shouldThrow500IfConnectionFails() {
             Exception expectedException = new ConnectionException("");
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -186,7 +194,9 @@ class AbstractV2RequestHandlerTest {
             Exception cause = new SecurityException();
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -199,7 +209,9 @@ class AbstractV2RequestHandlerTest {
             Exception cause = new ConnectIOException("SSL trust");
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -213,7 +225,9 @@ class AbstractV2RequestHandlerTest {
             Exception cause = new UnknownHostException("localhostt");
             Exception expectedException = new ConnectionException("");
             expectedException.initCause(cause);
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -224,7 +238,9 @@ class AbstractV2RequestHandlerTest {
         @Test
         void shouldThrow500IfHandlerThrowsUnexpectedly() {
             Exception expectedException = new NullPointerException();
-            handler = new ThrowingAuthenticatedHandler(auth, gson, expectedException);
+            handler =
+                    new ThrowingAuthenticatedHandler(
+                            auth, credentialsManager, gson, expectedException);
 
             ApiException ex =
                     Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -239,7 +255,7 @@ class AbstractV2RequestHandlerTest {
 
         @BeforeEach
         void setup3() {
-            handler = new ConnectionDescriptorHandler(auth, gson);
+            handler = new ConnectionDescriptorHandler(auth, credentialsManager, gson);
             when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                     .thenReturn(CompletableFuture.completedFuture(true));
         }
@@ -358,8 +374,8 @@ class AbstractV2RequestHandlerTest {
     }
 
     static class AuthenticatedHandler extends AbstractV2RequestHandler<String> {
-        AuthenticatedHandler(AuthManager auth, Gson gson) {
-            super(auth, gson);
+        AuthenticatedHandler(AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+            super(auth, credentialsManager, gson);
         }
 
         @Override
@@ -401,8 +417,12 @@ class AbstractV2RequestHandlerTest {
     static class ThrowingAuthenticatedHandler extends AuthenticatedHandler {
         private final Exception thrown;
 
-        ThrowingAuthenticatedHandler(AuthManager auth, Gson gson, Exception thrown) {
-            super(auth, gson);
+        ThrowingAuthenticatedHandler(
+                AuthManager auth,
+                CredentialsManager credentialsManager,
+                Gson gson,
+                Exception thrown) {
+            super(auth, credentialsManager, gson);
             this.thrown = thrown;
         }
 
@@ -415,8 +435,9 @@ class AbstractV2RequestHandlerTest {
     static class ConnectionDescriptorHandler extends AuthenticatedHandler {
         ConnectionDescriptor desc;
 
-        ConnectionDescriptorHandler(AuthManager auth, Gson gson) {
-            super(auth, gson);
+        ConnectionDescriptorHandler(
+                AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+            super(auth, credentialsManager, gson);
         }
 
         @Override
@@ -427,8 +448,8 @@ class AbstractV2RequestHandlerTest {
     }
 
     static class FileResponseHandler extends AbstractV2RequestHandler<Path> {
-        FileResponseHandler(AuthManager auth, Gson gson) {
-            super(auth, gson);
+        FileResponseHandler(AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+            super(auth, credentialsManager, gson);
         }
 
         @Override
@@ -468,8 +489,8 @@ class AbstractV2RequestHandlerTest {
     }
 
     static class RawResponseHandler extends AbstractV2RequestHandler<String> {
-        RawResponseHandler(AuthManager auth, Gson gson) {
-            super(auth, gson);
+        RawResponseHandler(AuthManager auth, CredentialsManager credentialsManager, Gson gson) {
+            super(auth, credentialsManager, gson);
         }
 
         @Override

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ApiGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ApiGetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -71,13 +72,16 @@ class ApiGetHandlerTest {
     @Mock WebServer webServer;
     Set<RequestHandler> requestHandlers;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
         this.requestHandlers = new HashSet<>();
-        this.handler = new ApiGetHandler(() -> webServer, () -> requestHandlers, auth, gson);
+        this.handler =
+                new ApiGetHandler(
+                        () -> webServer, () -> requestHandlers, auth, credentialsManager, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AuthPostHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.AuthenticationScheme;
@@ -69,6 +70,7 @@ class AuthPostHandlerTest {
 
     AuthPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
@@ -77,7 +79,7 @@ class AuthPostHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new AuthPostHandler(auth, gson);
+        this.handler = new AuthPostHandler(auth, credentialsManager, gson);
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AuthTokenPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AuthTokenPostHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.jwt.AssetJwtHelper;
@@ -71,6 +72,7 @@ class AuthTokenPostHandlerTest {
 
     AuthTokenPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock AssetJwtHelper jwt;
     @Mock WebServer webServer;
     @Mock Logger logger;
@@ -78,7 +80,9 @@ class AuthTokenPostHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new AuthTokenPostHandler(auth, gson, jwt, () -> webServer, logger);
+        this.handler =
+                new AuthTokenPostHandler(
+                        auth, credentialsManager, gson, jwt, () -> webServer, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
@@ -86,6 +87,7 @@ class CertificatePostHandlerTest {
 
     CertificatePostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Environment env;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -106,7 +108,13 @@ class CertificatePostHandlerTest {
     void setup() {
         this.handler =
                 new CertificatePostHandler(
-                        auth, env, fs, gson, outputStreamFunction, certValidator);
+                        auth,
+                        credentialsManager,
+                        env,
+                        fs,
+                        gson,
+                        outputStreamFunction,
+                        certValidator);
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryGetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.net.AuthManager;
@@ -72,13 +73,14 @@ class DiscoveryGetHandlerTest {
 
     AbstractV2RequestHandler<EnvironmentNode> handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock DiscoveryStorage storage;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new DiscoveryGetHandler(auth, storage, gson);
+        this.handler = new DiscoveryGetHandler(auth, credentialsManager, storage, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.net.AuthManager;
@@ -78,6 +79,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DiscoveryRegistrationHandlerTest {
     AbstractV2RequestHandler<Map<String, String>> handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock DiscoveryStorage storage;
     @Mock WebServer webServer;
     @Mock DiscoveryJwtHelper jwt;
@@ -88,7 +90,14 @@ class DiscoveryRegistrationHandlerTest {
     void setup() {
         this.handler =
                 new DiscoveryRegistrationHandler(
-                        auth, storage, () -> webServer, jwt, UUID::fromString, gson, logger);
+                        auth,
+                        credentialsManager,
+                        storage,
+                        () -> webServer,
+                        jwt,
+                        UUID::fromString,
+                        gson,
+                        logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/LogoutPostHandlerTest.java
@@ -41,6 +41,7 @@ package io.cryostat.net.web.http.api.v2;
 import java.util.Optional;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -65,6 +66,7 @@ public class LogoutPostHandlerTest {
 
     LogoutPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
@@ -73,7 +75,7 @@ public class LogoutPostHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new LogoutPostHandler(auth, gson);
+        this.handler = new LogoutPostHandler(auth, credentialsManager, gson);
 
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateDeleteHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
@@ -73,6 +74,7 @@ public class ProbeTemplateDeleteHandlerTest {
 
     ProbeTemplateDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -97,7 +99,13 @@ public class ProbeTemplateDeleteHandlerTest {
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new ProbeTemplateDeleteHandler(
-                        auth, notificationFactory, templateService, logger, fs, gson);
+                        auth,
+                        credentialsManager,
+                        notificationFactory,
+                        templateService,
+                        logger,
+                        fs,
+                        gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/ProbeTemplateUploadHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.agent.ProbeValidationException;
 import io.cryostat.core.log.Logger;
@@ -77,6 +78,7 @@ public class ProbeTemplateUploadHandlerTest {
 
     ProbeTemplateUploadHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -101,7 +103,13 @@ public class ProbeTemplateUploadHandlerTest {
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new ProbeTemplateUploadHandler(
-                        auth, notificationFactory, templateService, logger, fs, gson);
+                        auth,
+                        credentialsManager,
+                        notificationFactory,
+                        templateService,
+                        logger,
+                        fs,
+                        gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleDeleteHandlerTest.java
@@ -38,6 +38,7 @@
 package io.cryostat.net.web.http.api.v2;
 
 import java.net.URI;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -217,6 +218,11 @@ class RuleDeleteHandlerTest {
             MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
             queryParams.set("clean", "true");
             Mockito.when(params.getQueryParams()).thenReturn(queryParams);
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            headers.set(
+                    "X-JMX-Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString("user:pass".getBytes()));
+            Mockito.when(params.getHeaders()).thenReturn(headers);
 
             Rule rule =
                     new Rule.Builder()
@@ -284,6 +290,11 @@ class RuleDeleteHandlerTest {
             MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
             queryParams.set("clean", "true");
             Mockito.when(params.getQueryParams()).thenReturn(queryParams);
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            headers.set(
+                    "X-JMX-Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString("user:pass".getBytes()));
+            Mockito.when(params.getHeaders()).thenReturn(headers);
 
             Rule rule =
                     new Rule.Builder()

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RuleGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RuleGetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -69,13 +70,14 @@ class RuleGetHandlerTest {
 
     RuleGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RuleRegistry registry;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new RuleGetHandler(auth, registry, gson, logger);
+        this.handler = new RuleGetHandler(auth, credentialsManager, registry, gson, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulePatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulePatchHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
@@ -71,6 +72,7 @@ class RulePatchTest {
 
     RulePatchHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RuleRegistry registry;
     @Mock NotificationFactory notificationFactory;
     @Mock Notification notification;
@@ -94,7 +96,9 @@ class RulePatchTest {
                 .when(notificationBuilder.message(Mockito.any()))
                 .thenReturn(notificationBuilder);
         Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
-        this.handler = new RulePatchHandler(auth, registry, notificationFactory, gson, logger);
+        this.handler =
+                new RulePatchHandler(
+                        auth, credentialsManager, registry, notificationFactory, gson, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesGetHandlerTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -67,13 +68,14 @@ class RulesGetHandlerTest {
 
     RulesGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RuleRegistry registry;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new RulesGetHandler(auth, registry, gson, logger);
+        this.handler = new RulesGetHandler(auth, credentialsManager, registry, gson, logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/RulesPostHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.messaging.notifications.Notification;
 import io.cryostat.messaging.notifications.NotificationFactory;
@@ -79,6 +80,7 @@ class RulesPostHandlerTest {
 
     RulesPostHandler handler;
     @Mock AuthManager authManager;
+    @Mock CredentialsManager credentialsManager;
     @Mock RuleRegistry ruleRegistry;
     @Mock NotificationFactory notificationFactory;
     @Mock Notification notification;
@@ -112,7 +114,13 @@ class RulesPostHandlerTest {
                 .thenReturn(notificationBuilder);
         Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
-                new RulesPostHandler(authManager, ruleRegistry, notificationFactory, gson, logger);
+                new RulesPostHandler(
+                        authManager,
+                        credentialsManager,
+                        ruleRegistry,
+                        notificationFactory,
+                        gson,
+                        logger);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetDeleteHandlerTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
@@ -74,13 +75,15 @@ class TargetDeleteHandlerTest {
 
     TargetDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock CustomTargetPlatformClient customTargetPlatformClient;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetDeleteHandler(auth, gson, customTargetPlatformClient);
+        this.handler =
+                new TargetDeleteHandler(auth, credentialsManager, gson, customTargetPlatformClient);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetEventsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetEventsGetHandlerTest.java
@@ -52,6 +52,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.jmc.serialization.SerializableEventTypeInfo;
@@ -77,6 +78,7 @@ class TargetEventsGetHandlerTest {
 
     TargetEventsGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock Logger logger;
     @Mock IFlightRecorderService service;
@@ -85,7 +87,8 @@ class TargetEventsGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetEventsGetHandler(auth, targetConnectionManager, gson);
+        this.handler =
+                new TargetEventsGetHandler(auth, credentialsManager, targetConnectionManager, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandlerTest.java
@@ -49,6 +49,7 @@ import javax.management.ObjectName;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.sys.Environment;
@@ -80,6 +81,7 @@ public class TargetProbeDeleteHandlerTest {
 
     TargetProbeDeleteHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock FileSystem fs;
     @Mock Logger logger;
     @Mock NotificationFactory notificationFactory;
@@ -105,7 +107,14 @@ public class TargetProbeDeleteHandlerTest {
         lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new TargetProbeDeleteHandler(
-                        logger, notificationFactory, fs, auth, targetConnectionManager, env, gson);
+                        logger,
+                        notificationFactory,
+                        fs,
+                        auth,
+                        credentialsManager,
+                        targetConnectionManager,
+                        env,
+                        gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbeGetHandlerTest.java
@@ -48,6 +48,7 @@ import javax.management.ObjectName;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.Event;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
@@ -80,6 +81,7 @@ public class TargetProbeGetHandlerTest {
 
     TargetProbesGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -90,7 +92,8 @@ public class TargetProbeGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetProbesGetHandler(auth, targetConnectionManager, gson);
+        this.handler =
+                new TargetProbesGetHandler(auth, credentialsManager, targetConnectionManager, gson);
     }
 
     @Nested

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandlerTest.java
@@ -49,6 +49,7 @@ import javax.management.ObjectName;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.agent.LocalProbeTemplateService;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
@@ -81,6 +82,7 @@ public class TargetProbePostHandlerTest {
 
     TargetProbePostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock LocalProbeTemplateService templateService;
     @Mock FileSystem fs;
     @Mock Logger logger;
@@ -112,6 +114,7 @@ public class TargetProbePostHandlerTest {
                         templateService,
                         fs,
                         auth,
+                        credentialsManager,
                         targetConnectionManager,
                         env,
                         gson);

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
@@ -51,6 +51,7 @@ import org.openjdk.jmc.common.unit.IOptionDescriptor;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.net.AuthManager;
@@ -80,6 +81,7 @@ class TargetRecordingOptionsListGetHandlerTest {
 
     TargetRecordingOptionsListGetHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock TargetConnectionManager targetConnectionManager;
     @Mock IFlightRecorderService service;
     @Mock JFRConnection connection;
@@ -89,7 +91,8 @@ class TargetRecordingOptionsListGetHandlerTest {
     @BeforeEach
     void setup() {
         this.handler =
-                new TargetRecordingOptionsListGetHandler(auth, targetConnectionManager, gson);
+                new TargetRecordingOptionsListGetHandler(
+                        auth, credentialsManager, targetConnectionManager, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
@@ -48,6 +48,7 @@ import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
 import io.cryostat.net.AuthManager;
@@ -80,13 +81,16 @@ class TargetSnapshotPostHandlerTest {
 
     TargetSnapshotPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock RecordingTargetHelper recordingTargetHelper;
     @Mock Logger logger;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetSnapshotPostHandler(auth, recordingTargetHelper, gson);
+        this.handler =
+                new TargetSnapshotPostHandler(
+                        auth, credentialsManager, recordingTargetHelper, gson);
     }
 
     @Test

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.net.AuthManager;
@@ -77,6 +78,7 @@ class TargetsPostHandlerTest {
 
     TargetsPostHandler handler;
     @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
     @Mock DiscoveryStorage storage;
     @Mock CustomTargetPlatformClient customTargetPlatformClient;
     @Mock Logger logger;
@@ -84,7 +86,9 @@ class TargetsPostHandlerTest {
 
     @BeforeEach
     void setup() {
-        this.handler = new TargetsPostHandler(auth, gson, storage, customTargetPlatformClient);
+        this.handler =
+                new TargetsPostHandler(
+                        auth, credentialsManager, gson, storage, customTargetPlatformClient);
     }
 
     @Test


### PR DESCRIPTION
Fixes #1142

JWT-based handlers and API V1 handlers all automatically check for stored JMX credentials because the abstract base classes implement this behaviour. The abstract V2 base class did not, so handlers either needed to handle it manually, or were restricted to requiring the client to pass the `X-JMX-Authorization` header. This change updates the V2 abstract base class to bring it in line with the others.
