### PR TITLE
fix(ci): push-to-quay needs get-pom-properties and fix spotbugs job to build headless

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
         java-version: '17'
         distribution: 'adopt'
     - name: Run spotbugs
-      run: mvn compile spotbugs:check
+      run: mvn -Dheadless=true compile spotbugs:check
 
   shellcheck:
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
 
   push-to-quay:
     runs-on: ubuntu-latest
-    needs: [integration-tests, spotless, spotbugs, shellcheck]
+    needs: [get-pom-properties, integration-tests, spotless, spotbugs, shellcheck]
     env:
       CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:


### PR DESCRIPTION
Fixes #1143 

The needs `get-pom-properties` change most likely fixes everything because I tested it with my own fork here: 
https://github.com/maxcao13/cryostat/tree/ci-testing
https://github.com/maxcao13/cryostat/blob/ci-testing/.github/workflows/ci.yaml
and heres the workflow:
https://github.com/maxcao13/cryostat/actions/runs/3308808673
and heres the pushed image:
https://quay.io/repository/macao/cryostat?tab=tags