### PR TITLE
chore(scripts): use `xpath` in cryostat dev scripts if available

### DIFF
--- a/devserver.sh
+++ b/devserver.sh
@@ -9,10 +9,12 @@ grafana_container="cryostat-devserver-grafana-dashboard"
 podname="cryostat-devserver"
 
 getPomProperty() {
-    if command -v xpath > /dev/null 2>&1 ; then
+    if command -v xpaths > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
+    elif command -v mvnd > /dev/null 2>&1 ; then
+        mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     else
-        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+        mvn help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     fi
 }
 

--- a/devserver.sh
+++ b/devserver.sh
@@ -9,7 +9,7 @@ grafana_container="cryostat-devserver-grafana-dashboard"
 podname="cryostat-devserver"
 
 getPomProperty() {
-    if command -v xpaths > /dev/null 2>&1 ; then
+    if command -v xpath > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
     elif command -v mvnd > /dev/null 2>&1 ; then
         mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -16,7 +16,7 @@ if [ -z "${MVN}" ]; then
 fi
 
 getPomProperty() {
-    if command -v xpaths > /dev/null 2>&1 ; then
+    if command -v xpath > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
     elif command -v mvnd > /dev/null 2>&1 ; then
         mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -16,10 +16,12 @@ if [ -z "${MVN}" ]; then
 fi
 
 getPomProperty() {
-    if command -v xpath > /dev/null 2>&1 ; then
+    if command -v xpaths > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
+    elif command -v mvnd > /dev/null 2>&1 ; then
+        mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     else
-        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+        mvn help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     fi
 }
 

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -15,16 +15,24 @@ if [ -z "${MVN}" ]; then
     MVN="$(which mvn)"
 fi
 
+getPomProperty() {
+    if command -v xpath > /dev/null 2>&1 ; then
+        xpath -q -e "project/properties/$1/text()" pom.xml
+    else
+        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+    fi
+}
+
 if [ -z "${POD_NAME}" ]; then
-    POD_NAME="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.podName)"
+    POD_NAME="$(getPomProperty cryostat.itest.podName)"
 fi
 
 if [ -z "${CONTAINER_NAME}" ]; then
-    CONTAINER_NAME="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.containerName)"
+    CONTAINER_NAME="$(getPomProperty cryostat.itest.containerName)"
 fi
 
 if [ -z "${ITEST_IMG_VERSION}" ]; then
-    ITEST_IMG_VERSION="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=project.version)"
+    ITEST_IMG_VERSION="$(getPomProperty project.version)"
     ITEST_IMG_VERSION="${ITEST_IMG_VERSION,,}" # lowercase
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,14 @@ if [ -z "${MVN}" ]; then
     MVN="$(which mvn)"
 fi
 
+getPomProperty() {
+    if command -v xpath > /dev/null 2>&1 ; then
+        xpath -q -e "project/properties/$1/text()" pom.xml
+    else
+        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+    fi
+}
+
 cleanup() {
     podman pod stop cryostat-pod
     podman pod rm cryostat-pod
@@ -21,7 +29,7 @@ fi
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"
 
 if [ -z "$CRYOSTAT_RJMX_PORT" ]; then
-    CRYOSTAT_RJMX_PORT="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
+    CRYOSTAT_RJMX_PORT="$(getPomProperty cryostat.rjmxPort)"
 fi
 
 if [ -z "$CRYOSTAT_RMI_PORT" ]; then
@@ -29,11 +37,11 @@ if [ -z "$CRYOSTAT_RMI_PORT" ]; then
 fi
 
 if [ -z "$CRYOSTAT_WEB_HOST" ]; then
-    CRYOSTAT_WEB_HOST="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
+    CRYOSTAT_WEB_HOST="$(getPomProperty cryostat.itest.webHost)"
 fi
 
 if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-    CRYOSTAT_WEB_PORT="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
+    CRYOSTAT_WEB_PORT="$(getPomProperty cryostat.itest.webPort)"
 fi
 
 if [ -z "$CRYOSTAT_EXT_WEB_PORT" ]; then

--- a/run.sh
+++ b/run.sh
@@ -9,10 +9,12 @@ if [ -z "${MVN}" ]; then
 fi
 
 getPomProperty() {
-    if command -v xpath > /dev/null 2>&1 ; then
+    if command -v xpaths > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
+    elif command -v mvnd > /dev/null 2>&1 ; then
+        mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     else
-        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+        mvn help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ if [ -z "${MVN}" ]; then
 fi
 
 getPomProperty() {
-    if command -v xpaths > /dev/null 2>&1 ; then
+    if command -v xpath > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
     elif command -v mvnd > /dev/null 2>&1 ; then
         mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -8,12 +8,20 @@ if [ -z "${MVN}" ]; then
     MVN="$(which mvn)"
 fi
 
+getPomProperty() {
+    if command -v xpath > /dev/null 2>&1 ; then
+        xpath -q -e "project/properties/$1/text()" pom.xml
+    else
+        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+    fi
+}
+
 runCryostat() {
     local DIR; local host; local datasourcePort; local grafanaPort;
     DIR="$(dirname "$(readlink -f "$0")")"
-    host="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
-    datasourcePort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
-    grafanaPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.port)"
+    host="$(getPomProperty cryostat.itest.webHost)"
+    datasourcePort="$(getPomProperty cryostat.itest.jfr-datasource.port)"
+    grafanaPort="$(getPomProperty cryostat.itest.grafana.port)"
     # credentials `user:pass`
     echo "user:d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1" > "./conf/cryostat-users.properties"
 
@@ -67,8 +75,8 @@ runPostgres() {
         mkdir "$(dirname "$0")/conf/postgres"
     fi
     local image; local version;
-    image="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=postgres.image)"
-    version="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=postgres.version)"
+    image="$(getPomProperty postgres.image)"
+    version="$(getPomProperty postgres.version)"
     podman run \
         --name postgres \
         --pod cryostat-pod \
@@ -109,7 +117,7 @@ runDemoApps() {
 
     local webPort;
     if [ -z "$CRYOSTAT_WEB_PORT" ]; then
-        webPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webPort)"
+        webPort="$(getPomProperty cryostat.itest.webPort)"
     else
         webPort="${CRYOSTAT_WEB_PORT}"
     fi
@@ -177,8 +185,8 @@ runDemoApps() {
 
 runJfrDatasource() {
     local stream; local tag;
-    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.imageStream)"
-    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.version)"
+     stream="$(getPomProperty cryostat.itest.jfr-datasource.imageStream)"
+    tag="$(getPomProperty cryostat.itest.jfr-datasource.version)"
     podman run \
         --name jfr-datasource \
         --pull always \
@@ -188,10 +196,10 @@ runJfrDatasource() {
 
 runGrafana() {
     local stream; local tag; local host; local port;
-    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.imageStream)"
-    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.version)"
-    host="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.webHost)"
-    port="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
+    stream="$(getPomProperty cryostat.itest.grafana.imageStream)"
+    tag="$(getPomProperty cryostat.itest.grafana.version)"
+    host="$(getPomProperty cryostat.itest.webHost)"
+    port="$(getPomProperty cryostat.itest.jfr-datasource.port)"
     podman run \
         --name grafana \
         --pull always \
@@ -204,9 +212,9 @@ runGrafana() {
 
 runReportGenerator() {
     local RJMX_PORT=10000
-    stream="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.imageStream)"
-    tag="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.version)"
-    port="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.reports.port)"
+    stream="$(getPomProperty cryostat.itest.reports.imageStream)"
+    tag="$(getPomProperty cryostat.itest.reports.version)"
+    port="$(getPomProperty cryostat.itest.reports.port)"
     podman run \
         --name reports \
         --pull always \
@@ -221,10 +229,10 @@ runReportGenerator() {
 
 createPod() {
     local jmxPort; local webPort; local datasourcePort; local grafanaPort;
-    jmxPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.rjmxPort)"
-    webPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.webPort)"
-    datasourcePort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.jfr-datasource.port)"
-    grafanaPort="$(${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.itest.grafana.port)"
+    jmxPort="$(getPomProperty cryostat.rjmxPort)"
+    webPort="$(getPomProperty cryostat.webPort)"
+    datasourcePort="$(getPomProperty cryostat.itest.jfr-datasource.port)"
+    grafanaPort="$(getPomProperty cryostat.itest.grafana.port)"
     podman pod create \
         --replace \
         --hostname cryostat \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -4,15 +4,13 @@
 set -x
 set -e
 
-if [ -z "${MVN}" ]; then
-    MVN="$(which mvn)"
-fi
-
 getPomProperty() {
-    if command -v xpath > /dev/null 2>&1 ; then
+    if command -v xpaths > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
+    elif command -v mvnd > /dev/null 2>&1 ; then
+        mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     else
-        ${MVN} help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
+        mvn help:evaluate -o -B -q -DforceStdout -Dexpression="$1"
     fi
 }
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -5,7 +5,7 @@ set -x
 set -e
 
 getPomProperty() {
-    if command -v xpaths > /dev/null 2>&1 ; then
+    if command -v xpath > /dev/null 2>&1 ; then
         xpath -q -e "project/properties/$1/text()" pom.xml
     elif command -v mvnd > /dev/null 2>&1 ; then
         mvnd help:evaluate -o -B -q -DforceStdout -Dexpression="$1"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1355 

## Description of the change:
This allows cryostat dev setup to be faster with xpath if it is available vs. using `mvn:evaluate`.

## How to manually test:
1. Have optional xpath installed 
2. Run `sh smoketest.sh` with this pr changes, and without and see the difference.
