### PR TITLE
build(deps): bump graphql-java-extended-scalars from 17.0 to 19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
   <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
   <io.fabric8.client.version>6.2.0</io.fabric8.client.version>
   <io.vertx.web.version>4.3.4</io.vertx.web.version>
+  <!--
+    FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
+    https://github.com/vert-x3/vertx-web/blob/${io.vertx.web.version}/vertx-web-graphql/pom.xml#L35
+  -->
+  <com.graphql.java.extended.scalars.version>19.2</com.graphql.java.extended.scalars.version>
   <com.nimbusds.jose.jwt.version>9.25.6</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.71</org.bouncycastle.version>
   <org.jasypt.version>1.9.3</org.jasypt.version>
@@ -168,14 +173,9 @@
     <version>${io.vertx.web.version}</version>
   </dependency>
   <dependency>
-      <!--
-      FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
-      https://github.com/graphql-java/graphql-java-extended-scalars/commit/2bc8468753ffe5d2e112416207ab749173712c10
-      https://github.com/vert-x3/vertx-web/blob/4.2.5/vertx-web-graphql/pom.xml#L35
-      -->
     <groupId>com.graphql-java</groupId>
     <artifactId>graphql-java-extended-scalars</artifactId>
-    <version>17.0</version>
+    <version>${com.graphql.java.extended.scalars.version}</version>
   </dependency>
   <dependency>
     <groupId>com.nimbusds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
     https://github.com/vert-x3/vertx-web/blob/${io.vertx.web.version}/vertx-web-graphql/pom.xml#L35
   -->
-  <com.graphql.java.extended.scalars.version>19.2</com.graphql.java.extended.scalars.version>
+  <com.graphql.java.extended.scalars.version>19.0</com.graphql.java.extended.scalars.version>
   <com.nimbusds.jose.jwt.version>9.25.6</com.nimbusds.jose.jwt.version>
   <org.bouncycastle.version>1.71</org.bouncycastle.version>
   <org.jasypt.version>1.9.3</org.jasypt.version>


### PR DESCRIPTION
Related to #1230
