### PR TITLE
fix(reports): fix "view report" failure timing out on jwt report get handlers

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathWithJwtHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathWithJwtHandler.java
@@ -123,7 +123,7 @@ class ReportGetFromPathWithJwtHandler extends AbstractAssetJwtConsumingHandler {
 
     @Override
     public boolean isAsync() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetWithJwtHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/ReportGetWithJwtHandler.java
@@ -125,7 +125,7 @@ class ReportGetWithJwtHandler extends AbstractAssetJwtConsumingHandler {
 
     @Override
     public boolean isAsync() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -596,14 +596,18 @@ public class RecordingArchiveHelper {
             String subdirectoryName, String recordingName, String filter, boolean formatted) {
         CompletableFuture<Path> future = new CompletableFuture<>();
         try {
+            System.out.println(archivedRecordingsPath);
             Path tempSubdirectory = archivedRecordingsReportPath.resolve(subdirectoryName);
             if (!fs.exists(tempSubdirectory)) {
+                System.out.println("Creating temp subdirectory");
                 tempSubdirectory = fs.createDirectory(tempSubdirectory);
             }
             String fileName =
                     String.format(
                             "%s-%s.report%s",
                             recordingName, filter.hashCode(), formatted ? ".html" : ".json");
+            System.out.println("fileName: " + fileName);
+            System.out.println("tempSubdirectory: " + tempSubdirectory);
             future.complete(tempSubdirectory.resolve(fileName).toAbsolutePath());
         } catch (IOException e) {
             future.completeExceptionally(e);
@@ -815,6 +819,7 @@ public class RecordingArchiveHelper {
         try {
             boolean checkConnectUrl = !jvmIdHelper.isSpecialDirectory(subdirectoryName);
             Path path = archivedRecordingsPath.resolve(subdirectoryName).resolve(recordingName);
+            System.out.println(path);
             validateRecordingPath(Optional.of(path), recordingName, checkConnectUrl);
             return CompletableFuture.completedFuture(path);
         } catch (RecordingNotFoundException | ArchivePathException e) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -596,18 +596,14 @@ public class RecordingArchiveHelper {
             String subdirectoryName, String recordingName, String filter, boolean formatted) {
         CompletableFuture<Path> future = new CompletableFuture<>();
         try {
-            System.out.println(archivedRecordingsPath);
             Path tempSubdirectory = archivedRecordingsReportPath.resolve(subdirectoryName);
             if (!fs.exists(tempSubdirectory)) {
-                System.out.println("Creating temp subdirectory");
                 tempSubdirectory = fs.createDirectory(tempSubdirectory);
             }
             String fileName =
                     String.format(
                             "%s-%s.report%s",
                             recordingName, filter.hashCode(), formatted ? ".html" : ".json");
-            System.out.println("fileName: " + fileName);
-            System.out.println("tempSubdirectory: " + tempSubdirectory);
             future.complete(tempSubdirectory.resolve(fileName).toAbsolutePath());
         } catch (IOException e) {
             future.completeExceptionally(e);
@@ -819,7 +815,6 @@ public class RecordingArchiveHelper {
         try {
             boolean checkConnectUrl = !jvmIdHelper.isSpecialDirectory(subdirectoryName);
             Path path = archivedRecordingsPath.resolve(subdirectoryName).resolve(recordingName);
-            System.out.println(path);
             validateRecordingPath(Optional.of(path), recordingName, checkConnectUrl);
             return CompletableFuture.completedFuture(path);
         } catch (RecordingNotFoundException | ArchivePathException e) {

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathWithJwtHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetFromPathWithJwtHandlerTest.java
@@ -141,8 +141,8 @@ class ReportGetFromPathWithJwtHandlerTest {
         }
 
         @Test
-        void shouldBeAsync() {
-            Assertions.assertTrue(handler.isAsync());
+        void shouldNotBeAsync() {
+            Assertions.assertFalse(handler.isAsync());
         }
 
         @Test

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetWithJwtHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ReportGetWithJwtHandlerTest.java
@@ -141,8 +141,8 @@ class ReportGetWithJwtHandlerTest {
         }
 
         @Test
-        void shouldBeAsync() {
-            Assertions.assertTrue(handler.isAsync());
+        void shouldNotBeAsync() {
+            Assertions.assertFalse(handler.isAsync());
         }
 
         @Test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1340 

## Description of the change:
This change makes some jwt report get handlers non-async. Having them as `async` was causing a timeout due to the vertx event loop being blocked while waiting for a report response from the reports sidecar.

## Motivation for the change:
See #1340 
It makes sense that we wouldn't want these handlers async since we are actively waiting on a http response ourselves and are planning to return it.

## How to manually test:
1. Run cryostat normally with smoketest
2. Create a recording and archive it after a few seconds. 
3. Press view report on the kebab  (this uses the jwt handler) (Do not view a report within the iframe as this caches the report).
4. Notice that the report is generated without a timeout as opposed to before.
