### PR TITLE
feat(agent): relax JMX connection requirements to support agent connection stubs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   <com.google.dagger.version>2.44.2</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.17.0-SNAPSHOT</io.cryostat.core.version>
+  <io.cryostat.core.version>2.17.1</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   <com.google.dagger.version>2.44.2</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.16.2</io.cryostat.core.version>
+  <io.cryostat.core.version>2.17.0-SNAPSHOT</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -290,7 +290,6 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
                 try {
                     ref = jvmIdHelper.get().resolveId(ref);
                 } catch (Exception e) {
-                    logger.warn("Failed to resolve jvmId for node [{}]", child.getName());
                     // if Exception is of SSL or JMX Auth, ignore warning and use null jvmId
                     if (!(AbstractAuthenticatedRequestHandler.isJmxAuthFailure(e)
                             || AbstractAuthenticatedRequestHandler.isJmxSslFailure(e))) {

--- a/src/main/java/io/cryostat/net/AgentConnection.java
+++ b/src/main/java/io/cryostat/net/AgentConnection.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.rjmx.ConnectionException;
+import org.openjdk.jmc.rjmx.IConnectionHandle;
+import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+
+import io.cryostat.core.FlightRecorderException;
+import io.cryostat.core.net.IDException;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.sys.Clock;
+import io.cryostat.core.templates.Template;
+import io.cryostat.core.templates.TemplateService;
+import io.cryostat.core.templates.TemplateType;
+import io.cryostat.recordings.JvmIdHelper;
+
+import io.vertx.ext.web.client.WebClient;
+import org.jsoup.nodes.Document;
+
+class AgentConnection implements JFRConnection {
+
+    private final URI agentUri;
+    private final long httpTimeout;
+    private final WebClient webClient;
+    private final Clock clock;
+    private final JvmIdHelper idHelper;
+
+    AgentConnection(
+            URI agentUri,
+            long httpTimeoutSeconds,
+            WebClient webClient,
+            Clock clock,
+            JvmIdHelper idHelper) {
+        this.agentUri = agentUri;
+        this.httpTimeout = httpTimeoutSeconds;
+        this.webClient = webClient;
+        this.clock = clock;
+        this.idHelper = idHelper;
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public void connect() throws ConnectionException {
+        // TODO test connection by pinging agent callback
+    }
+
+    @Override
+    public void disconnect() {}
+
+    @Override
+    public long getApproximateServerTime(Clock arg0) {
+        return clock.now().toEpochMilli();
+    }
+
+    @Override
+    public IConnectionHandle getHandle() throws ConnectionException, IOException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getHost() {
+        return agentUri.getHost();
+    }
+
+    @Override
+    public JMXServiceURL getJMXURL() throws IOException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getJvmId() throws IDException, IOException {
+        // this should have already been populated when the agent published itself to the Discovery
+        // API. If not, then this will fail, but we were in a bad state to begin with.
+        return idHelper.getJvmId(agentUri.toString());
+    }
+
+    @Override
+    public int getPort() {
+        return agentUri.getPort();
+    }
+
+    @Override
+    public IFlightRecorderService getService()
+            throws ConnectionException, IOException, ServiceNotAvailableException {
+        return new AgentJFRService(httpTimeout, webClient);
+    }
+
+    @Override
+    public TemplateService getTemplateService() {
+        return new TemplateService() {
+
+            @Override
+            public Optional<IConstrainedMap<EventOptionID>> getEvents(
+                    String name, TemplateType type) throws FlightRecorderException {
+                return Optional.empty();
+            }
+
+            @Override
+            public List<Template> getTemplates() throws FlightRecorderException {
+                return List.of();
+            }
+
+            @Override
+            public Optional<Document> getXml(String name, TemplateType type)
+                    throws FlightRecorderException {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @Override
+    public boolean isConnected() {
+        // TODO Auto-generated method stub
+        return true;
+    }
+}

--- a/src/main/java/io/cryostat/net/AgentConnectionFactory.java
+++ b/src/main/java/io/cryostat/net/AgentConnectionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net;
+
+import java.net.URI;
+
+import io.cryostat.core.sys.Clock;
+import io.cryostat.recordings.JvmIdHelper;
+
+import io.vertx.ext.web.client.WebClient;
+
+class AgentConnectionFactory {
+
+    private final long httpTimeout;
+    private final WebClient webClient;
+    private final Clock clock;
+    private final JvmIdHelper idHelper;
+
+    AgentConnectionFactory(
+            long httpTimeoutSeconds, WebClient webClient, Clock clock, JvmIdHelper idHelper) {
+        this.httpTimeout = httpTimeoutSeconds;
+        this.webClient = webClient;
+        this.clock = clock;
+        this.idHelper = idHelper;
+    }
+
+    AgentConnection createConnection(URI agentUri) {
+        return new AgentConnection(agentUri, httpTimeout, webClient, clock, idHelper);
+    }
+}

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.IDescribedMap;
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
+import org.openjdk.jmc.flightrecorder.configuration.internal.DefaultValueMap;
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import io.vertx.ext.web.client.WebClient;
+
+class AgentJFRService implements IFlightRecorderService {
+
+    private final long httpTimeout;
+    private final WebClient webClient;
+
+    AgentJFRService(long httpTimeout, WebClient webClient) {
+        this.httpTimeout = httpTimeout;
+        this.webClient = webClient;
+    }
+
+    @Override
+    public IDescribedMap<EventOptionID> getDefaultEventOptions() {
+        return new DefaultValueMap<>(Map.of());
+    }
+
+    @Override
+    public IDescribedMap<String> getDefaultRecordingOptions() {
+        return new DefaultValueMap<>(Map.of());
+    }
+
+    @Override
+    public String getVersion() {
+        return "agent"; // TODO
+    }
+
+    @Override
+    public void close(IRecordingDescriptor descriptor) throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public void enable() throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public Collection<? extends IEventTypeInfo> getAvailableEventTypes()
+            throws FlightRecorderException {
+        return List.of();
+    }
+
+    @Override
+    public Map<String, IOptionDescriptor<?>> getAvailableRecordingOptions()
+            throws FlightRecorderException {
+        return Map.of();
+    }
+
+    @Override
+    public List<IRecordingDescriptor> getAvailableRecordings() throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return List.of();
+    }
+
+    @Override
+    public IConstrainedMap<EventOptionID> getCurrentEventTypeSettings()
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return new DefaultValueMap<>(Map.of());
+    }
+
+    @Override
+    public IConstrainedMap<EventOptionID> getEventSettings(IRecordingDescriptor arg0)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return new DefaultValueMap<>(Map.of());
+    }
+
+    @Override
+    public Map<? extends IEventTypeID, ? extends IEventTypeInfo> getEventTypeInfoMapByID()
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return Map.of();
+    }
+
+    @Override
+    public IConstrainedMap<String> getRecordingOptions(IRecordingDescriptor arg0)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return new DefaultValueMap<>(Map.of());
+    }
+
+    @Override
+    public List<String> getServerTemplates() throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        return List.of();
+    }
+
+    @Override
+    public IRecordingDescriptor getSnapshotRecording() throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public IRecordingDescriptor getUpdatedRecordingDescription(IRecordingDescriptor arg0)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        // TODO Auto-generated method stub
+        return true;
+    }
+
+    @Override
+    public InputStream openStream(IRecordingDescriptor arg0, boolean arg1)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public InputStream openStream(IRecordingDescriptor arg0, IQuantity arg1, boolean arg2)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public InputStream openStream(
+            IRecordingDescriptor arg0, IQuantity arg1, IQuantity arg2, boolean arg3)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public IRecordingDescriptor start(
+            IConstrainedMap<String> arg0, IConstrainedMap<EventOptionID> arg1)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public void stop(IRecordingDescriptor arg0) throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public void updateEventOptions(IRecordingDescriptor arg0, IConstrainedMap<EventOptionID> arg1)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public void updateRecordingOptions(IRecordingDescriptor arg0, IConstrainedMap<String> arg1)
+            throws FlightRecorderException {
+        // TODO Auto-generated method stub
+        throw new UnimplementedException();
+    }
+
+    public static class UnimplementedException extends IllegalStateException {}
+}

--- a/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
+++ b/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
@@ -196,6 +196,7 @@ class TargetConnectionManagerTest {
         TargetConnectionManager mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        () -> agentConnectionFactory,
                         platformClient,
                         ForkJoinPool.commonPool(),
                         Scheduler.systemScheduler(),
@@ -237,6 +238,7 @@ class TargetConnectionManagerTest {
         TargetConnectionManager mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        () -> agentConnectionFactory,
                         platformClient,
                         Runnable::run,
                         Scheduler.disabledScheduler(),

--- a/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
+++ b/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
@@ -68,6 +68,7 @@ class TargetConnectionManagerTest {
     TargetConnectionManager mgr;
     @Mock Logger logger;
     @Mock JFRConnectionToolkit jfrConnectionToolkit;
+    @Mock AgentConnectionFactory agentConnectionFactory;
     @Mock PlatformClient platformClient;
     Duration TTL = Duration.ofMillis(250);
 
@@ -76,6 +77,7 @@ class TargetConnectionManagerTest {
         this.mgr =
                 new TargetConnectionManager(
                         () -> jfrConnectionToolkit,
+                        () -> agentConnectionFactory,
                         platformClient,
                         new DirectExecutor(),
                         Scheduler.disabledScheduler(),

--- a/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
+++ b/src/test/java/io/cryostat/net/TargetConnectionManagerTest.java
@@ -111,7 +111,7 @@ class TargetConnectionManagerTest {
                                 return Mockito.mock(JFRConnection.class);
                             }
                         });
-        ConnectionDescriptor descriptor = new ConnectionDescriptor("foo");
+        ConnectionDescriptor descriptor = new ConnectionDescriptor("localhost:0");
         mgr.executeConnectedTask(
                 descriptor,
                 conn1 -> {
@@ -127,20 +127,6 @@ class TargetConnectionManagerTest {
 
     @Test
     void shouldReuseConnectionInSequentialAccessWithoutDelay() throws Exception {
-        Mockito.when(jfrConnectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
-                .thenAnswer(
-                        new Answer<JMXServiceURL>() {
-                            @Override
-                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
-                                String host = args.getArgument(0);
-                                int port = args.getArgument(1);
-                                return new JMXServiceURL(
-                                        "rmi",
-                                        "",
-                                        0,
-                                        String.format("/jndi/rmi://%s:%d/jmxrmi", host, port));
-                            }
-                        });
         Mockito.when(jfrConnectionToolkit.connect(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer<JFRConnection>() {
@@ -150,7 +136,8 @@ class TargetConnectionManagerTest {
                                 return Mockito.mock(JFRConnection.class);
                             }
                         });
-        ConnectionDescriptor desc = new ConnectionDescriptor("foo");
+        ConnectionDescriptor desc =
+                new ConnectionDescriptor("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
         JFRConnection conn1 = mgr.executeConnectedTask(desc, a -> a);
         JFRConnection conn2 = mgr.executeConnectedTask(desc, a -> a);
         MatcherAssert.assertThat(conn1, Matchers.sameInstance(conn2));
@@ -158,20 +145,6 @@ class TargetConnectionManagerTest {
 
     @Test
     void shouldCreateNewConnectionIfPreviousExplicitlyClosed() throws Exception {
-        Mockito.when(jfrConnectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
-                .thenAnswer(
-                        new Answer<JMXServiceURL>() {
-                            @Override
-                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
-                                String host = args.getArgument(0);
-                                int port = args.getArgument(1);
-                                return new JMXServiceURL(
-                                        "rmi",
-                                        "",
-                                        0,
-                                        String.format("/jndi/rmi://%s:%d/jmxrmi", host, port));
-                            }
-                        });
         ArgumentCaptor<List<Runnable>> closeListeners = ArgumentCaptor.forClass(List.class);
         Mockito.when(
                         jfrConnectionToolkit.connect(
@@ -184,7 +157,8 @@ class TargetConnectionManagerTest {
                                 return Mockito.mock(JFRConnection.class);
                             }
                         });
-        ConnectionDescriptor desc = new ConnectionDescriptor("foo");
+        ConnectionDescriptor desc =
+                new ConnectionDescriptor("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
         JFRConnection conn1 = mgr.executeConnectedTask(desc, a -> a);
         closeListeners.getValue().forEach(Runnable::run);
         JFRConnection conn2 = mgr.executeConnectedTask(desc, a -> a);
@@ -203,20 +177,6 @@ class TargetConnectionManagerTest {
                         Duration.ofNanos(1),
                         1,
                         logger);
-        Mockito.when(jfrConnectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
-                .thenAnswer(
-                        new Answer<JMXServiceURL>() {
-                            @Override
-                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
-                                String host = args.getArgument(0);
-                                int port = args.getArgument(1);
-                                return new JMXServiceURL(
-                                        "rmi",
-                                        "",
-                                        0,
-                                        String.format("/jndi/rmi://%s:%d/jmxrmi", host, port));
-                            }
-                        });
         Mockito.when(jfrConnectionToolkit.connect(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer<JFRConnection>() {
@@ -226,7 +186,8 @@ class TargetConnectionManagerTest {
                                 return Mockito.mock(JFRConnection.class);
                             }
                         });
-        ConnectionDescriptor desc = new ConnectionDescriptor("foo");
+        ConnectionDescriptor desc =
+                new ConnectionDescriptor("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
         JFRConnection conn1 = mgr.executeConnectedTask(desc, a -> a);
         Thread.sleep(10);
         JFRConnection conn2 = mgr.executeConnectedTask(desc, a -> a);
@@ -245,20 +206,6 @@ class TargetConnectionManagerTest {
                         Duration.ofNanos(1),
                         -1,
                         logger);
-        Mockito.when(jfrConnectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
-                .thenAnswer(
-                        new Answer<JMXServiceURL>() {
-                            @Override
-                            public JMXServiceURL answer(InvocationOnMock args) throws Throwable {
-                                String host = args.getArgument(0);
-                                int port = args.getArgument(1);
-                                return new JMXServiceURL(
-                                        "rmi",
-                                        "",
-                                        0,
-                                        String.format("/jndi/rmi://%s:%d/jmxrmi", host, port));
-                            }
-                        });
         Mockito.when(jfrConnectionToolkit.connect(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenAnswer(
                         new Answer<JFRConnection>() {
@@ -268,8 +215,10 @@ class TargetConnectionManagerTest {
                                 return Mockito.mock(JFRConnection.class);
                             }
                         });
-        ConnectionDescriptor desc1 = new ConnectionDescriptor("foo");
-        ConnectionDescriptor desc2 = new ConnectionDescriptor("bar");
+        ConnectionDescriptor desc1 =
+                new ConnectionDescriptor("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
+        ConnectionDescriptor desc2 =
+                new ConnectionDescriptor("service:jmx:rmi:///jndi/rmi://example:1/jmxrmi");
         JFRConnection conn1 = mgr.executeConnectedTask(desc1, a -> a);
         JFRConnection conn2 = mgr.executeConnectedTask(desc2, a -> a);
         MatcherAssert.assertThat(conn1, Matchers.not(Matchers.sameInstance(conn2)));


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1300
Fixes: #1310
See also https://github.com/cryostatio/cryostat-agent/pull/26
Depends on https://github.com/cryostatio/cryostat-core/pull/171

## Description of the change:
This change allows Discovery Plugins to include a computed JVM ID for the targets they are publishing about. This is intended primarily for Agents where the discovery plugin is also the target itself. This also implements a stubbed out `JFRConnection` implementation that represents an HTTP remote Cryostat Agent. Currently this stub does not actually talk to the Agent at all - see #1309.

## Motivation for the change:
Allowing plugins to publish their own JVM IDs must be done carefully - the plugin and Cryostat should always agree on the same ID for each target, so in effect both Cryostat and the plugin should use the same version of `cryostat-core` or at least the same algorithm for computing the ID.

If this is done, then this means Cryostat can skip the step of connecting to each of the published targets on every plugin update to check the JVM ID - that work is offloaded to the plugin instead, reducing total I/O. This also (re-)enables, in a very limited fashion, plugins to publish themselves *without* a JMX Service URL, ie a `connectUrl` property that is of some other form. This means that the published target becomes visible in the discovery API, but is not interactable in any normal way (cannot list recordings, start a recording, etc.). In the current Agent scenario this is useful for Agents that are configured for push-only - they have an HTTP callback URL for discovery plugin liveness checking, but they do not have any open JMX connection.

These HTTP remote Agents cannot currently be interacted with, but the stubs are in place to allow various operations to be implemented along with the Agent implementing simple APIs to support these actions.

## How to manually test:
1. `cd cryostat-agent ; mvn install` (or configure your `mvn` to be able to pull from GH pkgs)
2. `cd cryostat-core ; git fetch upstream ; git checkout v2.17.1 ; mvn install` (or configure your `mvn` to be able to pull from GH pkgs)
3. `cd quarkus-test ; ./mvnw -U clean package && podman build -t quay.io/andrewazores/quarkus-test:latest -f src/main/docker/Dockerfile.jvm . ; podman image prune -f`
4. `cd cryostat`
5. modify `smoketest.sh` as follows:

```diff
diff --git a/smoketest.sh b/smoketest.sh
index 48c0f88c..5e720529 100755
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -122,17 +122,18 @@ runDemoApps() {
     podman run \
         --name quarkus-test-agent-1 \
         --pod cryostat-pod \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar" \
         --env QUARKUS_HTTP_PORT=10010 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_HARVESTER_PERIOD_MS=30000 \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
         --env CRYOSTAT_AGENT_WEBSERVER_PORT="9977" \
         --env CRYOSTAT_AGENT_CALLBACK="http://localhost:9977/" \
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
-        --rm -d quay.io/andrewazores/quarkus-test:0.0.10
+        --rm -d quay.io/andrewazores/quarkus-test:latest
 
     podman run \
         --name quarkus-test-agent-2 \
@@ -141,13 +142,15 @@ runDemoApps() {
         --env QUARKUS_HTTP_PORT=10011 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_HARVESTER_MAX_AGE=30000 \
+        --env CRYOSTAT_AGENT_HARVESTER_MAX_SIZE=30000 \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
         --env CRYOSTAT_AGENT_WEBSERVER_PORT="9988" \
         --env CRYOSTAT_AGENT_CALLBACK="http://localhost:9988/" \
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
-        --rm -d quay.io/andrewazores/quarkus-test:0.0.10
+        --rm -d quay.io/andrewazores/quarkus-test:latest
 
     # copy a jboss-client.jar into /clientlib first
     # manual entry URL: service:jmx:remote+http://localhost:9990
```
this sets up the two `quarkus-test` sample applications to use the Agent with the JFR harvester (HTTP push) functionality. `quarkus-test-1` will *not* open a JMX port, and will use its HTTP callback URL as its `connectUrl` for discovery.
6. `CRYOSTAT_IMAGE=$THIS_PR_IMAGE sh smoketest.sh`
7. Both `quarkus-test` applications should be visible in the UI and API results. `quarkus-test-1` should not be interactable for starting recordings, but it should periodically push JFR files into the `Archives > Uploads` and some simple queries should work without throwing exceptions (list active recordings, list event types, list event templates should all return empty collections). `quarkus-test-2` should be interactable, should not push JFR files into archives, but should have a visible `cryostast-agent` recording automatically started by the agent.
