### PR TITLE
feat(probes): Allow TargetProbePostHandler to send notification of probe events

### DIFF
--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -166,6 +166,8 @@ if [ -n "$CRYOSTAT_JUL_CONFIG" ]; then
     FLAGS+=("-Djava.util.logging.config.file=$CRYOSTAT_JUL_CONFIG")
 fi
 
+FLAGS+=("-javaagent:/opt/cryostat.d/conf.d/jmc_agent.jar")
+
 CLASSPATH="$( cat /app/jib-classpath-file )"
 if [ -n "$CRYOSTAT_CLIENTLIB_PATH" ]; then
     CLASSPATH="$CLASSPATH:$CRYOSTAT_CLIENTLIB_PATH/*"

--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -166,8 +166,6 @@ if [ -n "$CRYOSTAT_JUL_CONFIG" ]; then
     FLAGS+=("-Djava.util.logging.config.file=$CRYOSTAT_JUL_CONFIG")
 fi
 
-FLAGS+=("-javaagent:/opt/cryostat.d/conf.d/jmc_agent.jar")
-
 CLASSPATH="$( cat /app/jib-classpath-file )"
 if [ -n "$CRYOSTAT_CLIENTLIB_PATH" ]; then
     CLASSPATH="$CLASSPATH:$CRYOSTAT_CLIENTLIB_PATH/*"

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetProbePostHandler.java
@@ -39,7 +39,6 @@ package io.cryostat.net.web.http.api.v2;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,28 +165,31 @@ class TargetProbePostHandler extends AbstractV2RequestHandler<Void> {
                 getConnectionDescriptorFromParams(requestParams),
                 connection -> {
                     AgentJMXHelper helper = new AgentJMXHelper(connection.getHandle());
-                    helper.defineEventProbes(probeTemplateService.getTemplate(probeTemplate));
-                    System.out.println("Probe template applied: " + probeTemplate);
-                    List<Event> response = new ArrayList<Event>();
-                    String probes = helper.retrieveEventProbes();
-                    if (probes != null && !probes.isBlank()) {
-                        ProbeTemplate template = new ProbeTemplate();
-                        template.deserialize(
-                                new ByteArrayInputStream(
-                                        probes.getBytes(StandardCharsets.UTF_8)));
-                        for (Event e : template.getEvents()) {
-                            response.add(e);
-                            System.out.println(e);
-                        }
+                    String templateString = probeTemplateService.getTemplate(probeTemplate);
+                    helper.defineEventProbes(templateString);
+                    ProbeTemplate template = new ProbeTemplate();
+                    template.deserialize(
+                            new ByteArrayInputStream(
+                                    templateString.getBytes(StandardCharsets.UTF_8)));
+                    if (template.getEvents().length > 0) {
+                        Event event = template.getEvents()[0];
+                        notificationFactory
+                                .createBuilder()
+                                .metaCategory(NOTIFICATION_CATEGORY)
+                                .metaType(HttpMimeType.JSON)
+                                .message(
+                                        Map.of(
+                                                "targetId",
+                                                targetId,
+                                                "probeTemplate",
+                                                probeTemplate,
+                                                "event",
+                                                event))
+                                .build()
+                                .send();
+                    } else {
+                        throw new ApiException(501, "No event found in probe template");
                     }
-                    System.out.println(response);
-                    notificationFactory
-                            .createBuilder()
-                            .metaCategory(NOTIFICATION_CATEGORY)
-                            .metaType(HttpMimeType.JSON)
-                            .message(Map.of("targetId", targetId, "probeTemplate", probeTemplate, "event", response))
-                            .build()
-                            .send();
                     return new IntermediateResponse<Void>().body(null);
                 });
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1279 

## Description of the change:
This change makes the TargetProbePostHandler add an extra field in the notification that it emits through the websocket which is an array of the events that the uploaded probe are listening for.

## Motivation for the change:
This allows the front-end to update state from notifications instead of re-querying the back-end endpoints. 

## How to manually test:
1. Download the adoptium jmc agent jar from (download from https://github.com/adoptium/jmc-build/releases) (I use 8.3.0), rename the jar to `jmc_agent.jar`, and move it into `cryostat/conf`
2. Modify `entrypoint.bash` to include a line `FLAGS+=("-javaagent:/opt/cryostat.d/conf.d/jmc_agent.jar")`
3. Run this pr with sh smoketest.sh.
4. Navigate to events tab, and select cryostat as the selected Target JVM. 
5. Upload a ProbeTemplate, e.g. this one 
```
<jfragent>
    <config>
        <classprefix>__JFREvent</classprefix>
        <allowtostring>true</allowtostring>
        <allowconverter>true</allowconverter>
    </config>
    <events>
        <event id="demo.jfr.test1">
            <label>DemoEvent</label>
            <description>Event for the agent plugin demo</description>
            <class>io.cryostat.net.web.http.api.v1.TargetTemplatesGetHandler</class>
            <path>demo</path>
            <stacktrace>true</stacktrace>
            <rethrow>false</rethrow>
            <location>ENTRY</location>
            <method>
                <name>handleAuthenticated</name>
                <descriptor>(Lio/vertx/ext/web/RoutingContext;)V</descriptor>
            </method>
        </event>
    </events>
</jfragent>
```
6. Click on the kebab menu next to the uploaded template, and press insert probes. 
7. Notice the notification come through the web socket with the events listed in the Inserted Probe Template.
