### PR TITLE
fix(ci): fix github label from being applied on every pull-request target action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,10 @@
 name: Label pull request
 
 on:
-- pull_request_target
+  pull_request_target:
+    types: 
+      - opened
+      - reopened
 
 jobs:
   triage:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1334 

## Description of the change:
Allows github-actions bot to only apply the `needs-triage` label when a pull request is opened or re-opened. Also see https://github.com/cryostatio/cryostat/issues/1194#issuecomment-1384723406

## Motivation for the change:
See #1334. This is annoying as every time someone added commits or force pushed, the label is applied and we need to remove it again in order for CI tests to run.

## How to manually test:
1. None
