### PR TITLE
fix(k8s): no implicit own-namespace watching

### DIFF
--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
@@ -40,16 +40,19 @@ package io.cryostat.platform.internal;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.net.AuthManager;
-import io.cryostat.net.NoopAuthManager;
+
+import dagger.Lazy;
 
 class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatformClient> {
 
     private final Logger logger;
-    private final NoopAuthManager authMgr;
-    private final JvmDiscoveryClient discoveryClient;
+    private final Lazy<? extends AuthManager> authMgr;
+    private final Lazy<JvmDiscoveryClient> discoveryClient;
 
     DefaultPlatformStrategy(
-            Logger logger, NoopAuthManager authMgr, JvmDiscoveryClient discoveryClient) {
+            Logger logger,
+            Lazy<? extends AuthManager> authMgr,
+            Lazy<JvmDiscoveryClient> discoveryClient) {
         this.logger = logger;
         this.authMgr = authMgr;
         this.discoveryClient = discoveryClient;
@@ -68,11 +71,11 @@ class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatfo
     @Override
     public DefaultPlatformClient getPlatformClient() {
         logger.info("Selected Default Platform Strategy");
-        return new DefaultPlatformClient(logger, discoveryClient);
+        return new DefaultPlatformClient(logger, discoveryClient.get());
     }
 
     @Override
     public AuthManager getAuthManager() {
-        return authMgr;
+        return authMgr.get();
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -125,18 +125,6 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
         return authMgr;
     }
 
-    protected List<String> getNamespaces() {
-        // TODO should the own-namespace always be implied or should it be required for the user to
-        // explicitly specify?
-        List<String> list = new ArrayList<>();
-        list.add(getOwnNamespace());
-        String cfg = env.getEnv(Variables.K8S_NAMESPACES, "");
-        if (StringUtils.isNotBlank(cfg)) {
-            list.addAll(Arrays.asList(cfg.split(",")));
-        }
-        return list;
-    }
-
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     protected String getOwnNamespace() {
         try {
@@ -145,5 +133,14 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
             logger.trace(e);
             return null;
         }
+    }
+
+    protected List<String> getNamespaces() {
+        List<String> list = new ArrayList<>();
+        String cfg = env.getEnv(Variables.K8S_NAMESPACES, "");
+        if (StringUtils.isNotBlank(cfg)) {
+            list.addAll(Arrays.asList(cfg.split(",")));
+        }
+        return list;
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeEnvPlatformStrategy.java
@@ -55,13 +55,13 @@ class KubeEnvPlatformStrategy implements PlatformDetectionStrategy<KubeEnvPlatfo
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
     private final Logger logger;
     private final FileSystem fs;
-    private final AuthManager authMgr;
+    private final Lazy<? extends AuthManager> authMgr;
     private final Environment env;
 
     KubeEnvPlatformStrategy(
             Logger logger,
             FileSystem fs,
-            AuthManager authMgr,
+            Lazy<? extends AuthManager> authMgr,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env) {
         this.logger = logger;
@@ -90,7 +90,7 @@ class KubeEnvPlatformStrategy implements PlatformDetectionStrategy<KubeEnvPlatfo
 
     @Override
     public AuthManager getAuthManager() {
-        return authMgr;
+        return authMgr.get();
     }
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -37,6 +37,8 @@
  */
 package io.cryostat.platform.internal;
 
+import java.util.function.BiFunction;
+
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
@@ -44,26 +46,17 @@ import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
 import dagger.Lazy;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
 
-    private OpenShiftClient osClient;
-
     OpenShiftPlatformStrategy(
             Logger logger,
-            AuthManager authMgr,
+            Lazy<? extends AuthManager> authMgr,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
             FileSystem fs) {
         super(logger, authMgr, connectionToolkit, env, fs);
-        try {
-            this.osClient = new DefaultOpenShiftClient();
-        } catch (Exception e) {
-            logger.info(e);
-            this.osClient = null;
-        }
     }
 
     @Override
@@ -72,32 +65,12 @@ class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
     }
 
     @Override
-    public boolean isAvailable() {
-        logger.trace("Testing OpenShift Platform Availability");
-        if (osClient == null) {
-            return false;
-        }
-        try {
-            String namespace = getOwnNamespace();
-            if (namespace == null) {
-                return false;
-            }
-            osClient.routes().inNamespace(namespace).list();
-            return true;
-        } catch (Exception e) {
-            logger.info(e);
-            return false;
-        }
+    protected BiFunction<OpenShiftClient, String, ?> testAvailability() {
+        return (client, ns) -> client.routes().inNamespace(ns).list();
     }
 
     @Override
-    public KubeApiPlatformClient getPlatformClient() {
-        logger.info("Selected OpenShift Platform Strategy");
-        return super.getPlatformClient();
-    }
-
-    @Override
-    public AuthManager getAuthManager() {
-        return authMgr;
+    protected OpenShiftClient createClient() {
+        return super.createClient().adapt(OpenShiftClient.class);
     }
 }

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -37,8 +37,6 @@
  */
 package io.cryostat.platform.internal;
 
-import java.util.function.BiFunction;
-
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
@@ -46,6 +44,7 @@ import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
 import dagger.Lazy;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
@@ -65,8 +64,8 @@ class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
     }
 
     @Override
-    protected BiFunction<OpenShiftClient, String, ?> testAvailability() {
-        return (client, ns) -> client.routes().inNamespace(ns).list();
+    protected boolean testAvailability(KubernetesClient client) {
+        return super.testAvailability(client) && (((OpenShiftClient) client).isSupported());
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -60,13 +60,13 @@ public abstract class PlatformStrategyModule {
     @ElementsIntoSet
     static Set<PlatformDetectionStrategy<?>> providePlatformDetectionStrategies(
             Logger logger,
-            OpenShiftAuthManager openShiftAuthManager,
-            NoopAuthManager noopAuthManager,
+            Lazy<OpenShiftAuthManager> openShiftAuthManager,
+            Lazy<NoopAuthManager> noopAuthManager,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             NetworkResolver resolver,
             Environment env,
             FileSystem fs,
-            JvmDiscoveryClient discoveryClient) {
+            Lazy<JvmDiscoveryClient> discoveryClient) {
         return Set.of(
                 new OpenShiftPlatformStrategy(
                         logger, openShiftAuthManager, connectionToolkit, env, fs),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1365

## Description of the change:
This removes the own-namespace from being implicitly included in the list of watched namespaces in k8s environments.

## Motivation for the change:
The end user, or managing Cryostat Operator, should explicitly list any and all namespaces that they want the Cryostat instance to watch. The implicit inclusion of Cryostat's own namespace restricted users' choices since it was not previously possible to have Cryostat *not* watch that namespace and discover itself.

## How to manually test:
1. Deploy test image in k8s environment
2. Set `CRYOSTAT_K8S_NAMESPACES` environment variable to ex. `CRYOSTAT_K8S_NAMESPACES=myns1,myns2`.
3. Using the HTTP API or web-client, check if Cryostat discovers itself. Repeat steps 2 and 3 including (or not) the Cryostat deployment namespace in the list.
