### PR TITLE
feat(discovery): enable OpenShift cross-namespace discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Cryostat can be configured via the following environment variables:
 * `CRYOSTAT_JDP_PORT`: the JDP multicast port to send discovery packets. Defaults to `7095`.
 * `CRYOSTAT_CONFIG_PATH`: the filesystem path for the configuration directory. Defaults to `/opt/cryostat.d/conf.d`.
 * `CRYOSTAT_DISABLE_BUILTIN_DISCOVERY`: set to `true` to disable built-in target discovery mechanisms (see `CRYOSTAT_PLATFORM`). Custom Target "discovery" remains available, but discovery via JDP, Kubernetes API, or Kubernetes environment variable is disabled and ignored. This will still allow platform detection to automatically select an `AuthManager`. This is intended for use when Cryostat Discovery Plugins are the only desired mechanism for locating target applications. See #936 and [cryostat-agent](https://github.com/cryostatio/cryostat-agent). Defaults to `false`.
+* `CRYOSTAT_K8S_NAMESPACES`: set to a comma-separated list of Namespaces that Cryostat should query to discover target JVM applications with its built-in discovey mechanism.
 
 #### Configuration for Automated Analysis Reports
 

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -66,6 +66,7 @@ public final class Variables {
     public static final String AUTH_MANAGER_ENV_VAR = "CRYOSTAT_AUTH_MANAGER";
     public static final String DISABLE_BUILTIN_DISCOVERY = "CRYOSTAT_DISABLE_BUILTIN_DISCOVERY";
     public static final String DISCOVERY_PING_PERIOD_MS = "CRYOSTAT_DISCOVERY_PING_PERIOD";
+    public static final String K8S_NAMESPACES = "CRYOSTAT_K8S_NAMESPACES";
 
     // webserver configuration
     public static final String WEBSERVER_HOST = "CRYOSTAT_WEB_HOST";

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -68,8 +68,9 @@ public abstract class PlatformStrategyModule {
             FileSystem fs,
             JvmDiscoveryClient discoveryClient) {
         return Set.of(
-                new OpenShiftPlatformStrategy(logger, openShiftAuthManager, connectionToolkit, fs),
-                new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit, fs),
+                new OpenShiftPlatformStrategy(
+                        logger, openShiftAuthManager, connectionToolkit, env, fs),
+                new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit, env, fs),
                 new KubeEnvPlatformStrategy(logger, fs, noopAuthManager, connectionToolkit, env),
                 new DefaultPlatformStrategy(logger, noopAuthManager, discoveryClient));
     }

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -97,7 +97,8 @@ class KubeApiPlatformClientTest {
     @BeforeEach
     void setup() throws Exception {
         this.platformClient =
-                new KubeApiPlatformClient(NAMESPACE, k8sClient, () -> connectionToolkit, logger);
+                new KubeApiPlatformClient(
+                        List.of(NAMESPACE), k8sClient, () -> connectionToolkit, logger);
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1188
Related to #760
Related to https://github.com/cryostatio/cryostat-operator/issues/501

## Description of the change:
~~The primary change is a one-liner: `k8sClient.endpoints().inNamespace(namespace) -> k8sClient.endpoints().inAnyNamespace()`. This also does a bit of refactoring.~~
This updates the `KubeApiPlatformClient` class, which is the internal implementation that handles the `Endpoints` querying discovery behaviour, to not be restricted to only querying for `Endpoints` objects within the same `Namespace` that the Cryostat container is running within. A new `CRYSOTAT_K8S_NAMESPACES` environment variable is added. The variable's value is expected to be a comma-separated list of namespace names. The `KubeApiPlatformClient` sets up an `Informer` for each of these namespaces, and collates results from all of the informers when handling operations like listing targets or constructing the discovery tree. If this environment variable is unset/blank then the namespace Cryostat is running in is used as a singleton list value, which maintains the existing behaviour.

## Motivation for the change:
~~If the Operator has deployed Cryostat in an `AllNamespaces` mode, then Cryostat's built-in OpenShift discovery mechanism should look in all namespaces, not only the one which Cryostat is deployed within. This is still subject to the hardcoded `svc.port.name == 'jfr-jmx' || svc.port.number == 9091` behaviour as before. The previous Discovery Plugin API and the upcoming `cryostat-agent` address that. This PR also does not handle the "multi-tenant" case of multi-namespace installations, ie cases where not only are applications divided between different Namespaces but where users have differing permissions between namespaces. The combination of Operator `AllNamespaces` and this PR only enables an all-privileged model across multiple namespaces - any user with access to Cryostat has access to all of the recording data within Cryostat, regardless of where the data originated and what the user's permissions are within that origin (namespace).~~
The Operator may deploy Cryostat into its own namespace and expect it to monitor targets across multiple namespaces which all have the same or similar permissions levels (same levels of user and service account access etc). This PR does not add any handling or security considerations for varying access levels across the listed namespaces. If Cryostat's service account has access to those namespaces then it will be able to discover targets there, collect JFR data from those targets, and store it in its archives. Any user with access to Cryostat will then be able to read those files from the archives, even if they do not have permission to access the targets in the namespace where the data originated. See #1188 for work toward enforcing namespace separation. These two PRs together would enable a proper cluster-wide/`AllNamespaces` Cryostat installation.

TODO later, to hook in with #1188, is to support some syntax like `CRYOSTAT_K8S_NAMESPACES='*'`, which would cause the `KubeApiPlatformClient` to install an `Informer` with `.inAnyNamespace()` for full cluster-wide `Endpoints` discovery. This is slightly trickier when it comes to constructing the discovery tree since the namespaces are not known in advance but found while creating the tree, so some transient caching of namespace `EnvironmentNode`s may be needed to ensure that different `Endpoints` objects and their ownership chains do not cause duplicate namespaces to be registered into the final tree.

## How to manually test:
See comments below.
