### PR TITLE
fix(api): fix GET /api serialization and webserver JFR event

### DIFF
--- a/src/container/include/cryostat.jfc
+++ b/src/container/include/cryostat.jfc
@@ -30,7 +30,7 @@
    0 ms
   </setting>
  </event>
- <event name="io.cyostat.net.web.WebServer.WebServerRequestEvent">
+ <event name="io.cyostat.net.web.WebServer.WebServerRequest">
   <setting name="enabled">
    true
   </setting>

--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -38,7 +38,9 @@
 package io.cryostat;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.Security;
+import java.util.logging.LogManager;
 
 import javax.inject.Singleton;
 
@@ -141,6 +143,10 @@ class Cryostat extends AbstractVerticle {
 
     public static void main(String[] args) throws IOException {
         final Client client = DaggerCryostat_Client.builder().build();
+        try (InputStream config = CryostatCore.class.getResourceAsStream("/logging.properties")) {
+            LogManager.getLogManager()
+                    .updateConfiguration(config, k -> ((o, n) -> o != null ? o : n));
+        }
         CryostatCore.initialize();
 
         Security.addProvider(BouncyCastleProviderSingleton.getInstance());

--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -144,8 +144,7 @@ class Cryostat extends AbstractVerticle {
     public static void main(String[] args) throws IOException {
         final Client client = DaggerCryostat_Client.builder().build();
         try (InputStream config = CryostatCore.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager()
-                    .updateConfiguration(config, k -> ((o, n) -> o != null ? o : n));
+            LogManager.getLogManager().updateConfiguration(config, k -> ((o, n) -> n));
         }
         CryostatCore.initialize();
 

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -44,8 +44,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -243,8 +241,6 @@ public class WebServer extends AbstractVerticle {
 
         this.server.requestHandler(
                 req -> {
-                    Instant start = Instant.now();
-
                     WebServerRequest evt =
                             new WebServerRequest(
                                     req.remoteAddress().host(),
@@ -256,13 +252,6 @@ public class WebServer extends AbstractVerticle {
                     req.response()
                             .endHandler(
                                     (res) -> {
-                                        logger.info(
-                                                "({}): {} {} {} {}ms",
-                                                req.remoteAddress().toString(),
-                                                req.method().toString(),
-                                                req.path(),
-                                                req.response().getStatusCode(),
-                                                Duration.between(start, Instant.now()).toMillis());
                                         evt.setStatusCode(req.response().getStatusCode());
                                         evt.end();
                                         if (evt.shouldCommit()) {

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -68,7 +68,6 @@ import io.cryostat.net.web.http.api.v2.ApiException;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
 import com.google.gson.Gson;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
@@ -77,10 +76,6 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.impl.BlockingHandlerDecorator;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Label;
-import jdk.jfr.Name;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
@@ -239,52 +234,7 @@ public class WebServer extends AbstractVerticle {
                     }
                 });
 
-        this.server.requestHandler(
-                req -> {
-                    WebServerRequest evt =
-                            new WebServerRequest(
-                                    req.remoteAddress().host(),
-                                    req.remoteAddress().port(),
-                                    req.method().toString(),
-                                    req.path());
-                    evt.begin();
-
-                    req.response()
-                            .endHandler(
-                                    (res) -> {
-                                        evt.setStatusCode(req.response().getStatusCode());
-                                        evt.end();
-                                        if (evt.shouldCommit()) {
-                                            evt.commit();
-                                        }
-                                    });
-                    router.handle(req);
-                });
-    }
-
-    @Name("io.cryostat.net.web.WebServer.WebServerRequest")
-    @Label("Web Server Request")
-    @Category("Cryostat")
-    @SuppressFBWarnings(
-            value = "URF_UNREAD_FIELD",
-            justification = "The event fields are recorded with JFR instead of accessed directly")
-    public static class WebServerRequest extends Event {
-        String host;
-        int port;
-        String method;
-        String path;
-        int statusCode;
-
-        public WebServerRequest(String host, int port, String method, String path) {
-            this.host = host;
-            this.port = port;
-            this.method = method;
-            this.path = path;
-        }
-
-        public void setStatusCode(int code) {
-            this.statusCode = code;
-        }
+        this.server.requestHandler(router::handle);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/ApiGetHandler.java
@@ -143,13 +143,13 @@ class ApiGetHandler extends AbstractV2RequestHandler<ApiGetHandler.ApiResponse> 
         final ApiVersion apiVersion;
 
         @SerializedName("verb")
-        final HttpMethod httpMethod;
+        final String httpMethod;
 
         final String path;
 
         SerializedHandler(RequestHandler handler) {
             this.apiVersion = handler.apiVersion();
-            this.httpMethod = handler.httpMethod();
+            this.httpMethod = handler.httpMethod().name();
             this.path = URI.create(handler.path()).normalize().toString();
         }
 

--- a/src/main/java/io/cryostat/net/web/http/generic/RequestLoggingHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/RequestLoggingHandler.java
@@ -37,42 +37,54 @@
  */
 package io.cryostat.net.web.http.generic;
 
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.RequestHandler;
+import io.cryostat.net.web.http.api.ApiVersion;
 
-import dagger.Binds;
-import dagger.Module;
-import dagger.multibindings.IntoSet;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerHandler;
 
-@Module
-public abstract class HttpGenericModule {
+class RequestLoggingHandler implements RequestHandler {
 
-    static final String NON_API_PATH = "^(?!/api/).*";
+    private final LoggerHandler delegate;
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindRequestLoggingHandler(RequestLoggingHandler handler);
+    @Inject
+    RequestLoggingHandler() {
+        this.delegate = LoggerHandler.create();
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsEnablingHandler(CorsEnablingHandler handler);
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.GENERIC;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindCorsOptionsHandler(CorsOptionsHandler handler);
+    @Override
+    public int getPriority() {
+        return 0;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindHealthGetHandler(HealthGetHandler handler);
+    @Override
+    public HttpMethod httpMethod() {
+        return null;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindHealthLivenessGetHandler(HealthLivenessGetHandler handler);
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return ResourceAction.NONE;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindStaticAssetsGetHandler(StaticAssetsGetHandler handler);
+    @Override
+    public String path() {
+        return ALL_PATHS;
+    }
 
-    @Binds
-    @IntoSet
-    abstract RequestHandler bindWebClientAssetsGetHandler(WebClientAssetsGetHandler handler);
+    @Override
+    public void handle(RoutingContext event) {
+        this.delegate.handle(event);
+    }
 }

--- a/src/main/java/io/cryostat/net/web/http/generic/RequestLoggingHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/generic/RequestLoggingHandler.java
@@ -90,8 +90,8 @@ class RequestLoggingHandler implements RequestHandler {
     }
 
     @Override
-    public void handle(RoutingContext event) {
-        HttpServerRequest req = event.request();
+    public void handle(RoutingContext ctx) {
+        HttpServerRequest req = ctx.request();
 
         WebServerRequest evt =
                 new WebServerRequest(
@@ -111,7 +111,7 @@ class RequestLoggingHandler implements RequestHandler {
                             }
                         });
 
-        this.delegate.handle(event);
+        this.delegate.handle(ctx);
     }
 
     @Name("io.cryostat.net.web.WebServer.WebServerRequest")

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,2 @@
+org.openjdk.jmc.level=OFF
+io.vertx.level=INFO

--- a/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.generic;
+
+import static org.mockito.Mockito.mock;
+
+import java.net.InetSocketAddress;
+
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.generic.RequestLoggingHandler.WebServerRequest;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerHandler;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequestLoggingHandlerTest {
+
+    RequestLoggingHandler handler;
+    MockedStatic<LoggerHandler> delegateStatic;
+    MockedConstruction<WebServerRequest> eventConstruction;
+    @Mock LoggerHandler delegate;
+
+    @BeforeEach
+    void setupEach() {
+        delegateStatic = Mockito.mockStatic(LoggerHandler.class);
+        delegateStatic.when(LoggerHandler::create).thenReturn(delegate);
+
+        eventConstruction = Mockito.mockConstruction(WebServerRequest.class);
+
+        this.handler = new RequestLoggingHandler();
+    }
+
+    @AfterEach
+    void cleanup() {
+        delegateStatic.close();
+        eventConstruction.close();
+    }
+
+    @Test
+    void shouldHandleAnyRequest() {
+        MatcherAssert.assertThat(handler.httpMethod(), Matchers.nullValue());
+    }
+
+    @Test
+    void shouldHandleCorrectPath() {
+        MatcherAssert.assertThat(handler.path(), Matchers.equalTo("*"));
+    }
+
+    @Test
+    void shouldHaveGenericVersion() {
+        MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.GENERIC));
+    }
+
+    @Test
+    void shouldBeAsync() {
+        Assertions.assertTrue(handler.isAsync());
+    }
+
+    @Test
+    void shouldHaveZeroPriority() {
+        MatcherAssert.assertThat(handler.getPriority(), Matchers.equalTo(0));
+    }
+
+    @Test
+    void shouldPerformNoResourceActions() {
+        MatcherAssert.assertThat(handler.resourceActions(), Matchers.empty());
+    }
+
+    @Test
+    void shouldHandleRequestByDelegating() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        SocketAddress addr =
+                SocketAddress.inetSocketAddress(
+                        InetSocketAddress.createUnresolved("localhost", 1234));
+        Mockito.when(req.remoteAddress()).thenReturn(addr);
+        Mockito.when(req.method()).thenReturn(HttpMethod.GET);
+        Mockito.when(req.path()).thenReturn("/some/path");
+
+        HttpServerResponse rep = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(req.response()).thenReturn(rep);
+
+        Mockito.verifyNoInteractions(delegate);
+        MatcherAssert.assertThat(eventConstruction.constructed(), Matchers.empty());
+
+        handler.handle(ctx);
+
+        Mockito.verify(delegate).handle(ctx);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldCheckAndCommitJfrEvent(boolean enabled) {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(ctx.request()).thenReturn(req);
+        SocketAddress addr =
+                SocketAddress.inetSocketAddress(
+                        InetSocketAddress.createUnresolved("localhost", 1234));
+        Mockito.when(req.remoteAddress()).thenReturn(addr);
+        Mockito.when(req.method()).thenReturn(HttpMethod.GET);
+        Mockito.when(req.path()).thenReturn("/some/path");
+
+        HttpServerResponse rep = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(req.response()).thenReturn(rep);
+
+        Mockito.verifyNoInteractions(delegate);
+        MatcherAssert.assertThat(eventConstruction.constructed(), Matchers.empty());
+
+        handler.handle(ctx);
+
+        MatcherAssert.assertThat(eventConstruction.constructed(), Matchers.hasSize(1));
+        WebServerRequest event = eventConstruction.constructed().get(0);
+
+        // We can't make these assertions because the event is a mock, so the constructor parameters
+        // are not assigned to fields
+        // MatcherAssert.assertThat(event.host, Matchers.equalTo(addr.host()));
+        // MatcherAssert.assertThat(event.port, Matchers.equalTo(addr.port()));
+        // MatcherAssert.assertThat(event.method, Matchers.equalTo("GET"));
+        // MatcherAssert.assertThat(event.path, Matchers.equalTo("/some/path"));
+
+        Mockito.verify(event, Mockito.times(0)).shouldCommit();
+        Mockito.verify(event, Mockito.times(0)).commit();
+
+        Mockito.when(event.shouldCommit()).thenReturn(enabled);
+
+        ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        Mockito.verify(rep).endHandler(endHandlerCaptor.capture());
+        Handler<Void> endHandler = endHandlerCaptor.getValue();
+        MatcherAssert.assertThat(endHandler, Matchers.notNullValue());
+
+        endHandler.handle(null);
+
+        Mockito.verify(event, Mockito.times(1)).shouldCommit();
+        Mockito.verify(event, Mockito.times(enabled ? 1 : 0)).commit();
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
@@ -165,6 +165,8 @@ class RequestLoggingHandlerTest {
 
         HttpServerResponse rep = Mockito.mock(HttpServerResponse.class);
         Mockito.when(req.response()).thenReturn(rep);
+        int sc = 200 + ((int) Math.random() * 300);
+        Mockito.when(rep.getStatusCode()).thenReturn(sc);
 
         Mockito.verifyNoInteractions(delegate);
         MatcherAssert.assertThat(eventConstruction.constructed(), Matchers.empty());
@@ -188,6 +190,7 @@ class RequestLoggingHandlerTest {
                         "/some/path"
                         )));
 
+        Mockito.verify(event, Mockito.times(0)).setStatusCode(Mockito.anyInt());
         Mockito.verify(event, Mockito.times(0)).shouldCommit();
         Mockito.verify(event, Mockito.times(0)).commit();
 
@@ -200,6 +203,7 @@ class RequestLoggingHandlerTest {
 
         endHandler.handle(null);
 
+        Mockito.verify(event, Mockito.times(1)).setStatusCode(sc);
         Mockito.verify(event, Mockito.times(1)).shouldCommit();
         Mockito.verify(event, Mockito.times(enabled ? 1 : 0)).commit();
     }

--- a/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/generic/RequestLoggingHandlerTest.java
@@ -43,6 +43,16 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.generic.RequestLoggingHandler.WebServerRequest;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerHandler;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -59,16 +69,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.cryostat.net.web.http.api.ApiVersion;
-import io.cryostat.net.web.http.generic.RequestLoggingHandler.WebServerRequest;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.LoggerHandler;
-
 @ExtendWith(MockitoExtension.class)
 class RequestLoggingHandlerTest {
 
@@ -83,10 +83,13 @@ class RequestLoggingHandlerTest {
         delegateStatic = Mockito.mockStatic(LoggerHandler.class);
         delegateStatic.when(LoggerHandler::create).thenReturn(delegate);
 
-        eventConstruction = Mockito.mockConstruction(WebServerRequest.class, (mock, ctx) -> {
-            eventConstructionArgs.clear();
-            eventConstructionArgs.addAll((List) ctx.arguments());
-        });
+        eventConstruction =
+                Mockito.mockConstruction(
+                        WebServerRequest.class,
+                        (mock, ctx) -> {
+                            eventConstructionArgs.clear();
+                            eventConstructionArgs.addAll((List) ctx.arguments());
+                        });
 
         this.handler = new RequestLoggingHandler();
     }
@@ -183,12 +186,9 @@ class RequestLoggingHandlerTest {
         // MatcherAssert.assertThat(event.port, Matchers.equalTo(addr.port()));
         // MatcherAssert.assertThat(event.method, Matchers.equalTo("GET"));
         // MatcherAssert.assertThat(event.path, Matchers.equalTo("/some/path"));
-        MatcherAssert.assertThat(eventConstructionArgs, Matchers.equalTo(List.of(
-                        "localhost",
-                        1234,
-                        "GET",
-                        "/some/path"
-                        )));
+        MatcherAssert.assertThat(
+                eventConstructionArgs,
+                Matchers.equalTo(List.of("localhost", 1234, "GET", "/some/path")));
 
         Mockito.verify(event, Mockito.times(0)).setStatusCode(Mockito.anyInt());
         Mockito.verify(event, Mockito.times(0)).shouldCommit();


### PR DESCRIPTION
Fixes #1191
Fixes #1192

- fix(api): GET /api returns properly serialized endpoint verb
- chore(log): replace request logging with Vertx impl
- correct event name and move into logging handler
