### PR TITLE
fix(graphql): expose archiveOnStop property in doStartRecording settings

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -165,7 +165,8 @@ class StartRecordingOnTargetMutator
                             desc,
                             ws.getDownloadURL(conn, desc.getName()),
                             ws.getReportURL(conn, desc.getName()),
-                            metadata);
+                            metadata,
+                            archiveOnStop);
                 });
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -137,6 +137,11 @@ class StartRecordingOnTargetMutator
                     if (settings.containsKey("maxSize")) {
                         builder = builder.maxSize((Long) settings.get("maxSize"));
                     }
+                    boolean archiveOnStop = false;
+                    if (settings.containsKey("archiveOnStop")) {
+                        Boolean v = (Boolean) settings.get("archiveOnStop");
+                        archiveOnStop = v != null && v;
+                    }
                     Metadata m = new Metadata();
                     if (settings.containsKey("metadata")) {
                         m =
@@ -152,7 +157,8 @@ class StartRecordingOnTargetMutator
                                     (String) settings.get("template"),
                                     TemplateType.valueOf(
                                             ((String) settings.get("templateType")).toUpperCase()),
-                                    m);
+                                    m,
+                                    archiveOnStop);
                     WebServer ws = webServer.get();
                     Metadata metadata = metadataManager.getMetadata(cd, desc.getName());
                     return new HyperlinkedSerializableRecordingDescriptor(

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -155,5 +155,6 @@ input RecordingSettings {
     toDisk: Boolean
     maxSize: Long
     maxAge: Long
+    archiveOnStop: Boolean
     metadata: Object
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -97,6 +97,7 @@ type ActiveRecording implements Recording {
     toDisk: Boolean!
     maxSize: Long!
     maxAge: Long!
+    archiveOnStop: Boolean!
 
     name: String!
     reportUrl: Url!

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -273,8 +273,8 @@ class GraphQLIT extends ExternalTargetsTest {
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
                     + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
                     + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: false,"
-                    + " metadata: { labels: { newLabel: someValue } }  }) { name state duration }}"
-                    + " }");
+                    + " metadata: { labels: { newLabel: someValue } }  }) { name state duration"
+                    + " archiveOnStop }} }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -271,10 +271,10 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                    + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
-                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: false,"
-                    + " metadata: { labels: { newLabel: someValue } }  }) { name state duration"
-                    + " archiveOnStop }} }");
+                        + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
+                        + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
+                        + " metadata: { labels: { newLabel: someValue } }  }) { name state duration"
+                        + " archiveOnStop }} }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -295,6 +295,7 @@ class GraphQLIT extends ExternalTargetsTest {
         recording.name = "graphql-itest";
         recording.duration = 30_000L;
         recording.state = "RUNNING";
+        recording.archiveOnStop = true;
         recording.metadata =
                 RecordingMetadata.of(
                         Map.of(
@@ -841,6 +842,7 @@ class GraphQLIT extends ExternalTargetsTest {
         boolean toDisk;
         long maxSize;
         long maxAge;
+        boolean archiveOnStop;
 
         ArchivedRecording doArchive;
         ActiveRecording doDelete;
@@ -855,6 +857,7 @@ class GraphQLIT extends ExternalTargetsTest {
                     duration,
                     maxAge,
                     maxSize,
+                    archiveOnStop,
                     metadata,
                     name,
                     reportUrl,
@@ -882,6 +885,7 @@ class GraphQLIT extends ExternalTargetsTest {
                     && duration == other.duration
                     && maxAge == other.maxAge
                     && maxSize == other.maxSize
+                    && archiveOnStop == other.archiveOnStop
                     && Objects.equals(metadata, other.metadata)
                     && Objects.equals(name, other.name)
                     && Objects.equals(reportUrl, other.reportUrl)
@@ -906,6 +910,8 @@ class GraphQLIT extends ExternalTargetsTest {
                     + maxAge
                     + ", maxSize="
                     + maxSize
+                    + ", archiveOnStop="
+                    + archiveOnStop
                     + ", metadata="
                     + metadata
                     + ", name="

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -272,8 +272,9 @@ class GraphQLIT extends ExternalTargetsTest {
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
                     + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
-                    + " template: \"Profiling\", templateType: \"TARGET\", metadata: { labels: {"
-                    + " newLabel: someValue } }  }) { name state duration }} }");
+                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: false,"
+                    + " metadata: { labels: { newLabel: someValue } }  }) { name state duration }}"
+                    + " }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(


### PR DESCRIPTION
Fixes #1178

Manual testing steps:

```bash
$ http -v :8181/api/v2.2/graphql Authorization:"Basic $(echo user:pass | base64)" query="{ targetNodes(filter: { name: \"service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi\" }) { doStartRecording(recording: { name:\"foo\", template:\"Profiling\", templateType:\"TARGET\", duration: 10 }) { name } } }"
```

(will probably need to separately define JMX keyring credentials for the Cryostat target)
This query starts a recording without specifying or reading `archiveOnStop` and should work identically before and after the PR.

```bash
$ http -v :8181/api/v2.2/graphql Authorization:"Basic $(echo user:pass | base64)" query="{ targetNodes(filter: { name: \"service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi\" }) { doStartRecording(recording: { name:\"bar\", template:\"Profiling\", templateType:\"TARGET\", duration: 10 }) { name archiveOnStop } } }"
```

This query starts a recording without specifying `archiveOnStop`, but then tries to read the value back from the started recording. This should fail on `main` and pass (`false` value) on this PR.

```bash
$ http -v :8181/api/v2.2/graphql Authorization:"Basic $(echo user:pass | base64)" query="{ targetNodes(filter: { name: \"service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi\" }) { doStartRecording(recording: { name:\"baz\", template:\"Profiling\", templateType:\"TARGET\", duration: 10, archiveOnStop: true }) { name archiveOnStop } } }"
```

This query starts a recording specifying `archiveOnStop` and reads the value back. This should also fail on `main` and pass (`true` value) on this PR.