### PR TITLE
test(smoketest): replace quarkus-test container with agent-equipped

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -103,11 +103,6 @@ runDemoApps() {
         --pod cryostat-pod \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.8.0
 
-    podman run \
-        --name quarkus-test \
-        --pod cryostat-pod \
-        --rm -d quay.io/andrewazores/quarkus-test:0.0.2
-
     local webPort;
     if [ -z "$CRYOSTAT_WEB_PORT" ]; then
         webPort="$(xpath -q -e 'project/properties/cryostat.itest.webPort/text()' pom.xml)"
@@ -119,11 +114,30 @@ runDemoApps() {
     else
         local protocol="http"
     fi
+
+    podman run \
+        --name quarkus-test-agent \
+        --pod cryostat-pod \
+        --env QUARKUS_HTTP_PORT=10012 \
+        --env JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env ORG_ACME_JMXHOST=localhost \
+        --env ORG_ACME_JMXPORT=9898 \
+        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
+        --env CRYOSTAT_AGENT_APP_NAME=quarkus-test-agent \
+        --env CRYOSTAT_AGENT_WEBSERVER_HOST=localhost \
+        --env CRYOSTAT_AGENT_WEBSERVER_PORT=9977 \
+        --env CRYOSTAT_AGENT_CALLBACK=http://localhost:9977/ \
+        --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
+        --env CRYOSTAT_AGENT_TRUST_ALL=true \
+        --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo -n user:pass | base64)" \
+        --rm -d quay.io/andrewazores/quarkus-test:0.0.9
+
     podman run \
         --name quarkus-test-plugin \
         --pod cryostat-pod \
         --restart unless-stopped \
         --env QUARKUS_HTTP_PORT=10010 \
+        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="true" \
         --env ORG_ACME_CRYOSTATSERVICE_AUTHORIZATION="Basic $(printf user:pass | base64)" \
         --env ORG_ACME_CRYOSTATSERVICE_MP_REST_URL="${protocol}://cryostat:${webPort}" \
         --env ORG_ACME_CRYOSTATSERVICE_CALLBACK_HOST="cryostat" \
@@ -137,6 +151,7 @@ runDemoApps() {
         --restart unless-stopped \
         --env QUARKUS_HTTP_PORT=10011 \
         --env JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9197 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" \
+        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="true" \
         --env ORG_ACME_CRYOSTATSERVICE_AUTHORIZATION="Basic $(printf user:pass | base64)" \
         --env ORG_ACME_CRYOSTATSERVICE_MP_REST_URL="${protocol}://cryostat:${webPort}" \
         --env ORG_ACME_CRYOSTATSERVICE_CALLBACK_HOST="cryostat" \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -120,8 +120,6 @@ runDemoApps() {
         --pod cryostat-pod \
         --env QUARKUS_HTTP_PORT=10012 \
         --env JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
-        --env ORG_ACME_JMXHOST="localhost" \
-        --env ORG_ACME_JMXPORT="9898" \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -120,16 +120,16 @@ runDemoApps() {
         --pod cryostat-pod \
         --env QUARKUS_HTTP_PORT=10012 \
         --env JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
-        --env ORG_ACME_JMXHOST=localhost \
-        --env ORG_ACME_JMXPORT=9898 \
+        --env ORG_ACME_JMXHOST="localhost" \
+        --env ORG_ACME_JMXPORT="9898" \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
-        --env CRYOSTAT_AGENT_APP_NAME=quarkus-test-agent \
-        --env CRYOSTAT_AGENT_WEBSERVER_HOST=localhost \
-        --env CRYOSTAT_AGENT_WEBSERVER_PORT=9977 \
-        --env CRYOSTAT_AGENT_CALLBACK=http://localhost:9977/ \
+        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
+        --env CRYOSTAT_AGENT_WEBSERVER_PORT="9977" \
+        --env CRYOSTAT_AGENT_CALLBACK="http://localhost:9977/" \
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
-        --env CRYOSTAT_AGENT_TRUST_ALL=true \
-        --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo -n user:pass | base64)" \
+        --env CRYOSTAT_AGENT_TRUST_ALL="true" \
+        --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --rm -d quay.io/andrewazores/quarkus-test:0.0.9
 
     podman run \


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-agent/pull/9
Related to https://github.com/cryostatio/cryostat/issues/520
Related to https://github.com/cryostatio/cryostat/issues/760

Just a basic example using https://github.com/andrewazores/quarkus-test with the `cryostat-agent` built into the image and configured with the handful of env vars needed. The `:0.0.9` image referenced is built with the `jwt-flow` agent PR branch. As we clear some of the backlog on the agent itself and get it into better shape as a discovery plugin then we can start configuring projects to pull in the agent as a dependency from GitHub Packages (the agent already [publishes Maven artifact JARs there](https://github.com/cryostatio/cryostat-agent/packages/1601815)) and use that for development iterations on the agent.

I left a PR and comment on `-reports` a while back detailing some similar steps done to get that custom agent-equipped image built: https://github.com/cryostatio/cryostat-reports/pull/45 . This might have some more useful context to read.

Here's how it's now done for `quarkus-test`: https://github.com/andrewazores/quarkus-test/commit/1b0d31893567fdcdc0c8830f5ab07a901a110c7a