### PR TITLE
ci(mergify): only dismiss own review approvals

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,7 @@ pull_request_rules:
       - base=main
     actions:
       dismiss_reviews:
+        approved: [ 'mergify', 'Mergifyio' ]
         changes_requested: [ 'mergify', 'Mergifyio' ]
 
   - name: block pull requests that manually update web-client submodule


### PR DESCRIPTION
Related to #1139

The current config prevents Mergify from dismissing others' change requests when PRs are updated, but it doesn't stop it from dismissing approvals. Our GitHub repo settings mostly enforce this idea anyway so it's redundant for Mergify to do it. However, the GitHub version is nicer because it allows approvals to remain if a reviewer uses the "Update branch" button on the PR to merge/rebase the PR.
