### PR TITLE
fix(discovery): should send notifications on credential store update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   <com.google.dagger.version>2.44.2</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.17.1</io.cryostat.core.version>
+  <io.cryostat.core.version>2.18.0</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -162,7 +162,7 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
                                                         gson.fromJson(
                                                                 plugin.getSubtree(),
                                                                 EnvironmentNode.class);
-                                                update(id, original.getChildren(), false);
+                                                update(id, original.getChildren());
                                             }
                                         } catch (JsonSyntaxException | ScriptException e) {
                                             throw new RuntimeException(e);
@@ -318,11 +318,6 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
 
     public List<? extends AbstractNode> update(
             UUID id, Collection<? extends AbstractNode> children) {
-        return update(id, children, true);
-    }
-
-    public List<? extends AbstractNode> update(
-            UUID id, Collection<? extends AbstractNode> children, boolean notify) {
         var updatedChildren =
                 modifyChildrenWithJvmIds(id, Objects.requireNonNull(children, "children"));
 
@@ -333,23 +328,21 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
         logger.trace("Discovery Update {} ({}): {}", id, plugin.getRealm(), updatedChildren);
         EnvironmentNode currentTree = gson.fromJson(plugin.getSubtree(), EnvironmentNode.class);
 
-        if (notify) {
-            Set<TargetNode> previousLeaves = findLeavesFrom(original);
-            Set<TargetNode> currentLeaves = findLeavesFrom(currentTree);
+        Set<TargetNode> previousLeaves = findLeavesFrom(original);
+        Set<TargetNode> currentLeaves = findLeavesFrom(currentTree);
 
-            Set<TargetNode> added = new HashSet<>(currentLeaves);
-            added.removeAll(previousLeaves);
+        Set<TargetNode> added = new HashSet<>(currentLeaves);
+        added.removeAll(previousLeaves);
 
-            Set<TargetNode> removed = new HashSet<>(previousLeaves);
-            removed.removeAll(currentLeaves);
+        Set<TargetNode> removed = new HashSet<>(previousLeaves);
+        removed.removeAll(currentLeaves);
 
-            removed.stream()
-                    .map(TargetNode::getTarget)
-                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
-            added.stream()
-                    .map(TargetNode::getTarget)
-                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
-        }
+        removed.stream()
+                .map(TargetNode::getTarget)
+                .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
+        added.stream()
+                .map(TargetNode::getTarget)
+                .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
         return currentTree.getChildren();
     }
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -78,7 +78,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class DiscoveryStorage extends AbstractPlatformClientVerticle {
@@ -378,11 +377,8 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
         for (TargetNode addedTNode : added) {
             ServiceRef atServiceRef = addedTNode.getTarget();
             for (TargetNode removedTNode : removed) {
-                if (new EqualsBuilder()
-                        .append(
-                                atServiceRef.getServiceUri(),
-                                removedTNode.getTarget().getServiceUri())
-                        .isEquals()) {
+                if (Objects.equals(
+                        atServiceRef.getServiceUri(), removedTNode.getTarget().getServiceUri())) {
                     updated.add(addedTNode);
                 }
             }
@@ -398,11 +394,8 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
         for (TargetNode srcTNode : src) {
             ServiceRef stServiceRef = srcTNode.getTarget();
             for (TargetNode updatedTNode : updated) {
-                if (new EqualsBuilder()
-                        .append(
-                                stServiceRef.getServiceUri(),
-                                updatedTNode.getTarget().getServiceUri())
-                        .isEquals()) {
+                if (Objects.equals(
+                        stServiceRef.getServiceUri(), updatedTNode.getTarget().getServiceUri())) {
                     tnSet.remove(srcTNode);
                 }
             }

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -331,18 +331,15 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
         Set<ServiceRef> previousRefs = getRefsFromLeaves(findLeavesFrom(originalTree));
         Set<ServiceRef> currentRefs = getRefsFromLeaves(findLeavesFrom(currentTree));
 
-        Set<ServiceRef> updated = ServiceRef.getUpdatedRefs(previousRefs, currentRefs);
-        updated.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.MODIFIED, sr));
+        ServiceRef.compare(previousRefs).to(currentRefs).updated().stream()
+                .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.MODIFIED, sr));
 
-        Set<ServiceRef> added =
-                ServiceRef.removeAllUpdatedRefs(
-                        ServiceRef.getAddedOrUpdatedRefs(previousRefs, currentRefs), updated);
-        added.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
+        ServiceRef.compare(previousRefs).to(currentRefs).added().stream()
+                .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
 
-        Set<ServiceRef> removed =
-                ServiceRef.removeAllUpdatedRefs(
-                        ServiceRef.getRemovedOrUpdatedRefs(previousRefs, currentRefs), updated);
-        removed.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
+        ServiceRef.compare(previousRefs).to(currentRefs).removed().stream()
+                .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
+        ;
 
         return currentTree.getChildren();
     }

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -229,11 +229,11 @@ public class ServiceRef {
         private Collection<ServiceRef> previous, current;
 
         public Compare(Collection<ServiceRef> previous) {
-            this.previous = previous;
+            this.previous = new HashSet<>(previous);
         }
 
         public Compare to(Collection<ServiceRef> current) {
-            this.current = current;
+            this.current = new HashSet<>(current);
             return this;
         }
 

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -246,19 +246,9 @@ public class ServiceRef {
         }
 
         public Collection<ServiceRef> updated() {
-            Collection<ServiceRef> added = addedOrUpdatedRefs();
-            Collection<ServiceRef> removed = removedOrUpdatedRefs();
             Collection<ServiceRef> updated = new HashSet<>();
-
-            // Manual Collection intersection since ServiceRef also compares jvmId
-            for (ServiceRef addedRef : added) {
-                for (ServiceRef removedRef : removed) {
-                    if (Objects.equals(addedRef.getServiceUri(), removedRef.getServiceUri())) {
-                        updated.add(addedRef);
-                    }
-                }
-            }
-
+            intersection(removedOrUpdatedRefs(), addedOrUpdatedRefs(), false)
+                    .forEach((ref) -> updated.add(ref));
             return updated;
         }
 
@@ -277,17 +267,24 @@ public class ServiceRef {
         private Collection<ServiceRef> removeAllUpdatedRefs(
                 Collection<ServiceRef> src, Collection<ServiceRef> updated) {
             Collection<ServiceRef> tnSet = new HashSet<>(src);
+            intersection(src, updated, true).stream().forEach((ref) -> tnSet.remove(ref));
+            return tnSet;
+        }
+
+        private Collection<ServiceRef> intersection(
+                Collection<ServiceRef> src, Collection<ServiceRef> other, boolean keepOld) {
+            final Collection<ServiceRef> intersection = new HashSet<>();
 
             // Manual removal since ServiceRef also compares jvmId
             for (ServiceRef srcRef : src) {
-                for (ServiceRef updatedRef : updated) {
-                    if (Objects.equals(srcRef.getServiceUri(), updatedRef.getServiceUri())) {
-                        tnSet.remove(srcRef);
+                for (ServiceRef otherRef : other) {
+                    if (Objects.equals(srcRef.getServiceUri(), otherRef.getServiceUri())) {
+                        intersection.add(keepOld ? srcRef : otherRef);
                     }
                 }
             }
 
-            return tnSet;
+            return intersection;
         }
     }
 }

--- a/src/main/java/io/cryostat/platform/ServiceRef.java
+++ b/src/main/java/io/cryostat/platform/ServiceRef.java
@@ -41,9 +41,11 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -217,5 +219,53 @@ public class ServiceRef {
         POD_NAME,
         REALM,
         ;
+    }
+
+    public static Set<ServiceRef> getAddedOrUpdatedRefs(
+            Set<ServiceRef> previousRefs, Set<ServiceRef> currentRefs) {
+        Set<ServiceRef> added = new HashSet<>(currentRefs);
+        added.removeAll(previousRefs);
+        return added;
+    }
+
+    public static Set<ServiceRef> getRemovedOrUpdatedRefs(
+            Set<ServiceRef> previousRefs, Set<ServiceRef> currentRefs) {
+        Set<ServiceRef> removed = new HashSet<>(previousRefs);
+        removed.removeAll(currentRefs);
+        return removed;
+    }
+
+    public static Set<ServiceRef> getUpdatedRefs(
+            Set<ServiceRef> previousRefs, Set<ServiceRef> currentRefs) {
+        Set<ServiceRef> added = getAddedOrUpdatedRefs(previousRefs, currentRefs);
+        Set<ServiceRef> removed = getRemovedOrUpdatedRefs(previousRefs, currentRefs);
+        Set<ServiceRef> updated = new HashSet<>();
+
+        // Manual set intersection since ServiceRef also compares jvmId
+        for (ServiceRef addedRef : added) {
+            for (ServiceRef removedRef : removed) {
+                if (Objects.equals(addedRef.getServiceUri(), removedRef.getServiceUri())) {
+                    updated.add(addedRef);
+                }
+            }
+        }
+
+        return updated;
+    }
+
+    public static Set<ServiceRef> removeAllUpdatedRefs(
+            Set<ServiceRef> src, Set<ServiceRef> updated) {
+        Set<ServiceRef> tnSet = new HashSet<>(src);
+
+        // Manual removal since ServiceRef also compares jvmId
+        for (ServiceRef srcRef : src) {
+            for (ServiceRef updatedRef : updated) {
+                if (Objects.equals(srcRef.getServiceUri(), updatedRef.getServiceUri())) {
+                    tnSet.remove(srcRef);
+                }
+            }
+        }
+
+        return tnSet;
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -355,18 +355,14 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
                 return;
             }
 
-            Set<ServiceRef> updated = ServiceRef.getUpdatedRefs(previousRefs, currentRefs);
-            updated.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.MODIFIED, sr));
+            ServiceRef.compare(previousRefs).to(currentRefs).updated().stream()
+                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.MODIFIED, sr));
 
-            Set<ServiceRef> added =
-                    ServiceRef.removeAllUpdatedRefs(
-                            ServiceRef.getAddedOrUpdatedRefs(previousRefs, currentRefs), updated);
-            added.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
+            ServiceRef.compare(previousRefs).to(currentRefs).added().stream()
+                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.FOUND, sr));
 
-            Set<ServiceRef> removed =
-                    ServiceRef.removeAllUpdatedRefs(
-                            ServiceRef.getRemovedOrUpdatedRefs(previousRefs, currentRefs), updated);
-            removed.stream().forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
+            ServiceRef.compare(previousRefs).to(currentRefs).removed().stream()
+                    .forEach(sr -> notifyAsyncTargetDiscovery(EventKind.LOST, sr));
         }
 
         @Override

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -231,6 +231,8 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
             case LOST:
                 deactivate(null, tde.getServiceRef());
                 break;
+            case MODIFIED:
+                break;
             default:
                 throw new UnsupportedOperationException(tde.getEventKind().toString());
         }

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -454,10 +454,7 @@ class DiscoveryStorageTest {
                     new EnvironmentNode("prev", BaseNodeType.REALM, Map.of(), Set.of(prevTarget));
 
             ServiceRef nextServiceRef =
-                    new ServiceRef(
-                            "id",
-                            URI.create("service:jmx:rmi:///jndi/rmi://localhost/jmxrmi"),
-                            "nextServiceRef");
+                    new ServiceRef("new_id", prevServiceRef.getServiceUri(), "nextServiceRef");
             TargetNode nextTarget = new TargetNode(BaseNodeType.JVM, nextServiceRef);
             EnvironmentNode next =
                     new EnvironmentNode("next", BaseNodeType.REALM, Map.of(), Set.of(nextTarget));
@@ -480,14 +477,12 @@ class DiscoveryStorageTest {
             List<? extends AbstractNode> updatedChildren = storage.update(id, List.of(nextTarget));
 
             MatcherAssert.assertThat(updatedChildren, Matchers.equalTo(List.of(nextTarget)));
-            MatcherAssert.assertThat(discoveryEvents, Matchers.hasSize(2));
+            MatcherAssert.assertThat(discoveryEvents, Matchers.hasSize(1));
 
-            TargetDiscoveryEvent lostEvent =
-                    new TargetDiscoveryEvent(EventKind.LOST, prevServiceRef);
-            TargetDiscoveryEvent foundEvent =
-                    new TargetDiscoveryEvent(EventKind.FOUND, nextServiceRef);
-            MatcherAssert.assertThat(
-                    discoveryEvents, Matchers.containsInRelativeOrder(lostEvent, foundEvent));
+            TargetDiscoveryEvent modifiedEvent =
+                    new TargetDiscoveryEvent(EventKind.MODIFIED, nextServiceRef);
+            System.out.println(modifiedEvent.getServiceRef());
+            MatcherAssert.assertThat(discoveryEvents, Matchers.contains(modifiedEvent));
         }
     }
 

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -687,21 +687,41 @@ class DiscoveryStorageTest {
                         null,
                         URI.create("service:jmx:rmi:///jndi/rmi://localhost:1/jmxrmi"),
                         "serviceRef1");
+        ServiceRef updatedServiceRef1 =
+                new ServiceRef(
+                        serviceRef1.getAlias().get(),
+                        serviceRef1.getServiceUri(),
+                        serviceRef1.getAlias().get());
         ServiceRef serviceRef2 =
                 new ServiceRef(
                         null,
                         URI.create("service:jmx:rmi:///jndi/rmi://localhost:2/jmxrmi"),
                         "serviceRef2");
+        ServiceRef updatedServiceRef2 =
+                new ServiceRef(
+                        serviceRef2.getAlias().get(),
+                        serviceRef2.getServiceUri(),
+                        serviceRef2.getAlias().get());
         ServiceRef serviceRef3 =
                 new ServiceRef(
                         null,
                         URI.create("service:jmx:rmi:///jndi/rmi://localhost:3/jmxrmi"),
                         "serviceRef3");
+        ServiceRef updatedServiceRef3 =
+                new ServiceRef(
+                        serviceRef3.getAlias().get(),
+                        serviceRef3.getServiceUri(),
+                        serviceRef3.getAlias().get());
         ServiceRef serviceRef4 =
                 new ServiceRef(
                         null,
                         URI.create("service:jmx:rmi:///jndi/rmi://localhost:4/jmxrmi"),
                         "serviceRef4");
+        ServiceRef updatedServiceRef4 =
+                new ServiceRef(
+                        serviceRef4.getAlias().get(),
+                        serviceRef4.getServiceUri(),
+                        serviceRef4.getAlias().get());
         TargetNode target1 = new TargetNode(BaseNodeType.JVM, serviceRef1);
         TargetNode target2 = new TargetNode(BaseNodeType.JVM, serviceRef2);
         TargetNode target3 = new TargetNode(BaseNodeType.JVM, serviceRef3);
@@ -713,7 +733,10 @@ class DiscoveryStorageTest {
                 new EnvironmentNode("next", BaseNodeType.REALM, Map.of(), Set.of(target4));
         EnvironmentNode realm2 =
                 new EnvironmentNode(
-                        "next", BaseNodeType.REALM, Map.of(), Set.of(target1, target2, agent));
+                        "next",
+                        BaseNodeType.REALM,
+                        Map.of(),
+                        Set.of(target4, target1, target2, agent));
 
         PluginInfo prevPlugin =
                 new PluginInfo("test-realm", URI.create("http://example.com"), gson.toJson(realm1));
@@ -735,13 +758,19 @@ class DiscoveryStorageTest {
                             }
                         });
 
+        List<TargetDiscoveryEvent> discoveryEvents = new ArrayList<>();
+        storage.addTargetDiscoveryListener(discoveryEvents::add);
+
         var updatedSubtree = storage.update(id, List.of(realm2));
         MatcherAssert.assertThat(updatedSubtree, Matchers.notNullValue());
         MatcherAssert.assertThat(updatedSubtree, Matchers.hasSize(1));
-        for (AbstractNode node : updatedSubtree) {
 
-            if (node instanceof TargetNode) {
-                TargetNode target = (TargetNode) node;
+        AbstractNode node = updatedSubtree.get(0); // realm2
+        MatcherAssert.assertThat(node, Matchers.instanceOf(EnvironmentNode.class));
+
+        for (AbstractNode childNode : ((EnvironmentNode) node).getChildren()) {
+            if (childNode instanceof TargetNode) {
+                TargetNode target = (TargetNode) childNode;
                 MatcherAssert.assertThat(
                         target.getTarget().getAlias().isPresent(), Matchers.is(true));
                 MatcherAssert.assertThat(target.getTarget().getJvmId(), Matchers.notNullValue());
@@ -749,22 +778,28 @@ class DiscoveryStorageTest {
                         target.getTarget().getJvmId(),
                         Matchers.equalTo(target.getTarget().getAlias().get()));
             } else {
-                MatcherAssert.assertThat(node, Matchers.instanceOf(EnvironmentNode.class));
-                EnvironmentNode env = (EnvironmentNode) node;
-                for (AbstractNode nested : env.getChildren()) {
-                    if (nested instanceof TargetNode) {
-                        TargetNode target = (TargetNode) nested;
-                        MatcherAssert.assertThat(
-                                target.getTarget().getAlias().isPresent(), Matchers.is(true));
-                        MatcherAssert.assertThat(
-                                target.getTarget().getJvmId(), Matchers.notNullValue());
-                        MatcherAssert.assertThat(
-                                target.getTarget().getJvmId(),
-                                Matchers.equalTo(target.getTarget().getAlias().get()));
-                    }
+                MatcherAssert.assertThat(childNode, Matchers.instanceOf(EnvironmentNode.class));
+                for (AbstractNode nestedNode : ((EnvironmentNode) childNode).getChildren()) {
+                    TargetNode target = (TargetNode) nestedNode;
+                    MatcherAssert.assertThat(
+                            target.getTarget().getAlias().isPresent(), Matchers.is(true));
+                    MatcherAssert.assertThat(
+                            target.getTarget().getJvmId(), Matchers.notNullValue());
+                    MatcherAssert.assertThat(
+                            target.getTarget().getJvmId(),
+                            Matchers.equalTo(target.getTarget().getAlias().get()));
                 }
             }
         }
+
+        MatcherAssert.assertThat(discoveryEvents, Matchers.hasSize(4));
+        MatcherAssert.assertThat(
+                discoveryEvents,
+                Matchers.containsInAnyOrder(
+                        new TargetDiscoveryEvent(EventKind.FOUND, updatedServiceRef1),
+                        new TargetDiscoveryEvent(EventKind.FOUND, updatedServiceRef2),
+                        new TargetDiscoveryEvent(EventKind.FOUND, updatedServiceRef3),
+                        new TargetDiscoveryEvent(EventKind.MODIFIED, updatedServiceRef4)));
     }
 
     @Test

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -660,8 +660,8 @@ class KubeApiPlatformClientTest {
                         .endSubset()
                         .build();
 
-        CountDownLatch latch = new CountDownLatch(3);
-        Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(3);
+        CountDownLatch latch = new CountDownLatch(2);
+        Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(2);
         platformClient.addTargetDiscoveryListener(
                 tde -> {
                     events.add(tde);
@@ -702,7 +702,7 @@ class KubeApiPlatformClientTest {
         latch.await();
         Thread.sleep(100); // to ensure no more events are coming
 
-        MatcherAssert.assertThat(events, Matchers.hasSize(3));
+        MatcherAssert.assertThat(events, Matchers.hasSize(2));
 
         ServiceRef original =
                 new ServiceRef(
@@ -740,16 +740,13 @@ class KubeApiPlatformClientTest {
                         AnnotationKey.POD_NAME,
                         "modifiedTarget"));
 
-        TargetDiscoveryEvent found = events.remove();
-        MatcherAssert.assertThat(found.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        MatcherAssert.assertThat(found.getServiceRef(), Matchers.equalTo(original));
+        TargetDiscoveryEvent foundEvent = events.remove();
+        MatcherAssert.assertThat(foundEvent.getEventKind(), Matchers.equalTo(EventKind.FOUND));
+        MatcherAssert.assertThat(foundEvent.getServiceRef(), Matchers.equalTo(original));
 
-        TargetDiscoveryEvent lost = events.remove();
-        MatcherAssert.assertThat(lost.getEventKind(), Matchers.equalTo(EventKind.LOST));
-        MatcherAssert.assertThat(lost.getServiceRef(), Matchers.equalTo(original));
-
-        TargetDiscoveryEvent refound = events.remove();
-        MatcherAssert.assertThat(refound.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        MatcherAssert.assertThat(refound.getServiceRef(), Matchers.equalTo(modified));
+        TargetDiscoveryEvent modifiedEvent = events.remove();
+        MatcherAssert.assertThat(
+                modifiedEvent.getEventKind(), Matchers.equalTo(EventKind.MODIFIED));
+        MatcherAssert.assertThat(modifiedEvent.getServiceRef(), Matchers.equalTo(modified));
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes:  https://github.com/cryostatio/cryostat-web/issues/805
Depends on https://github.com/cryostatio/cryostat-core/pull/172

## Description of the change:

- [x] Fixed Discovery Storage to always send WS notifications when new Jvmids are successfully computed.
- [x] Updated tests to check if notifications are sent (also apply fixes to check nested nested Environement node).

## Motivation for the change:

Front-end should be able to display newly computed jvmIds.

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2.  Choose any target with authentication (and no backend-saved credentials). See jvmId is null.
3. Add credentials.
4. See the updated jvmIds.
