### PR TITLE
fix(jmc-agent): Fix notification category for TargetProbeDeleteHandler

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbeDeleteHandler.java
@@ -67,7 +67,7 @@ class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
     private final FileSystem fs;
     private final TargetConnectionManager connectionManager;
     private final Environment env;
-    private static final String NOTIFICATION_CATEGORY = "ProbeTemplateDeleted";
+    private static final String NOTIFICATION_CATEGORY = "ProbesRemoved";
 
     @Inject
     TargetProbeDeleteHandler(
@@ -133,7 +133,7 @@ class TargetProbeDeleteHandler extends AbstractV2RequestHandler<Void> {
                                 .createBuilder()
                                 .metaCategory(NOTIFICATION_CATEGORY)
                                 .metaType(HttpMimeType.JSON)
-                                .message(Map.of("targetId", targetId))
+                                .message(Map.of("target", targetId))
                                 .build()
                                 .send();
                         return new IntermediateResponse<Void>().body(null);


### PR DESCRIPTION
Hi,

Quick fix to the TargetProbeDeleteHandler which fixes an issue found in the frontend as well. It currently uses the wrong notification category, this PR gives it it's own.

Related to #1126 