### PR TITLE
feat(k8s): publish discovered targets using k8s internal pod URL

### DIFF
--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -208,7 +208,7 @@ class KubeApiPlatformClientTest {
                         .endSubset()
                         .build();
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).create(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
         Mockito.when(connectionToolkit.createServiceURL(Mockito.anyString(), Mockito.anyInt()))
                 .thenAnswer(
@@ -361,7 +361,7 @@ class KubeApiPlatformClientTest {
                                         .build())
                         .endSubset()
                         .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).create(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
         platformClient.start();
         EnvironmentNode realmNode = platformClient.getDiscoveryTree();
@@ -505,7 +505,7 @@ class KubeApiPlatformClientTest {
                                         .build())
                         .endSubset()
                         .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).create(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
         TargetDiscoveryEvent evt = eventFuture.get(1, TimeUnit.SECONDS);
         MatcherAssert.assertThat(evt.getEventKind(), Matchers.equalTo(EventKind.FOUND));
@@ -582,8 +582,8 @@ class KubeApiPlatformClientTest {
 
         platformClient.start();
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).create(endpoints);
-        k8sClient.endpoints().inNamespace(NAMESPACE).delete(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).delete();
 
         latch.await();
         Thread.sleep(100); // to ensure no more events are coming
@@ -670,7 +670,7 @@ class KubeApiPlatformClientTest {
 
         platformClient.start();
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).create(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
         endpoints =
                 new EndpointsBuilder()
@@ -697,7 +697,7 @@ class KubeApiPlatformClientTest {
                                         .build())
                         .endSubset()
                         .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).replace(endpoints);
+        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).replace();
 
         latch.await();
         Thread.sleep(100); // to ensure no more events are coming


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1337
(nice)

## Description of the change:
This applies a simple transformation to the JMX service URLs published by the internal k8s discovery mechanism. Rather than constructing the URL simply by the Endpoints `$ip:$port`, it is transformed to `$ip-dashes.$namespace.pod:$port` according to https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods .

## Motivation for the change:
This will end up resolving to the same backing Pod, but it is a little more explicit about what is being connected to. In #1188 the namespace information embedded in the connection URL will be used to determine the security context to apply to data originating from that target, and all target definitions will be required to be defined with a connection URL conforming to such a platform-specific format (including custom targets and targets published by discovery plugins).

## How to manually test:
1. Deploy PR image in some k8s cluster
2. Check web-client or various target discovery API queries for JMX URL formats for targets discovered by built-in k8s discovery mechanism

Before:
![image](https://user-images.githubusercontent.com/3787464/213804649-59a8cd5c-f133-46be-ae73-de7be9069098.png)

After:
![image](https://user-images.githubusercontent.com/3787464/213806448-787b13df-3252-460b-898d-4b0a3a37143d.png)

----

```
$ http :8080/api/v1/targets
HTTP/1.1 200 OK
content-encoding: gzip
content-length: 315
content-type: application/json
```
```json
[
    {
        "alias": "cryostat1-f88f64b7-4gk92",
        "annotations": {
            "cryostat": {
                "HOST": "10.244.0.11",
                "NAMESPACE": "cryostat1",
                "POD_NAME": "cryostat1-f88f64b7-4gk92",
                "PORT": "9091",
                "REALM": "KubernetesApi"
            },
            "platform": {}
        },
        "connectUrl": "service:jmx:rmi:///jndi/rmi://10-244-0-11.cryostat1.pod:9091/jmxrmi",
        "jvmId": "IgzWdrTgqye4uk_OpK7yAx8NJKiAqzuekDdcnQGeTks=",
        "labels": {
            "app.kubernetes.io/instance": "cryostat1",
            "app.kubernetes.io/name": "cryostat",
            "pod-template-hash": "f88f64b7"
        }
    }
]
```

```
$ http :8080/api/v2.1/discovery
HTTP/1.1 200 OK
content-encoding: gzip
content-length: 593
content-type: application/json
```
```json
{
    "data": {
        "result": {
            "children": [
                {
                    "children": [],
                    "labels": {
                        "REALM": "3fa493ce-a277-4bd2-8ba1-a441b7d0b3f5"
                    },
                    "name": "Custom Targets",
                    "nodeType": "Realm"
                },
                {
                    "children": [
                        {
                            "children": [
                                {
                                    "children": [
                                        {
                                            "children": [
                                                {
                                                    "children": [
                                                        {
                                                            "labels": {},
                                                            "name": "service:jmx:rmi:///jndi/rmi://10-244-0-11.cryostat1.pod:9091/jmxrmi",
                                                            "nodeType": "Endpoint",
                                                            "target": {
                                                                "alias": "cryostat1-f88f64b7-4gk92",
                                                                "annotations": {
                                                                    "cryostat": {
                                                                        "HOST": "10.244.0.11",
                                                                        "NAMESPACE": "cryostat1",
                                                                        "POD_NAME": "cryostat1-f88f64b7-4gk92",
                                                                        "PORT": "9091",
                                                                        "REALM": "KubernetesApi"
                                                                    },
                                                                    "platform": {}
                                                                },
                                                                "connectUrl": "service:jmx:rmi:///jndi/rmi://10-244-0-11.cryostat1.pod:9091/jmxrmi",
                                                                "jvmId": "IgzWdrTgqye4uk_OpK7yAx8NJKiAqzuekDdcnQGeTks=",
                                                                "labels": {
                                                                    "app.kubernetes.io/instance": "cryostat1",
                                                                    "app.kubernetes.io/name": "cryostat",
                                                                    "pod-template-hash": "f88f64b7"
                                                                }
                                                            }
                                                        }
                                                    ],
                                                    "labels": {
                                                        "app.kubernetes.io/instance": "cryostat1",
                                                        "app.kubernetes.io/name": "cryostat",
                                                        "pod-template-hash": "f88f64b7"
                                                    },
                                                    "name": "cryostat1-f88f64b7-4gk92",
                                                    "nodeType": "Pod"
                                                }
                                            ],
                                            "labels": {
                                                "app.kubernetes.io/instance": "cryostat1",
                                                "app.kubernetes.io/name": "cryostat",
                                                "pod-template-hash": "f88f64b7"
                                            },
                                            "name": "cryostat1-f88f64b7",
                                            "nodeType": "ReplicaSet"
                                        }
                                    ],
                                    "labels": {
                                        "app.kubernetes.io/instance": "cryostat1",
                                        "app.kubernetes.io/managed-by": "Helm",
                                        "app.kubernetes.io/name": "cryostat",
                                        "app.kubernetes.io/version": "latest",
                                        "helm.sh/chart": "cryostat-0.2.0"
                                    },
                                    "name": "cryostat1",
                                    "nodeType": "Deployment"
                                }
                            ],
                            "labels": {},
                            "name": "cryostat1",
                            "nodeType": "Namespace"
                        }
                    ],
                    "labels": {
                        "REALM": "7759ff62-77b5-49d9-89e9-8bf951da8e87"
                    },
                    "name": "KubernetesApi",
                    "nodeType": "Realm"
                }
            ],
            "labels": {},
            "name": "Universe",
            "nodeType": "Universe"
        }
    },
    "meta": {
        "status": "OK",
        "type": "application/json"
    }
}
```