### PR TITLE
chore(dev): use JAVA_HOME instead of hardcoded path

### DIFF
--- a/certs/generate-dev-certs.sh
+++ b/certs/generate-dev-certs.sh
@@ -48,7 +48,7 @@ keytool \
     -importkeystore \
     -noprompt \
     -storetype PKCS12 \
-    -srckeystore /usr/lib/jvm/java-11-openjdk/lib/security/cacerts \
+    -srckeystore "${JAVA_HOME}/lib/security/cacerts" \
     -srcstorepass changeit \
     -destkeystore "$SSL_TRUSTSTORE" \
     -deststorepass "$SSL_TRUSTSTORE_PASS"


### PR DESCRIPTION
Signed-off-by: Andrew Azores <aazores@redhat.com>

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes #1353

## Description of the change:
Replaces a hardcoded path (assumes JDK11 installed in a Fedora-like location) with `$JAVA_HOME`
