### PR TITLE
build(pom): bump -core version for JMC agent underlying fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   <com.google.dagger.version>2.34.1</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.13.1</io.cryostat.core.version>
+  <io.cryostat.core.version>2.14.1</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>


### PR DESCRIPTION
Related to #1126
Related to #1140

Bumps -core version up to 2.14.1 which includes the required JMC Agent fixes for the updated probe handlers and new UI. I already bumped -core in v2.2 to this same version in the #1140 backport.