### PR TITLE
fix(datasource): enable overwrite and use hardcoded filename

### DIFF
--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -90,6 +90,7 @@ public class WebServer extends AbstractVerticle {
 
     // Use X- prefix so as to not trigger web-browser auth dialogs
     public static final String AUTH_SCHEME_HEADER = "X-WWW-Authenticate";
+    public static final String DATASOURCE_FILENAME = "cryostat-analysis.jfr";
 
     private final HttpServer server;
     private final NetworkConfiguration netConf;

--- a/src/main/java/io/cryostat/net/web/http/HttpModule.java
+++ b/src/main/java/io/cryostat/net/web/http/HttpModule.java
@@ -59,10 +59,17 @@ import dagger.Provides;
 public abstract class HttpModule {
 
     public static final String HTTP_REQUEST_TIMEOUT_SECONDS = "HTTP_REQUEST_TIMEOUT_SECONDS";
+    public static final String DATASOURCE_FILENAME = "DATASOURCE_FILENAME";
 
     @Provides
     @Named(HTTP_REQUEST_TIMEOUT_SECONDS)
     static long provideReportGenerationTimeoutSeconds(Environment env) {
         return Long.parseLong(env.getEnv(Variables.HTTP_REQUEST_TIMEOUT, "29"));
+    }
+
+    @Provides
+    @Named(DATASOURCE_FILENAME)
+    static String provideDatasourceFilename(Environment env) {
+        return "cryostat-analysis.jfr";
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/HttpModule.java
+++ b/src/main/java/io/cryostat/net/web/http/HttpModule.java
@@ -59,17 +59,10 @@ import dagger.Provides;
 public abstract class HttpModule {
 
     public static final String HTTP_REQUEST_TIMEOUT_SECONDS = "HTTP_REQUEST_TIMEOUT_SECONDS";
-    public static final String DATASOURCE_FILENAME = "DATASOURCE_FILENAME";
 
     @Provides
     @Named(HTTP_REQUEST_TIMEOUT_SECONDS)
     static long provideReportGenerationTimeoutSeconds(Environment env) {
         return Long.parseLong(env.getEnv(Variables.HTTP_REQUEST_TIMEOUT, "29"));
-    }
-
-    @Provides
-    @Named(DATASOURCE_FILENAME)
-    static String provideDatasourceFilename(Environment env) {
-        return "cryostat-analysis.jfr";
     }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
@@ -81,6 +81,7 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
 
     private final Environment env;
     private final long httpTimeoutSeconds;
+    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -90,6 +91,7 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
+            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
@@ -98,6 +100,7 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
+        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -188,13 +191,14 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                recordingName,
+                                datasourceFilename,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 
         CompletableFuture<ResponseMessage> future = new CompletableFuture<>();
         webClient
                 .postAbs(uploadUrl.toURI().resolve("/load").normalize().toString())
+                .addQueryParam("overwrite", "true")
                 .timeout(TimeUnit.SECONDS.toMillis(httpTimeoutSeconds))
                 .sendMultipartForm(
                         form,

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandler.java
@@ -55,6 +55,7 @@ import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.HttpModule;
 import io.cryostat.net.web.http.api.ApiVersion;
@@ -81,7 +82,6 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
 
     private final Environment env;
     private final long httpTimeoutSeconds;
-    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -91,7 +91,6 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
-            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
@@ -100,7 +99,6 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
-        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -191,7 +189,7 @@ class RecordingUploadPostFromPathHandler extends AbstractV2RequestHandler<String
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                datasourceFilename,
+                                WebServer.DATASOURCE_FILENAME,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
@@ -81,6 +81,7 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
 
     private final Environment env;
     private final long httpTimeoutSeconds;
+    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -90,6 +91,7 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
+            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
@@ -98,6 +100,7 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
+        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -188,13 +191,14 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                recordingName,
+                                datasourceFilename,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 
         CompletableFuture<ResponseMessage> future = new CompletableFuture<>();
         webClient
                 .postAbs(uploadUrl.toURI().resolve("/load").normalize().toString())
+                .addQueryParam("overwrite", "true")
                 .timeout(TimeUnit.SECONDS.toMillis(httpTimeoutSeconds))
                 .sendMultipartForm(
                         form,

--- a/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandler.java
@@ -55,6 +55,7 @@ import io.cryostat.configuration.Variables;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.HttpModule;
 import io.cryostat.net.web.http.api.ApiVersion;
@@ -81,7 +82,6 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
 
     private final Environment env;
     private final long httpTimeoutSeconds;
-    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -91,7 +91,6 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
-            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Gson gson) {
@@ -100,7 +99,6 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
-        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -191,7 +189,7 @@ class RecordingUploadPostHandler extends AbstractV2RequestHandler<String> {
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                datasourceFilename,
+                                WebServer.DATASOURCE_FILENAME,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -81,6 +81,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
 
     private final Environment env;
     private final long httpTimeoutSeconds;
+    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -90,6 +91,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
+            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Logger logger) {
@@ -98,6 +100,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
+        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -179,13 +182,14 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                recordingName,
+                                datasourceFilename,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 
         CompletableFuture<ResponseMessage> future = new CompletableFuture<>();
         webClient
                 .postAbs(uploadUrl.toURI().resolve("/load").normalize().toString())
+                .addQueryParam("overwrite", "true")
                 .timeout(TimeUnit.SECONDS.toMillis(httpTimeoutSeconds))
                 .sendMultipartForm(
                         form,

--- a/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandler.java
@@ -57,6 +57,7 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.DeprecatedApi;
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.HttpModule;
@@ -81,7 +82,6 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
 
     private final Environment env;
     private final long httpTimeoutSeconds;
-    private final String datasourceFilename;
     private final WebClient webClient;
     private final RecordingArchiveHelper recordingArchiveHelper;
 
@@ -91,7 +91,6 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
             CredentialsManager credentialsManager,
             Environment env,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
-            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             RecordingArchiveHelper recordingArchiveHelper,
             Logger logger) {
@@ -100,7 +99,6 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.recordingArchiveHelper = recordingArchiveHelper;
-        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -182,7 +180,7 @@ class RecordingUploadPostHandler extends AbstractAuthenticatedRequestHandler {
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                datasourceFilename,
+                                WebServer.DATASOURCE_FILENAME,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -61,6 +61,7 @@ import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.net.web.http.HttpModule;
@@ -82,7 +83,6 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
     private final Environment env;
     private final TargetConnectionManager targetConnectionManager;
     private final long httpTimeoutSeconds;
-    private final String datasourceFilename;
     private final WebClient webClient;
     private final FileSystem fs;
 
@@ -93,7 +93,6 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             Environment env,
             TargetConnectionManager targetConnectionManager,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
-            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             FileSystem fs,
             Logger logger) {
@@ -103,7 +102,6 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.fs = fs;
-        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -188,7 +186,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                datasourceFilename,
+                                WebServer.DATASOURCE_FILENAME,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandler.java
@@ -82,6 +82,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
     private final Environment env;
     private final TargetConnectionManager targetConnectionManager;
     private final long httpTimeoutSeconds;
+    private final String datasourceFilename;
     private final WebClient webClient;
     private final FileSystem fs;
 
@@ -92,6 +93,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
             Environment env,
             TargetConnectionManager targetConnectionManager,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeoutSeconds,
+            @Named(HttpModule.DATASOURCE_FILENAME) String datasourceFilename,
             WebClient webClient,
             FileSystem fs,
             Logger logger) {
@@ -101,6 +103,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
         this.httpTimeoutSeconds = httpTimeoutSeconds;
         this.webClient = webClient;
         this.fs = fs;
+        this.datasourceFilename = datasourceFilename;
     }
 
     @Override
@@ -185,7 +188,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
                 MultipartForm.create()
                         .binaryFileUpload(
                                 "file",
-                                recordingName,
+                                datasourceFilename,
                                 recordingPath.toString(),
                                 HttpMimeType.OCTET_STREAM.toString());
 
@@ -193,6 +196,7 @@ class TargetRecordingUploadPostHandler extends AbstractAuthenticatedRequestHandl
         try {
             webClient
                     .postAbs(uploadUrl.toURI().resolve("/load").normalize().toString())
+                    .addQueryParam("overwrite", "true")
                     .timeout(TimeUnit.SECONDS.toMillis(httpTimeoutSeconds))
                     .sendMultipartForm(
                             form,

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostFromPathHandlerTest.java
@@ -222,6 +222,8 @@ class RecordingUploadPostFromPathHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
@@ -275,6 +277,8 @@ class RecordingUploadPostFromPathHandlerTest {
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
                                 @Override
@@ -333,6 +337,8 @@ class RecordingUploadPostFromPathHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
@@ -392,6 +398,8 @@ class RecordingUploadPostFromPathHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {

--- a/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/RecordingUploadPostHandlerTest.java
@@ -215,6 +215,8 @@ class RecordingUploadPostHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
@@ -264,6 +266,8 @@ class RecordingUploadPostHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
@@ -320,6 +324,8 @@ class RecordingUploadPostHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {
@@ -376,6 +382,8 @@ class RecordingUploadPostHandlerTest {
             HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
             HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
             when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+            when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(httpReq);
             when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
             Mockito.doAnswer(
                             new Answer<Void>() {

--- a/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/RecordingUploadPostHandlerTest.java
@@ -195,6 +195,8 @@ class RecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -251,6 +253,8 @@ class RecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -316,6 +320,8 @@ class RecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -374,6 +380,8 @@ class RecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingUploadPostHandlerTest.java
@@ -232,6 +232,8 @@ class TargetRecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -301,6 +303,8 @@ class TargetRecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -373,6 +377,8 @@ class TargetRecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {
@@ -445,6 +451,8 @@ class TargetRecordingUploadPostHandlerTest {
         HttpRequest<Buffer> httpReq = Mockito.mock(HttpRequest.class);
         HttpResponse<Buffer> httpResp = Mockito.mock(HttpResponse.class);
         Mockito.when(webClient.postAbs(Mockito.anyString())).thenReturn(httpReq);
+        Mockito.when(httpReq.addQueryParam(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(httpReq);
         Mockito.when(httpReq.timeout(Mockito.anyLong())).thenReturn(httpReq);
         Mockito.doAnswer(
                         new Answer<Void>() {

--- a/src/test/java/itest/UploadRecordingIT.java
+++ b/src/test/java/itest/UploadRecordingIT.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 
 import io.vertx.core.MultiMap;
@@ -131,7 +132,9 @@ public class UploadRecordingIT extends StandardSelfTest {
                         });
 
         final String expectedUploadResponse =
-                String.format("Uploaded: %s\nSet: %s", RECORDING_NAME, RECORDING_NAME);
+                String.format(
+                        "Uploaded: %s\nSet: %s",
+                        WebServer.DATASOURCE_FILENAME, WebServer.DATASOURCE_FILENAME);
 
         MatcherAssert.assertThat(
                 uploadRespFuture.get().trim(), Matchers.equalTo(expectedUploadResponse));
@@ -154,7 +157,7 @@ public class UploadRecordingIT extends StandardSelfTest {
 
         MatcherAssert.assertThat(
                 getRespFuture.get().trim(),
-                Matchers.equalTo(String.format("**%s**", RECORDING_NAME)));
+                Matchers.equalTo(String.format("**%s**", WebServer.DATASOURCE_FILENAME)));
 
         // Query Data Source for recording metrics
         final CompletableFuture<JsonArray> queryRespFuture = new CompletableFuture<>();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/jfr-datasource/pull/153

## Description of the change:

Routes that post jfr file to datasource should now use query paramter `overwrite=true` and hardcoded name `cryostat-analysis.jfr`.

## Motivation for the change:

[See  https://github.com/cryostatio/jfr-datasource/issue/152](https://github.com/cryostatio/jfr-datasource/issues/152)