### PR TITLE
feat(activerecordings): add param for restarting existing recording definitions

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -173,6 +173,10 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                         recordingOptionsBuilderFactory
                                                 .create(connection.getService())
                                                 .name(recordingName);
+                                boolean restart = false;
+                                if (attrs.contains("restart")) {
+                                    restart = Boolean.parseBoolean(attrs.get("restart"));
+                                }
                                 if (attrs.contains("duration")) {
                                     builder =
                                             builder.duration(
@@ -217,6 +221,7 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 eventSpecifier);
                                 IRecordingDescriptor descriptor =
                                         recordingTargetHelper.startRecording(
+                                                restart,
                                                 connectionDescriptor,
                                                 builder.build(),
                                                 template.getLeft(),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -129,10 +129,14 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
+                    boolean restart = false;
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
+                    if (settings.containsKey("restart")) {
+                        restart = Boolean.parseBoolean((String) settings.get("restart"));
+                    }
                     if (settings.containsKey("duration")) {
                         builder =
                                 builder.duration(
@@ -162,6 +166,7 @@ class StartRecordingOnTargetMutator
                     }
                     IRecordingDescriptor desc =
                             recordingTargetHelper.startRecording(
+                                    restart,
                                     cd,
                                     builder.build(),
                                     (String) settings.get("template"),

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -206,41 +206,6 @@ public class RecordingTargetHelper {
                 });
     }
 
-    public IRecordingDescriptor startRecording(
-            ConnectionDescriptor connectionDescriptor,
-            IConstrainedMap<String> recordingOptions,
-            String templateName,
-            TemplateType templateType,
-            Metadata metadata)
-            throws Exception {
-        return startRecording(
-                false,
-                connectionDescriptor,
-                recordingOptions,
-                templateName,
-                templateType,
-                metadata,
-                false);
-    }
-
-    public IRecordingDescriptor startRecording(
-            ConnectionDescriptor connectionDescriptor,
-            IConstrainedMap<String> recordingOptions,
-            String templateName,
-            TemplateType templateType,
-            Metadata metadata,
-            boolean archiveOnStop)
-            throws Exception {
-        return startRecording(
-                false,
-                connectionDescriptor,
-                recordingOptions,
-                templateName,
-                templateType,
-                metadata,
-                archiveOnStop);
-    }
-
     /**
      * The returned {@link InputStream}, if any, is only readable while the remote connection
      * remains open. And so, {@link

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -152,6 +152,7 @@ type RecordingMetadata {
 }
 
 input RecordingSettings {
+    restart: Boolean
     name: String!
     template: String!
     templateType: String!


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/issues/847

## Description of the change:
This change adds parameters for the HTTP API and GraphQL API endpoint/fetcher for starting new recordings. The new parameter allows the client to specify that the recording should be "restarted" (closed/removed remotely and recreated) if a recording with the same name already exists on the target. This same logic is already implemented internally and used by Automated Rules, so this simply extends it to the explicit recording creation API entrypoints.

## Motivation for the change:
This is useful for the embedded charts dashboard views since those need to be backed by an active and running recording. If this recording has been previously created but some client stopped it without removing it, this parameter can be set so that it's quicker and cleaner for the user to trigger the required recording to be restarted and allow the charts dashboard views to be re-enabled.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Start a new recording on a particular target
3. Try to start another new recording using the same recording name. It should fail with an HTTP 400 response due to the naming conflict.
4. Try again, this time adding the `restart=true` form attribute. The request should now succeed and result in a single recording with the specified attributes being present on the target, regardless of whether the previous recording of the same name was running or stopped.
