### PR TITLE
build(core): use -core 2.16.2 from GH pkgs

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -114,6 +114,8 @@ jobs:
       with:
         repository: ${{ inputs.checkout-repo }}
         ref: ${{ inputs.checkout-ref }}
+        submodules: true
+        fetch-depth: 0
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -22,43 +22,16 @@ jobs:
         ref: ${{ inputs.checkout-ref }}
     - id: query-pom
       name: Get properties from POM
-      # Query POM for core and image version and save as output parameter
+      # Query POM for image version and save as output parameter
       run: |
-        CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
-        echo "::set-output name=core-version::v$CORE_VERSION"
         IMAGE_VERSION="$(mvn validate help:evaluate -Dexpression=cryostat.imageVersionLower -q -DforceStdout)"
         echo "::set-output name=image-version::$IMAGE_VERSION"
     outputs:
-      core-version: ${{ steps.query-pom.outputs.core-version }}
       image-version: ${{ steps.query-pom.outputs.image-version }}
-
-  build-deps:
-    runs-on: ubuntu-latest
-    needs: [get-pom-properties]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        repository: cryostatio/cryostat-core
-        ref: ${{ needs.get-pom-properties.outputs.core-version }}
-    - uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'adopt'
-    - uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: restore
-    - run: mvn -B -U -DskipTests=true clean install
-    - uses: actions/upload-artifact@v3
-      with:
-        name: cryostat-core
-        path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
-    - uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: save
 
   build-image:
     runs-on: ubuntu-latest
-    needs: [get-pom-properties, build-deps]
+    needs: [get-pom-properties]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -70,16 +43,19 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
+    - name: maven-settings
+      uses: s4u/maven-settings-action@v2
+      with:
+        servers: '[{"id": "github", "username": "dummy", "password": "${env.GITHUB_TOKEN_REF}"}]'
+        githubServer: false
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
-    - uses: actions/download-artifact@v3
-      with:
-        name: cryostat-core
-        path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
     - run: git submodule init
     - run: git submodule update --remote
     - run: mvn -B -U clean package
+      env:
+        GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
     - name: Save cryostat image
       run: podman save -o cryostat.tar --format oci-archive quay.io/cryostat/cryostat
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -114,8 +114,6 @@ jobs:
       with:
         repository: ${{ inputs.checkout-repo }}
         ref: ${{ inputs.checkout-ref }}
-        submodules: true
-        fetch-depth: 0
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
@@ -123,8 +121,15 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
+    - name: maven-settings
+      uses: s4u/maven-settings-action@v2
+      with:
+        servers: '[{"id": "github", "username": "dummy", "password": "${env.GITHUB_TOKEN_REF}"}]'
+        githubServer: false
     - name: Run spotbugs
       run: mvn -Dheadless=true compile spotbugs:check
+      env:
+        GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,13 @@
 <name>cryostat</name>
 <url>http://maven.apache.org</url>
 
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/cryostatio/cryostat-core</url>
+  </repository>
+</repositories>
+
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <java.version>17</java.version>
@@ -71,7 +78,7 @@
   <com.google.dagger.version>2.44.2</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.14.1</io.cryostat.core.version>
+  <io.cryostat.core.version>2.16.2</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-core/issues/92
See also https://github.com/cryostatio/cryostat-reports/pull/63

## Description of the change:
This replaces the inlined `-core` build with simply retrieving the artifact from the GitHub Packages repository for the dependency.

## Motivation for the change:
This simplifies the CI setup and should also reduce the total CI run time since the artifact is built once (on release) and then each consuming project should cache it, or at worst redownload it rather than rebuild it.
