### PR TITLE
chore(scripts): replace xpath with 'mvn help:evaluate' and default to running version tagged image

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ exec:exec@destroy-pod`
 *To run on local podman, [cgroups v2](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html) should be enabled.
 This allows resource configuration for any rootless containers running on podman. To ensure podman works with cgroups v2, follow these [instructions](https://podman.io/blogs/2019/10/29/podman-crun-f31.html).
 
-*Requires `xpath` to be available on your `$PATH` - ex. `dnf install perl-XML-XPath`.
-
 Note: If your podman runtime is set to runc v1.0.0-rc91 or later it is not necessary to change it to crun as recommended in the instructions, since this version of runc supports cgroups v2. The article refers to an older version of runc.
 
 ## CONFIGURATION

--- a/devserver.sh
+++ b/devserver.sh
@@ -60,18 +60,22 @@ createPod() {
 }
 
 runReportGenerator() {
+    local stream; local tag; local port;
+    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.imageStream -q -DforceStdout)"
+    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.version -q -DforceStdout)"
+    port="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.port -q -DforceStdout)"
     podman run \
         --name "${reports_container}" \
         --pod "${podname}" \
         --restart on-failure \
-        --env QUARKUS_HTTP_PORT=10001 \
+        --env QUARKUS_HTTP_PORT="${port}" \
         --rm -d quay.io/cryostat/cryostat-reports:latest
 }
 
 runJfrDatasource() {
     local stream; local tag;
-    stream="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.imageStream/text()' pom.xml)"
-    tag="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.version/text()' pom.xml)"
+    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.jfr-datasource.imageStream -q -DforceStdout)"
+    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.jfr-datasource.version -q -DforceStdout)"
     podman run \
         --name "${datasource_container}" \
         --pod "${podname}" \
@@ -80,8 +84,8 @@ runJfrDatasource() {
 
 runGrafana() {
     local stream; local tag;
-    stream="$(xpath -q -e 'project/properties/cryostat.itest.grafana.imageStream/text()' pom.xml)"
-    tag="$(xpath -q -e 'project/properties/cryostat.itest.grafana.version/text()' pom.xml)"
+    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.grafana.imageStream -q -DforceStdout)"
+    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.grafana.version -q -DforceStdout)"
     podman run \
         --name "${grafana_container}" \
         --pod "${podname}" \

--- a/devserver.sh
+++ b/devserver.sh
@@ -69,7 +69,7 @@ runReportGenerator() {
         --pod "${podname}" \
         --restart on-failure \
         --env QUARKUS_HTTP_PORT="${port}" \
-        --rm -d quay.io/cryostat/cryostat-reports:latest
+        --rm -d "${stream}:${tag}"
 }
 
 runJfrDatasource() {

--- a/devserver.sh
+++ b/devserver.sh
@@ -61,9 +61,9 @@ createPod() {
 
 runReportGenerator() {
     local stream; local tag; local port;
-    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.imageStream -q -DforceStdout)"
-    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.version -q -DforceStdout)"
-    port="$(${MVN} help:evaluate -Dexpression=cryostat.itest.reports.port -q -DforceStdout)"
+    stream="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.reports.imageStream -q -DforceStdout)"
+    tag="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.reports.version -q -DforceStdout)"
+    port="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.reports.port -q -DforceStdout)"
     podman run \
         --name "${reports_container}" \
         --pod "${podname}" \
@@ -74,8 +74,8 @@ runReportGenerator() {
 
 runJfrDatasource() {
     local stream; local tag;
-    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.jfr-datasource.imageStream -q -DforceStdout)"
-    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.jfr-datasource.version -q -DforceStdout)"
+    stream="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.jfr-datasource.imageStream -q -DforceStdout)"
+    tag="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.jfr-datasource.version -q -DforceStdout)"
     podman run \
         --name "${datasource_container}" \
         --pod "${podname}" \
@@ -84,8 +84,8 @@ runJfrDatasource() {
 
 runGrafana() {
     local stream; local tag;
-    stream="$(${MVN} help:evaluate -Dexpression=cryostat.itest.grafana.imageStream -q -DforceStdout)"
-    tag="$(${MVN} help:evaluate -Dexpression=cryostat.itest.grafana.version -q -DforceStdout)"
+    stream="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.grafana.imageStream -q -DforceStdout)"
+    tag="$(${MVN} -o -B -q help:evaluate -Dexpression=cryostat.itest.grafana.version -q -DforceStdout)"
     podman run \
         --name "${grafana_container}" \
         --pod "${podname}" \

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
   <cryostat.itest.jfr-datasource.port>8080</cryostat.itest.jfr-datasource.port>
   <cryostat.itest.jfr-datasource.imageStream>quay.io/cryostat/jfr-datasource</cryostat.itest.jfr-datasource.imageStream>
   <cryostat.itest.jfr-datasource.version>latest</cryostat.itest.jfr-datasource.version>
+  <cryostat.itest.reports.port>10001</cryostat.itest.reports.port>
+  <cryostat.itest.reports.imageStream>quay.io/cryostat/cryostat-reports</cryostat.itest.reports.imageStream>
+  <cryostat.itest.reports.version>latest</cryostat.itest.reports.version>
   <cryostat.itest.jmx.db-passwd>${cryostat.itest.podName}</cryostat.itest.jmx.db-passwd>
 
   <io.reactiverse.plugin.version>1.0.27</io.reactiverse.plugin.version>

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -16,15 +16,15 @@ if [ -z "${MVN}" ]; then
 fi
 
 if [ -z "${POD_NAME}" ]; then
-    POD_NAME="$(xpath -q -e 'project/properties/cryostat.itest.podName/text()' pom.xml)"
+    POD_NAME="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.podName)"
 fi
 
 if [ -z "${CONTAINER_NAME}" ]; then
-    CONTAINER_NAME="$(xpath -q -e 'project/properties/cryostat.itest.containerName/text()' pom.xml)"
+    CONTAINER_NAME="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.containerName)"
 fi
 
 if [ -z "${ITEST_IMG_VERSION}" ]; then
-    ITEST_IMG_VERSION="$(xpath -q -e 'project/version/text()' pom.xml)"
+    ITEST_IMG_VERSION="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=project.version)"
     ITEST_IMG_VERSION="${ITEST_IMG_VERSION,,}" # lowercase
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ fi
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"
 
 if [ -z "$CRYOSTAT_RJMX_PORT" ]; then
-    CRYOSTAT_RJMX_PORT="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
+    CRYOSTAT_RJMX_PORT="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
 fi
 
 if [ -z "$CRYOSTAT_RMI_PORT" ]; then
@@ -29,11 +29,11 @@ if [ -z "$CRYOSTAT_RMI_PORT" ]; then
 fi
 
 if [ -z "$CRYOSTAT_WEB_HOST" ]; then
-    CRYOSTAT_WEB_HOST="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
+    CRYOSTAT_WEB_HOST="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
 fi
 
 if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-    CRYOSTAT_WEB_PORT="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
+    CRYOSTAT_WEB_PORT="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
 fi
 
 if [ -z "$CRYOSTAT_EXT_WEB_PORT" ]; then

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [ -z "$CRYOSTAT_IMAGE" ]; then
-    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:latest"
+    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:$(${MVN} validate help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.imageVersionLower)"
 fi
 
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,10 @@
 set -x
 set -e
 
+if [ -z "${MVN}" ]; then
+    MVN="$(which mvn)"
+fi
+
 cleanup() {
     podman pod stop cryostat-pod
     podman pod rm cryostat-pod
@@ -17,7 +21,7 @@ fi
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"
 
 if [ -z "$CRYOSTAT_RJMX_PORT" ]; then
-    CRYOSTAT_RJMX_PORT="$(xpath -q -e 'project/properties/cryostat.rjmxPort/text()' pom.xml)"
+    CRYOSTAT_RJMX_PORT="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
 fi
 
 if [ -z "$CRYOSTAT_RMI_PORT" ]; then
@@ -25,11 +29,11 @@ if [ -z "$CRYOSTAT_RMI_PORT" ]; then
 fi
 
 if [ -z "$CRYOSTAT_WEB_HOST" ]; then
-    CRYOSTAT_WEB_HOST="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
+    CRYOSTAT_WEB_HOST="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
 fi
 
 if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-    CRYOSTAT_WEB_PORT="$(xpath -q -e 'project/properties/cryostat.itest.webPort/text()' pom.xml)"
+    CRYOSTAT_WEB_PORT="$(${MVN} help:evaluate -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
 fi
 
 if [ -z "$CRYOSTAT_EXT_WEB_PORT" ]; then

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -199,6 +199,9 @@ runGrafana() {
 
 runReportGenerator() {
     local RJMX_PORT=10000
+    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.imageStream)"
+    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.version)"
+    port="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.port)"
     podman run \
         --name reports \
         --pull always \
@@ -207,8 +210,8 @@ runReportGenerator() {
         --memory 512M \
         --restart on-failure \
         --env JAVA_OPTIONS="-XX:ActiveProcessorCount=1 -XX:+UseSerialGC -Dorg.openjdk.jmc.flightrecorder.parser.singlethreaded=true -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.rmi.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false" \
-        --env QUARKUS_HTTP_PORT=10001 \
-        --rm -d quay.io/cryostat/cryostat-reports:latest
+        --env QUARKUS_HTTP_PORT="${port}" \
+        --rm -d "${stream}:${tag}"
 }
 
 createPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -4,12 +4,16 @@
 set -x
 set -e
 
+if [ -z "${MVN}" ]; then
+    MVN="$(which mvn)"
+fi
+
 runCryostat() {
     local DIR; local host; local datasourcePort; local grafanaPort;
     DIR="$(dirname "$(readlink -f "$0")")"
-    host="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
-    datasourcePort="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"
-    grafanaPort="$(xpath -q -e 'project/properties/cryostat.itest.grafana.port/text()' pom.xml)"
+    host="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
+    datasourcePort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
+    grafanaPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.port)"
     # credentials `user:pass`
     echo "user:d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1" > "./conf/cryostat-users.properties"
 
@@ -63,8 +67,8 @@ runPostgres() {
         mkdir "$(dirname "$0")/conf/postgres"
     fi
     local image; local version;
-    image="$(xpath -q -e 'project/properties/postgres.image/text()' pom.xml)"
-    version="$(xpath -q -e 'project/properties/postgres.version/text()' pom.xml)"
+    image="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=postgres.image)"
+    version="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=postgres.version)"
     podman run \
         --name postgres \
         --pod cryostat-pod \
@@ -105,7 +109,7 @@ runDemoApps() {
 
     local webPort;
     if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-        webPort="$(xpath -q -e 'project/properties/cryostat.itest.webPort/text()' pom.xml)"
+        webPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
     else
         webPort="${CRYOSTAT_WEB_PORT}"
     fi
@@ -168,8 +172,8 @@ runDemoApps() {
 
 runJfrDatasource() {
     local stream; local tag;
-    stream="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.imageStream/text()' pom.xml)"
-    tag="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.version/text()' pom.xml)"
+    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.imageStream)"
+    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.version)"
     podman run \
         --name jfr-datasource \
         --pull always \
@@ -179,10 +183,10 @@ runJfrDatasource() {
 
 runGrafana() {
     local stream; local tag; local host; local port;
-    stream="$(xpath -q -e 'project/properties/cryostat.itest.grafana.imageStream/text()' pom.xml)"
-    tag="$(xpath -q -e 'project/properties/cryostat.itest.grafana.version/text()' pom.xml)"
-    host="$(xpath -q -e 'project/properties/cryostat.itest.webHost/text()' pom.xml)"
-    port="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"
+    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.imageStream)"
+    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.version)"
+    host="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
+    port="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
     podman run \
         --name grafana \
         --pull always \
@@ -209,10 +213,10 @@ runReportGenerator() {
 
 createPod() {
     local jmxPort; local webPort; local datasourcePort; local grafanaPort;
-    jmxPort="$(xpath -q -e 'project/properties/cryostat.rjmxPort/text()' pom.xml)"
-    webPort="$(xpath -q -e 'project/properties/cryostat.webPort/text()' pom.xml)"
-    datasourcePort="$(xpath -q -e 'project/properties/cryostat.itest.jfr-datasource.port/text()' pom.xml)"
-    grafanaPort="$(xpath -q -e 'project/properties/cryostat.itest.grafana.port/text()' pom.xml)"
+    jmxPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
+    webPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.webPort)"
+    datasourcePort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
+    grafanaPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.port)"
     podman pod create \
         --replace \
         --hostname cryostat \


### PR DESCRIPTION
Related to #1118
Fixes #1247
Fixes #1248

- chore(devserver): replace xpath with 'mvn help:evaluate'
- chore(run.sh): replace xpath with 'mvn help:evaluate'
- chore(smoketest.sh): replace xpath with 'mvn help:evaluate'
- chore(run.sh): use project version from pom for version to run
