### PR TITLE
ci(secret): pass secrets to reusable workflows

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -11,6 +11,10 @@ on:
       image-version:
         description: the Cryostat application version that will be built
         value: ${{ jobs.get-pom-properties.outputs.image-version }}
+    secrets:
+      GH_PKGS_READ_TOKEN:
+        required: true
+        description: read-only token for pulling artifacts from GitHub Packages
 
 jobs:
   get-pom-properties:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,6 +24,7 @@ jobs:
     with:
       checkout-repo: ${{ github.event.pull_request.head.repo.full_name }}
       checkout-ref: ${{ github.event.pull_request.head.ref }}
+    secrets: inherit
     if: github.repository_owner == 'cryostatio' && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
 
   push-to-ghcr:

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-and-test:
     uses: ./.github/workflows/ci-jobs.yml
+    secrets: inherit
     if: github.repository_owner == 'cryostatio'
   push-to-quay:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related to #1304

Secrets are not passed from the "real" GitHub Actions workflow into the composable reusable workflows by default, which I believe is causing the current CI failures (ex. https://github.com/cryostatio/cryostat/actions/runs/3761519894/jobs/6393388169).

According to https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow , it's as easy as setting the secrets to be inherited by the reusable workflow since they are both in our org.
