### PR TITLE
ci(image): add config to delete PR-scoped images on close

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,0 +1,21 @@
+name: Clean up PR-scoped test images
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-images:
+    name: Delete PR-scoped test images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: r26d/ghcr-delete-image-action@v1.2.2
+        with:
+          owner: ${{ github.repository_owner }}
+          name: cryostat
+          token: ${{ secrets.GHCR_PR_TOKEN }}
+          ignore-missing-package: true
+          tag-regex: pr-${{ github.event.number }}-.*
+          tagged-keep-latest: 0
+        if: github.repository_owner == 'cryostatio'


### PR DESCRIPTION
Related to #1133
Related to #1173
