### PR TITLE
feat(targets): dryrun query params for testing connectUrl and credentials

### DIFF
--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -153,7 +153,6 @@ public class CredentialsManager
         }
     }
 
-    @Deprecated
     public static String targetIdToMatchExpression(String targetId) {
         if (StringUtils.isBlank(targetId)) {
             return null;

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -196,7 +196,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             return new IntermediateResponse<ServiceRef>().body(serviceRef);
         } catch (JvmIdGetException e) {
             if (AbstractAuthenticatedRequestHandler.isJmxAuthFailure(e)) {
-                throw new ApiException(406, "Credentials Not Acceptable", e);
+                throw new ApiException(406, "Credentials Not Provided/Not Acceptable", e);
             }
             if (AbstractAuthenticatedRequestHandler.isUnknownTargetFailure(e)) {
                 throw new ApiException(404, "Target Not Found", e);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -170,7 +170,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             MultiMap queries = params.getQueryParams();
             boolean dryRun =
                     StringUtils.isNotBlank(queries.get("dryrun"))
-                            && Boolean.TRUE.equals(Boolean.valueOf(queries.get("dryrun")));
+                            && Boolean.valueOf(queries.get("dryrun"));
 
             String jvmId = jvmIdHelper.getJvmId(uri.toString(), !dryRun, credentials);
             ServiceRef serviceRef = new ServiceRef(jvmId, uri, alias);
@@ -196,7 +196,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             return new IntermediateResponse<ServiceRef>().body(serviceRef);
         } catch (JvmIdGetException e) {
             if (AbstractAuthenticatedRequestHandler.isJmxAuthFailure(e)) {
-                throw new ApiException(406, "Credentials Not Provided/Not Acceptable", e);
+                throw new ApiException(420, "JMX Credentials Not Provided or Not Valid", e);
             }
             if (AbstractAuthenticatedRequestHandler.isUnknownTargetFailure(e)) {
                 throw new ApiException(404, "Target Not Found", e);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -178,7 +178,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                             : Optional.of(new Credentials(username, password));
 
             if (!dryRun && credentials.isPresent()) {
-                String matchExpression = String.format("target.connectUrl == '%s'", connectUrl);
+                String matchExpression = CredentialsManager.targetIdToMatchExpression(connectUrl);
                 int id = credentialsManager.addCredentials(matchExpression, credentials.get());
                 notificationFactory
                         .createBuilder()

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -196,7 +196,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             return new IntermediateResponse<ServiceRef>().body(serviceRef);
         } catch (JvmIdGetException e) {
             if (AbstractAuthenticatedRequestHandler.isJmxAuthFailure(e)) {
-                throw new ApiException(420, "JMX Credentials Not Provided or Not Valid", e);
+                throw new ApiException(427, "JMX Authentication Failure", e);
             }
             if (AbstractAuthenticatedRequestHandler.isUnknownTargetFailure(e)) {
                 throw new ApiException(404, "Target Not Found", e);

--- a/src/main/java/io/cryostat/recordings/JvmIdHelper.java
+++ b/src/main/java/io/cryostat/recordings/JvmIdHelper.java
@@ -178,10 +178,10 @@ public class JvmIdHelper extends AbstractEventEmitter<JvmIdHelper.IdEvent, Strin
         return getJvmId(targetId, true, Optional.empty());
     }
 
-    public String getJvmId(String targetId, boolean saveToCached, Optional<Credentials> credentials)
+    public String getJvmId(String targetId, boolean cache, Optional<Credentials> credentials)
             throws JvmIdGetException {
         try {
-            return (saveToCached ? this.ids.get(targetId) : computeJvmId(targetId, credentials))
+            return (cache ? this.ids.get(targetId) : computeJvmId(targetId, credentials))
                     .get(connectionTimeoutSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException | ScriptException e) {
             logger.warn("Could not get jvmId for target {}", targetId);

--- a/src/main/java/io/cryostat/recordings/JvmIdHelper.java
+++ b/src/main/java/io/cryostat/recordings/JvmIdHelper.java
@@ -165,13 +165,18 @@ public class JvmIdHelper extends AbstractEventEmitter<JvmIdHelper.IdEvent, Strin
     }
 
     public String getJvmId(ConnectionDescriptor connectionDescriptor) throws JvmIdGetException {
-        return getJvmId(connectionDescriptor.getTargetId());
+        return getJvmId(connectionDescriptor.getTargetId(), true);
     }
 
     public String getJvmId(String targetId) throws JvmIdGetException {
+        return getJvmId(targetId, true);
+    }
+
+    public String getJvmId(String targetId, boolean saveToCached) throws JvmIdGetException {
         try {
-            return this.ids.get(targetId).get(connectionTimeoutSeconds, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            return (saveToCached ? this.ids.get(targetId) : computeJvmId(targetId))
+                    .get(connectionTimeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException | ScriptException e) {
             logger.warn("Could not get jvmId for target {}", targetId);
             throw new JvmIdGetException(e, targetId);
         }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -204,6 +204,7 @@ class TargetsPostHandlerTest {
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
         Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
                 .thenReturn("id");
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
@@ -223,6 +224,8 @@ class TargetsPostHandlerTest {
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
         Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
                 .thenReturn("id");
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
@@ -233,8 +236,6 @@ class TargetsPostHandlerTest {
         attrs.set("annotations.cryostat.HOST", "app.example.com");
         attrs.set("annotations.cryostat.PID", "1234");
         attrs.set("annotations.cryostat.MADEUPKEY", "should not appear");
-
-        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
 
         IntermediateResponse<ServiceRef> response = handler.handle(params);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
@@ -286,6 +287,7 @@ class TargetsPostHandlerTest {
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(queries);
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
         Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
                 .thenReturn("id");
 
@@ -317,6 +319,7 @@ class TargetsPostHandlerTest {
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(queries);
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
         Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
                 .thenReturn("id");

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -441,6 +441,6 @@ class TargetsPostHandlerTest {
                 .thenThrow(jvmIdGetException);
 
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(406));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(420));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -441,6 +441,6 @@ class TargetsPostHandlerTest {
                 .thenThrow(jvmIdGetException);
 
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
-        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(420));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -148,7 +148,11 @@ class TargetsPostHandlerTest {
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
         Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
 
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
@@ -205,7 +209,11 @@ class TargetsPostHandlerTest {
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
 
@@ -226,7 +234,11 @@ class TargetsPostHandlerTest {
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
         String alias = "TestTarget";
@@ -265,7 +277,11 @@ class TargetsPostHandlerTest {
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
 
@@ -288,7 +304,11 @@ class TargetsPostHandlerTest {
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
         Mockito.when(params.getQueryParams()).thenReturn(queries);
         Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
 
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
@@ -321,7 +341,11 @@ class TargetsPostHandlerTest {
         Mockito.when(params.getQueryParams()).thenReturn(queries);
         Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
         Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
-        Mockito.when(jvmIdHelper.getJvmId(Mockito.anyString(), Mockito.anyBoolean()))
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
                 .thenReturn("id");
 
         String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -47,7 +47,10 @@ import java.util.Set;
 import io.cryostat.MainModule;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
 import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.messaging.notifications.Notification;
+import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.http.HttpMimeType;
@@ -56,6 +59,7 @@ import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.platform.internal.CustomTargetPlatformClient;
 import io.cryostat.recordings.JvmIdHelper;
+import io.cryostat.rules.MatchExpressionValidationException;
 
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
@@ -73,6 +77,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openjdk.nashorn.internal.runtime.ParserException;
 
 @ExtendWith(MockitoExtension.class)
 class TargetsPostHandlerTest {
@@ -84,10 +89,30 @@ class TargetsPostHandlerTest {
     @Mock JvmIdHelper jvmIdHelper;
     @Mock CustomTargetPlatformClient customTargetPlatformClient;
     @Mock Logger logger;
+    @Mock NotificationFactory notificationFactory;
+    @Mock Notification.Builder notificationBuilder;
+    @Mock Notification notification;
     Gson gson = MainModule.provideGson(logger);
 
     @BeforeEach
     void setup() {
+        Mockito.lenient().when(notificationFactory.createBuilder()).thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.meta(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaCategory(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(Notification.MetaType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(HttpMimeType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.message(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
         this.handler =
                 new TargetsPostHandler(
                         auth,
@@ -96,6 +121,7 @@ class TargetsPostHandlerTest {
                         storage,
                         jvmIdHelper,
                         customTargetPlatformClient,
+                        notificationFactory,
                         logger);
     }
 
@@ -159,6 +185,50 @@ class TargetsPostHandlerTest {
         String alias = "TestTarget";
         attrs.set("connectUrl", connectUrl);
         attrs.set("alias", alias);
+
+        IntermediateResponse<ServiceRef> response = handler.handle(params);
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+        ArgumentCaptor<ServiceRef> refCaptor = ArgumentCaptor.forClass(ServiceRef.class);
+        Mockito.verify(customTargetPlatformClient).addTarget(refCaptor.capture());
+        ServiceRef captured = refCaptor.getValue();
+        MatcherAssert.assertThat(captured.getServiceUri(), Matchers.equalTo(new URI(connectUrl)));
+        MatcherAssert.assertThat(captured.getAlias(), Matchers.equalTo(Optional.of(alias)));
+        MatcherAssert.assertThat(captured.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
+        MatcherAssert.assertThat(
+                captured.getCryostatAnnotations(),
+                Matchers.equalTo(Map.of(AnnotationKey.REALM, "Custom Targets")));
+        MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(captured));
+    }
+
+    @Test
+    void testSuccessfulRequestWithCredentials() throws Exception {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+        Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        Mockito.when(
+                        credentialsManager.addCredentials(
+                                Mockito.anyString(), Mockito.any(Credentials.class)))
+                .thenReturn(1001);
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
+                .thenReturn("id");
+
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        String alias = "TestTarget";
+        String username = "username";
+        String password = "password";
+
+        attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", alias);
+        attrs.set("username", username);
+        attrs.set("password", password);
 
         IntermediateResponse<ServiceRef> response = handler.handle(params);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
@@ -442,5 +512,36 @@ class TargetsPostHandlerTest {
 
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(427));
+    }
+
+    @Test
+    void testRequestWithMatchExpressionValidationException() throws Exception {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        MultiMap queries = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+        Mockito.when(params.getQueryParams()).thenReturn(queries);
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
+
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        String alias = "TestTarget";
+        String username = "username";
+        String password = "password";
+
+        attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", alias);
+        attrs.set("username", username);
+        attrs.set("password", password);
+
+        Exception cause = new ParserException("Parse failed");
+        Exception matchExpressionValidationException =
+                new MatchExpressionValidationException(cause);
+        Mockito.when(
+                        credentialsManager.addCredentials(
+                                Mockito.anyString(), Mockito.any(Credentials.class)))
+                .thenThrow(matchExpressionValidationException);
+
+        ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(params));
+        MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
 }

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -250,7 +250,7 @@ public class CustomTargetsIT extends StandardSelfTest {
         MatcherAssert.assertThat(storedCredential.id, Matchers.any(Integer.class));
         MatcherAssert.assertThat(
                 storedCredential.matchExpression,
-                Matchers.equalTo("target.connectUrl == 'localhost:0'"));
+                Matchers.equalTo("target.connectUrl == \"localhost:0\""));
         MatcherAssert.assertThat(
                 storedCredential.numMatchingTargets, Matchers.equalTo(Integer.valueOf(1)));
 

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -66,6 +66,27 @@ public class CustomTargetsIT extends StandardSelfTest {
 
     @Test
     @Order(1)
+    void shouldBeAbleToTestTargetConnection() throws InterruptedException, ExecutionException {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        form.add("connectUrl", "localhost:0");
+        form.add("alias", "self");
+
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        webClient
+                .post("/api/v2/targets?dryrun=true")
+                .sendForm(
+                        form,
+                        ar -> {
+                            assertRequestStatus(ar, response);
+                            response.complete(ar.result().bodyAsJsonObject());
+                        });
+        JsonObject body = response.get().getJsonObject("data").getJsonObject("result");
+        MatcherAssert.assertThat(body.getString("connectUrl"), Matchers.equalTo("localhost:0"));
+        MatcherAssert.assertThat(body.getString("alias"), Matchers.equalTo("self"));
+    }
+
+    @Test
+    @Order(2)
     void shouldBeAbleToDefineTarget()
             throws TimeoutException, ExecutionException, InterruptedException {
         MultiMap form = MultiMap.caseInsensitiveMultiMap();
@@ -121,7 +142,7 @@ public class CustomTargetsIT extends StandardSelfTest {
     }
 
     @Test
-    @Order(2)
+    @Order(3)
     void targetShouldAppearInListing()
             throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<JsonArray> response = new CompletableFuture<>();
@@ -185,7 +206,7 @@ public class CustomTargetsIT extends StandardSelfTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void shouldBeAbleToDeleteTarget()
             throws TimeoutException, ExecutionException, InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
@@ -233,7 +254,7 @@ public class CustomTargetsIT extends StandardSelfTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void targetShouldNoLongerAppearInListing() throws ExecutionException, InterruptedException {
         CompletableFuture<JsonArray> response = new CompletableFuture<>();
         webClient

--- a/src/test/java/itest/util/http/StoredCredential.java
+++ b/src/test/java/itest/util/http/StoredCredential.java
@@ -41,4 +41,12 @@ public class StoredCredential {
     public int id;
     public String matchExpression;
     public int numMatchingTargets;
+
+    public StoredCredential(int id, String matchExpression, int numMatchingTargets) {
+        this.id = id;
+        this.matchExpression = matchExpression;
+        this.numMatchingTargets = numMatchingTargets;
+    }
+
+    public StoredCredential() {}
 }


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-web/issues/592

This added the back-end support for test connection UI via `dryrun` query parameter. I chose another status code for JMX Auth Failure here is to avoid returning `427` that triggers openning up Auth Modal in the front-end. Another way is to re-use 427 but there must be a way for the front-end to know which requests are dryruns (i.e. maybe a custom header?)

**Manual Tests**

Using `localhost:9091` here to go around duplicate target error:

- With credentials
```bash
https --form POST https://localhost:8181/api/v2/targets?dryrun=true \
connectUrl='service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi' \
alias="self" \
username="smoketest" \
password="smoketest" \
--verify=no \
--auth user:pass \
--auth-type basic
```

For non-dryrun requests (saving target), the workaround could be the front-end first posts a credentials with the matchExpression that matches this target. Then, cached when computing jvmid can grab it from there.

- Without credentials
```bash
https --form POST https://localhost:8181/api/v2/targets?dryrun=true \
connectUrl='service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi' \
alias="self" \
--verify=no \
--auth user:pass \
--auth-type basic
```