### PR TITLE
fix(ci): correct image version pass between workflows

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    outputs:
+      image-version:
+        description: the Cryostat application version that will be built
+        value: ${{ jobs.get-pom-properties.outputs.image-version }}
 
 jobs:
   get-pom-properties:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -12,7 +12,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-      - edited
     branches:
       - main
       - v[0-9]+

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -39,14 +39,14 @@ jobs:
       run: podman load -i cryostat.tar
       if: github.repository_owner == 'cryostatio'
     - name: Tag cryostat image
-      run: podman tag cryostat ghcr.io/${{ github.repository_owner }}/cryostat:pr-${{ github.event.number }}
+      run: podman tag cryostat ghcr.io/${{ github.repository_owner }}/cryostat:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
       if: github.repository_owner == 'cryostatio'
     - name: Push PR test image to ghcr.io
       id: push-to-ghcr
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat
-        tags: pr-${{ github.event.number }}
+        tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.event.pull_request.user.login }}
         password: ${{ secrets.CI_GHCR_TEST_SECRET }}

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Tag images
       id: tag-image
       env:
-        IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
+        IMAGE_VERSION: ${{ needs.build-and-test.outputs.image-version }}
       run: |
         podman tag $CRYOSTAT_IMG $CRYOSTAT_IMG:$IMAGE_VERSION
         if [ "$GITHUB_REF" == "refs/heads/main" ]; then


### PR DESCRIPTION
Related to #1118

`push-to-quay` is currently broken since #1133: https://github.com/cryostatio/cryostat/actions/runs/3329598845/jobs/5507297247

The way to pass data using `outputs` from a reusable workflow into the caller is described here: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow