### PR TITLE
ci(checkout): check out correct fork/branch during PR CI run

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    inputs:
+      checkout-repo:
+        required: false
+        type: string
+      checkout-ref:
+        required: false
+        type: string
     outputs:
       image-version:
         description: the Cryostat application version that will be built
@@ -10,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
     - id: query-pom
       name: Get properties from POM
       # Query POM for core and image version and save as output parameter
@@ -52,6 +62,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@v2
@@ -84,6 +96,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@v2
@@ -111,6 +125,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
     - name: Run spotless
       run: mvn spotless:check
 
@@ -119,6 +136,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
         submodules: true
         fetch-depth: 0
     - uses: skjolber/maven-cache-github-action@v1
@@ -135,5 +154,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.checkout-repo }}
+        ref: ${{ inputs.checkout-ref }}
     - name: Run shellcheck
       run: mvn shellcheck:check

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -21,6 +21,9 @@ on:
 jobs:
   build-and-test:
     uses: ./.github/workflows/ci-jobs.yml
+    with:
+      checkout-repo: ${{ github.repository }}
+      checkout-ref: ${{ github.event.pull_request.head.ref }}
     if: github.repository_owner == 'cryostatio' && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
 
   push-to-ghcr:


### PR DESCRIPTION
Related to #1118
Related to #1133

Previous PR to change the trigger event to `pull_request_target` changes the runner context to the base repo's. This means the `checkout` action in various CI steps is actually just checking out the upstream `main` branch, rather than the PR branch. This update corrects the `checkout` action to check out the PR branch for PRs, or leave it as the defaults after final push. This is what we talked about on an earlier call and is what we thought the new PR flow would actually be doing.