### PR TITLE
fix(discovery): allow targets restarting quickly using JDP to render correctly on the -web

### DIFF
--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -344,12 +344,12 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
             Set<TargetNode> removed = new HashSet<>(previousLeaves);
             removed.removeAll(currentLeaves);
 
-            added.stream()
-                    .map(TargetNode::getTarget)
-                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
             removed.stream()
                     .map(TargetNode::getTarget)
                     .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
+            added.stream()
+                    .map(TargetNode::getTarget)
+                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
         }
         return currentTree.getChildren();
     }

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -134,8 +134,8 @@ public class ServiceRef {
             return false;
         }
         ServiceRef sr = (ServiceRef) other;
-        // id is intentionally ignored ?
         return new EqualsBuilder()
+                .append(jvmId, sr.jvmId)
                 .append(serviceUri, sr.serviceUri)
                 .append(alias, sr.alias)
                 .append(labels, sr.labels)
@@ -145,8 +145,8 @@ public class ServiceRef {
 
     @Override
     public int hashCode() {
-        // id is intentionally ignored ?
         return new HashCodeBuilder()
+                .append(jvmId)
                 .append(serviceUri)
                 .append(alias)
                 .append(labels)

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -482,12 +482,12 @@ class DiscoveryStorageTest {
             MatcherAssert.assertThat(updatedChildren, Matchers.equalTo(List.of(nextTarget)));
             MatcherAssert.assertThat(discoveryEvents, Matchers.hasSize(2));
 
-            TargetDiscoveryEvent foundEvent =
-                    new TargetDiscoveryEvent(EventKind.FOUND, nextServiceRef);
             TargetDiscoveryEvent lostEvent =
                     new TargetDiscoveryEvent(EventKind.LOST, prevServiceRef);
+            TargetDiscoveryEvent foundEvent =
+                    new TargetDiscoveryEvent(EventKind.FOUND, nextServiceRef);
             MatcherAssert.assertThat(
-                    discoveryEvents, Matchers.containsInRelativeOrder(foundEvent, lostEvent));
+                    discoveryEvents, Matchers.containsInRelativeOrder(lostEvent, foundEvent));
         }
     }
 

--- a/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
@@ -73,7 +73,7 @@ class CustomTargetPlatformClientTest {
         try {
             SERVICE_REF =
                     new ServiceRef(
-                            "id",
+                            null,
                             URIUtil.convert(
                                     new JMXServiceURL(
                                             "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi")),

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -123,7 +123,7 @@ class DefaultPlatformClientTest {
 
         ServiceRef exp1 =
                 new ServiceRef(
-                        "id1", URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
+                        null, URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
         exp1.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.REALM,
@@ -136,7 +136,7 @@ class DefaultPlatformClientTest {
                         "9091"));
         ServiceRef exp2 =
                 new ServiceRef(
-                        "id2", URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
+                        null, URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
         exp2.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.REALM,
@@ -176,7 +176,7 @@ class DefaultPlatformClientTest {
 
         ServiceRef exp1 =
                 new ServiceRef(
-                        "id1", URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
+                        null, URIUtil.convert(desc1.getJmxServiceUrl()), desc1.getMainClass());
         exp1.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.REALM,
@@ -189,7 +189,7 @@ class DefaultPlatformClientTest {
                         "9091"));
         ServiceRef exp2 =
                 new ServiceRef(
-                        "id2", URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
+                        null, URIUtil.convert(desc3.getJmxServiceUrl()), desc3.getMainClass());
         exp2.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.REALM,
@@ -244,7 +244,7 @@ class DefaultPlatformClientTest {
 
         TargetDiscoveryEvent event = future.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(event.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        ServiceRef serviceRef = new ServiceRef("id", URIUtil.convert(url), javaMain);
+        ServiceRef serviceRef = new ServiceRef(null, URIUtil.convert(url), javaMain);
         serviceRef.setCryostatAnnotations(
                 Map.of(
                         AnnotationKey.REALM,

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -230,7 +230,7 @@ class KubeApiPlatformClientTest {
         // targetA is intentionally not a matching service
         ServiceRef serv1 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.3", 1234)),
                         "targetB");
         serv1.setCryostatAnnotations(
@@ -247,7 +247,7 @@ class KubeApiPlatformClientTest {
                         "targetB"));
         ServiceRef serv2 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.4", 9091)),
                         "targetC");
         serv2.setCryostatAnnotations(
@@ -264,7 +264,7 @@ class KubeApiPlatformClientTest {
                         "targetC"));
         ServiceRef serv3 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.5", 9091)),
                         "targetD");
         serv3.setCryostatAnnotations(
@@ -281,7 +281,7 @@ class KubeApiPlatformClientTest {
                         "targetD"));
         ServiceRef serv4 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.6", 5678)),
                         "targetE");
         serv4.setCryostatAnnotations(
@@ -366,7 +366,7 @@ class KubeApiPlatformClientTest {
         EnvironmentNode realmNode = platformClient.getDiscoveryTree();
         ServiceRef serv1 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.2", 9091)),
                         "targetA");
         serv1.setCryostatAnnotations(
@@ -383,7 +383,7 @@ class KubeApiPlatformClientTest {
                         "targetA"));
         ServiceRef serv2 =
                 new ServiceRef(
-                        "mockId",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.3", 1234)),
                         "targetB");
         serv2.setCryostatAnnotations(
@@ -510,7 +510,7 @@ class KubeApiPlatformClientTest {
         MatcherAssert.assertThat(evt.getEventKind(), Matchers.equalTo(EventKind.FOUND));
         ServiceRef serv =
                 new ServiceRef(
-                        "id",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("192.168.1.10", 9876)),
                         "watchedTarget");
         serv.setCryostatAnnotations(
@@ -591,7 +591,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef serv =
                 new ServiceRef(
-                        "id",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("192.168.1.10", 9876)),
                         "watchedTarget");
         serv.setCryostatAnnotations(
@@ -705,7 +705,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef original =
                 new ServiceRef(
-                        "id",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("192.168.1.10", 9876)),
                         "watchedTarget");
         original.setCryostatAnnotations(
@@ -723,7 +723,7 @@ class KubeApiPlatformClientTest {
 
         ServiceRef modified =
                 new ServiceRef(
-                        "id",
+                        null,
                         URIUtil.convert(connectionToolkit.createServiceURL("192.168.1.10", 9876)),
                         "modifiedTarget");
         modified.setCryostatAnnotations(

--- a/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeEnvPlatformClientTest.java
@@ -131,7 +131,7 @@ class KubeEnvPlatformClientTest {
 
             ServiceRef serv1 =
                     new ServiceRef(
-                            "id1",
+                            null,
                             URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.1", 1234)),
                             "foo");
             serv1.setCryostatAnnotations(
@@ -142,7 +142,7 @@ class KubeEnvPlatformClientTest {
                             AnnotationKey.PORT, "1234"));
             ServiceRef serv2 =
                     new ServiceRef(
-                            "id2",
+                            null,
                             URIUtil.convert(connectionToolkit.createServiceURL("1.2.3.4", 9999)),
                             "bar");
             serv2.setCryostatAnnotations(
@@ -186,7 +186,7 @@ class KubeEnvPlatformClientTest {
 
             ServiceRef serv1 =
                     new ServiceRef(
-                            "id1",
+                            null,
                             URIUtil.convert(connectionToolkit.createServiceURL("127.0.0.1", 1234)),
                             "foo");
             serv1.setCryostatAnnotations(
@@ -197,7 +197,7 @@ class KubeEnvPlatformClientTest {
                             AnnotationKey.PORT, "1234"));
             ServiceRef serv2 =
                     new ServiceRef(
-                            "id2",
+                            null,
                             URIUtil.convert(connectionToolkit.createServiceURL("1.2.3.4", 9999)),
                             "bar");
             serv2.setCryostatAnnotations(


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat-web/issues/493

Before fixing tests, was there a reason that the notifications were in the previous order?

The only "issue" is that the LOST target will eventually notify Cryostat that it was lost but nothing will be done, (no notifications emitted since the subtree will be the same), but this is just unnecessary work. 

I will test this on my own through OpenShift to make sure that it doesn't break that functionality.