### PR TITLE
build(oci): add config to allow building images for other archs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Build Requirements:
 - JDK17+
 - Maven 3+
 - Podman 2.0+
+- `qemu-user-static` to build container images for other archs
 
 Run Requirements:
 - Kubernetes/OpenShift/Minishift, Podman/Docker, or other container platform

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,10 @@
 
   <imageBuilder>/usr/bin/podman</imageBuilder>
 
+  <build.os>linux</build.os>
+  <build.arch>amd64</build.arch>
   <baseImage>localhost/cryostat-base</baseImage>
-  <baseImageTag>latest</baseImageTag>
+  <baseImageTag>latest-${build.os}-${build.arch}</baseImageTag>
   <baseImageTarball>base.tar.gz</baseImageTarball>
   <node.version>v16.18.1</node.version>
   <yarn.version>v1.22.19</yarn.version>
@@ -435,6 +437,8 @@
             <executable>${imageBuilder}</executable>
             <arguments>
               <argument>build</argument>
+              <argument>--platform</argument>
+              <argument>${build.os}/${build.arch}</argument>
               <argument>--file</argument>
               <argument>${project.build.outputDirectory}/Dockerfile</argument>
               <argument>--tag</argument>
@@ -753,10 +757,16 @@
         </dockerClient>
         <from>
           <image>tar://${project.build.directory}/${baseImageTarball}</image>
+          <platforms>
+            <platform>
+              <os>${build.os}</os>
+              <architecture>${build.arch}</architecture>
+            </platform>
+          </platforms>
         </from>
         <to>
           <image>${cryostat.imageStream}</image>
-          <tags>${cryostat.imageVersionLower}</tags>
+          <tags>${cryostat.imageVersionLower}-${build.os}-${build.arch}</tags>
         </to>
         <container>
           <format>OCI</format>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1329

## Description of the change:
This adds some configuration to the `pom.xml` so that the build architecture (and OS, though this only makes sense to use `linux` now) can be changed by setting `-Dbuild.arch=arm64`. This will cause the image build to pull the specified architecture for the UBI layer, and to build the application image for that specified architecture as well. `qemu-user-static` (on Fedora, or equivalent package elsewhere) must be installed for this step to work, since part of building the application base image involves pulling the cross-arch UBI and running commands within it (ex. `microdnf`), so this part must be emulated to prepare the image.

## Motivation for the change:
Once we can verify that these images work as expected on real ARM hardware, we can continue to publish these on push via CI alongside the existing `linux/amd64` images so that developers who may be running on ARM hardware can also run Cryostat. Or, Cryostat upstream releases could be used in production ARM environments.

I expect/hope the CI setup will basically consist of adding one of these actions as a step:
- https://github.com/docker/setup-qemu-action (equivalent to installing `qemu-user-static` on your workstation)
- https://github.com/uraimo/run-on-arch-action
and then invoking `mvn -Dbuild.arch=arm64 clean package ...` as usual.

~~TODO figure if there's a nice way with the existing base image build and `jib` plugin to do an image manifest, rather than creating separate tagged images for different archs.~~