### PR TITLE
fix(targets): remove jvmId from ServiceRef equals and hash

### DIFF
--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -135,7 +135,6 @@ public class ServiceRef {
         }
         ServiceRef sr = (ServiceRef) other;
         return new EqualsBuilder()
-                .append(jvmId, sr.jvmId)
                 .append(serviceUri, sr.serviceUri)
                 .append(alias, sr.alias)
                 .append(labels, sr.labels)
@@ -146,7 +145,6 @@ public class ServiceRef {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-                .append(jvmId)
                 .append(serviceUri)
                 .append(alias)
                 .append(labels)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1252 

## Description of the change:
Removes jvmId from ServiceRef equals and hash.

## Motivation for the change:
This is because if a target restarts, the jvmId will be different and Cryostat will think it's actually a new target and will add a new TargetNode into the database, resulting in two of the "same" target, one being the old lost target, and the other being the new restarted target. This was changed in https://github.com/cryostatio/cryostat/pull/1189 but it needs to be reverted because of the above reason. 

## How to manually test:
1. Run the PR.
2.  `    podman ps --format "{{.Pod}} || {{.ID}} || {{.RunningFor}} || {{.Names}}"`
3.  Recognize the vertx-fib-demo-1 id and run this:
```bash
podman kill "THE_DEMO_CONTAINER_ID" && 
podman run --name vertx-fib-demo-1 --env HTTP_PORT=8081 --env JMX_PORT=9093 --pod cryostat-pod --rm -d quay.io/andrewazores/vertx-fib-demo:0.9.1
```
4.  `http --verify=no -v :8181/api/v1/targets 'Authorization: Basic dXNlcjpwYXNzCg'` and see there is no extra 9093 target and that Cryostat never sees the original issue in https://github.com/cryostatio/cryostat-web/issues/493
