### PR TITLE
fix(ci): add ITEST_IMG_VERSION arg to repeated-tests bash script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       with:
         step: restore
     - name: Run integration tests
-      run: POD_NAME=cryostat-itests CONTAINER_NAME=cryostat-itest bash repeated-integration-tests.bash
+      run: POD_NAME=cryostat-itests CONTAINER_NAME=cryostat-itest ITEST_IMG_VERSION=latest bash repeated-integration-tests.bash
     - name: Print itest logs
       if: ${{ failure() }}
       run: ls -1dt target/cryostat-itests-*.log | head -n1 | xargs cat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       run: POD_NAME=cryostat-itests CONTAINER_NAME=cryostat-itest ITEST_IMG_VERSION=latest bash repeated-integration-tests.bash
     - name: Print itest logs
       if: ${{ failure() }}
-      run: ls -1dt target/cryostat-itests-*.log | head -n1 | xargs cat
+      run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -23,6 +23,11 @@ if [ -z "${CONTAINER_NAME}" ]; then
     CONTAINER_NAME="$(xpath -q -e 'project/properties/cryostat.itest.containerName/text()' pom.xml)"
 fi
 
+if [ -z "${ITEST_IMG_VERSION}" ]; then
+    ITEST_IMG_VERSION="$(xpath -q -e 'project/version/text()' pom.xml)"
+    ITEST_IMG_VERSION="${ITEST_IMG_VERSION,,}" # lowercase
+fi
+
 function cleanup() {
     if podman pod exists "${POD_NAME}"; then
         "${MVN}" exec:exec@destroy-pod
@@ -43,6 +48,7 @@ STARTFLAGS=(
     "failsafe:integration-test"
     "failsafe:verify"
     "-DfailIfNoTests=true"
+    "-Dcryostat.imageVersion=${ITEST_IMG_VERSION}"
 )
 
 if [ -n "$2" ]; then

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -74,8 +74,8 @@ DIR="$(dirname "$(readlink -f "$0")")"
 runcount=0
 while [ "${runcount}" -lt "${runs}" ]; do
     timestamp="$(date -Iminutes)"
-    client_logfile="$DIR/target/${POD_NAME}-${timestamp}.client.log"
-    server_logfile="$DIR/target/${POD_NAME}-${timestamp}.server.log"
+    client_logfile="$DIR/target/${CONTAINER_NAME}-${timestamp}.client.log"
+    server_logfile="$DIR/target/${CONTAINER_NAME}-${timestamp}.server.log"
     mkdir -p "$(dirname "$client_logfile")"
     mkdir -p "$(dirname "$server_logfile")"
     >"${client_logfile}"


### PR DESCRIPTION
Fixes #1152 

Also, I didn't mention this before but there is a mismatch of the itest output filename logs between the bash script and the mvn build executions. 

That's why in the split-container-pr #1138, I had to change the `run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat` -> `cryostat-itests`. 

The pom.xml here on this line: 

https://github.com/cryostatio/cryostat/blob/132459fbefed742f00c26058b184b2889f790aa3/pom.xml#L633

outputs the file as `cryostat-itest-timestamp.log` while the script does `cryostat-itests-timestamp.log` since `cryostat.itest.containerName="cryostat-itest"`. 

Which should be changed here?