### PR TITLE
chore(smoketest): correct conflicting discovery plugins

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -148,20 +148,6 @@ runDemoApps() {
         --env ORG_ACME_JMXPORT="9097" \
         -d quay.io/andrewazores/quarkus-test:0.0.10
 
-    podman run \
-        --name quarkus-test-plugin-2 \
-        --pod cryostat-pod \
-        --restart unless-stopped \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9197 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" \
-        --env QUARKUS_HTTP_PORT=10011 \
-        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="true" \
-        --env ORG_ACME_CRYOSTATSERVICE_AUTHORIZATION="Basic $(printf user:pass | base64)" \
-        --env ORG_ACME_CRYOSTATSERVICE_MP_REST_URL="${protocol}://cryostat:${webPort}" \
-        --env ORG_ACME_CRYOSTATSERVICE_CALLBACK_HOST="cryostat" \
-        --env ORG_ACME_JMXHOST="cryostat" \
-        --env ORG_ACME_JMXPORT="9197" \
-        -d quay.io/andrewazores/quarkus-test:0.0.10
-
     # copy a jboss-client.jar into /clientlib first
     # manual entry URL: service:jmx:remote+http://localhost:9990
     podman run \
@@ -260,7 +246,6 @@ createPod() {
     # 10000: cryostat-reports RJMX
     # 10001: cryostat-reports HTTP
     # 10010: quarkus-test-plugin HTTP
-    # 10011: quarkus-test-plugin-2 HTTP
 }
 
 destroyPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -120,10 +120,10 @@ runDemoApps() {
     fi
 
     podman run \
-        --name quarkus-test-agent \
+        --name quarkus-test-agent-1 \
         --pod cryostat-pod \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
-        --env QUARKUS_HTTP_PORT=10012 \
+        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env QUARKUS_HTTP_PORT=10010 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
@@ -135,18 +135,19 @@ runDemoApps() {
         --rm -d quay.io/andrewazores/quarkus-test:0.0.10
 
     podman run \
-        --name quarkus-test-plugin \
+        --name quarkus-test-agent-2 \
         --pod cryostat-pod \
-        --restart unless-stopped \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
-        --env QUARKUS_HTTP_PORT=10010 \
-        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="true" \
-        --env ORG_ACME_CRYOSTATSERVICE_AUTHORIZATION="Basic $(printf user:pass | base64)" \
-        --env ORG_ACME_CRYOSTATSERVICE_MP_REST_URL="${protocol}://cryostat:${webPort}" \
-        --env ORG_ACME_CRYOSTATSERVICE_CALLBACK_HOST="cryostat" \
-        --env ORG_ACME_JMXHOST="cryostat" \
-        --env ORG_ACME_JMXPORT="9097" \
-        -d quay.io/andrewazores/quarkus-test:0.0.10
+        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9098 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env QUARKUS_HTTP_PORT=10011 \
+        --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
+        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
+        --env CRYOSTAT_AGENT_WEBSERVER_PORT="9988" \
+        --env CRYOSTAT_AGENT_CALLBACK="http://localhost:9988/" \
+        --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
+        --env CRYOSTAT_AGENT_TRUST_ALL="true" \
+        --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
+        --rm -d quay.io/andrewazores/quarkus-test:0.0.10
 
     # copy a jboss-client.jar into /clientlib first
     # manual entry URL: service:jmx:remote+http://localhost:9990
@@ -236,16 +237,17 @@ createPod() {
     # 9093: vertx-fib-demo-1 RJMX
     # 9094: vertx-fib-demo-2 RJMX
     # 9095: vertx-fib-demo-3 RJMX
-    # 9096: quarkus-test RJMX
-    # 9097: quarkus-test-plugin RJMX
-    # 9197: quarkus-test-plugin-2 RJMX
-    # 9999: quarkus-test HTTP
+    # 9097: quarkus-test-agent-1 RJMX
+    # 9098: quarkus-test-agent-2 RJMX
     # 8082: Wildfly HTTP
     # 9990: Wildfly Admin Console
     # 9991: Wildfly RJMX
+    # 9977: quarkus-test-agent-1 Agent-HTTP
+    # 9988: quarkus-test-agent-2 Agent-HTTP
     # 10000: cryostat-reports RJMX
     # 10001: cryostat-reports HTTP
-    # 10010: quarkus-test-plugin HTTP
+    # 10010: quarkus-test-agent-1 HTTP
+    # 10011: quarkus-test-agent-2 HTTP
 }
 
 destroyPod() {


### PR DESCRIPTION
Fixes #1253

The previous setup had two different `quarkus-test` app instances configured to use their own built-in Discovery Plugin implementation in application code, plus another third instance configured to use an early build of the Cryostat Agent to act as the associated Discovery Plugin. These configs created conflicts where two plugins tried to register with the same information, and also resulted in the containers being unable to shut down cleanly because the Agent code does not yet properly handle being improperly initialized and missing some of the expected environment variables/system properties.

These things could be fixed by correcting the configs for the applications' plugin implementations and fixing the broken bad state handling in the agent, but it was quicker, easier, and probably more valuable to just switch the overall setup to using two app instances, both using the Agent implementation with correct configurations and disabled app-level implementations.
