### PR TITLE
feat(match-expr): add `MatchExpression` resource

### DIFF
--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -53,6 +53,7 @@ import io.cryostat.messaging.MessagingServer;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.recordings.RecordingMetadataManager;
+import io.cryostat.rules.MatchExpressionManager;
 import io.cryostat.rules.RuleProcessor;
 import io.cryostat.rules.RuleRegistry;
 
@@ -178,6 +179,8 @@ class Cryostat extends AbstractVerticle {
         MessagingServer messagingServer();
 
         RecordingMetadataManager recordingMetadataManager();
+
+        MatchExpressionManager matchExpressionManager();
 
         @Component.Builder
         interface Builder {

--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -53,7 +53,6 @@ import io.cryostat.messaging.MessagingServer;
 import io.cryostat.net.HttpServer;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.recordings.RecordingMetadataManager;
-import io.cryostat.rules.MatchExpressionManager;
 import io.cryostat.rules.RuleProcessor;
 import io.cryostat.rules.RuleRegistry;
 
@@ -179,8 +178,6 @@ class Cryostat extends AbstractVerticle {
         MessagingServer messagingServer();
 
         RecordingMetadataManager recordingMetadataManager();
-
-        MatchExpressionManager matchExpressionManager();
 
         @Component.Builder
         interface Builder {

--- a/src/main/java/io/cryostat/net/security/ResourceAction.java
+++ b/src/main/java/io/cryostat/net/security/ResourceAction.java
@@ -39,6 +39,7 @@ package io.cryostat.net.security;
 
 import static io.cryostat.net.security.ResourceType.CERTIFICATE;
 import static io.cryostat.net.security.ResourceType.CREDENTIALS;
+import static io.cryostat.net.security.ResourceType.MATCH_EXPRESSION;
 import static io.cryostat.net.security.ResourceType.RECORDING;
 import static io.cryostat.net.security.ResourceType.REPORT;
 import static io.cryostat.net.security.ResourceType.RULE;
@@ -80,6 +81,11 @@ public enum ResourceAction {
     READ_REPORT(READ, REPORT),
     UPDATE_REPORT(UPDATE, REPORT),
     DELETE_REPORT(DELETE, REPORT),
+
+    CREATE_MATCH_EXPRESSION(CREATE, MATCH_EXPRESSION),
+    READ_MATCH_EXPRESSION(READ, MATCH_EXPRESSION),
+    UPDATE_MATCH_EXPRESSION(UPDATE, MATCH_EXPRESSION),
+    DELETE_MATCH_EXPRESSION(DELETE, MATCH_EXPRESSION),
 
     CREATE_CREDENTIALS(CREATE, CREDENTIALS),
     READ_CREDENTIALS(READ, CREDENTIALS),

--- a/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
@@ -140,4 +140,25 @@ public abstract class HttpApiBetaModule {
     @IntoSet
     abstract RequestHandler bindRecordingsFromIdPostBodyHandler(
             RecordingsFromIdPostBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindMatchExpressionGetHandler(MatchExpressionGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindMatchExpressionsGetHandler(MatchExpressionsGetHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindMatchExpressionsPostHandler(MatchExpressionsPostHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindMatchExpressionsPostBodyHandler(
+            MatchExpressionsPostBodyHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindMatchExpressionDeleteHandler(MatchExpressionDeleteHandler handler);
 }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
@@ -63,7 +63,7 @@ import io.vertx.core.http.HttpMethod;
 
 public class MatchExpressionDeleteHandler extends AbstractV2RequestHandler<Void> {
 
-    private final MatchExpressionManager matchExpressionManager;
+    private final MatchExpressionManager expressionManager;
     private final NotificationFactory notificationFactory;
 
     @Inject
@@ -74,7 +74,7 @@ public class MatchExpressionDeleteHandler extends AbstractV2RequestHandler<Void>
             NotificationFactory notificationFactory,
             Gson gson) {
         super(auth, credentialsManager, gson);
-        this.matchExpressionManager = matchExpressionManager;
+        this.expressionManager = matchExpressionManager;
         this.notificationFactory = notificationFactory;
     }
 
@@ -111,16 +111,16 @@ public class MatchExpressionDeleteHandler extends AbstractV2RequestHandler<Void>
     @Override
     public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
         int id = Integer.parseInt(params.getPathParams().get("id"));
-        Optional<MatchExpression> matchExpression = matchExpressionManager.get(id);
+        Optional<MatchExpression> matchExpression = expressionManager.get(id);
         if (matchExpression.isEmpty()) {
             return new IntermediateResponse<Void>().statusCode(404);
         }
 
         MatchExpression expr = matchExpression.get();
-        if (this.matchExpressionManager.delete(id)) {
+        if (expressionManager.delete(id)) {
             notificationFactory
                     .createBuilder()
-                    .metaCategory("CredentialsDeleted")
+                    .metaCategory("MatchExpressionDeleted")
                     .metaType(HttpMimeType.JSON)
                     .message(Map.of("id", id, "matchExpression", expr.getMatchExpression()))
                     .build()

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+
+public class MatchExpressionDeleteHandler extends AbstractV2RequestHandler<Void> {
+
+    private final MatchExpressionManager matchExpressionManager;
+    private final NotificationFactory notificationFactory;
+
+    @Inject
+    MatchExpressionDeleteHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            MatchExpressionManager matchExpressionManager,
+            NotificationFactory notificationFactory,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
+        this.matchExpressionManager = matchExpressionManager;
+        this.notificationFactory = notificationFactory;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.DELETE;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.DELETE_MATCH_EXPRESSION);
+    }
+
+    @Override
+    public String path() {
+        return basePath() + "matchExpressions/:id";
+    }
+
+    @Override
+    public List<HttpMimeType> produces() {
+        return List.of(HttpMimeType.JSON);
+    }
+
+    @Override
+    public IntermediateResponse<Void> handle(RequestParameters params) throws ApiException {
+        int id = Integer.parseInt(params.getPathParams().get("id"));
+        Optional<MatchExpression> matchExpression = matchExpressionManager.get(id);
+        if (matchExpression.isEmpty()) {
+            return new IntermediateResponse<Void>().statusCode(404);
+        }
+
+        MatchExpression expr = matchExpression.get();
+        if (this.matchExpressionManager.delete(id)) {
+            notificationFactory
+                    .createBuilder()
+                    .metaCategory("CredentialsDeleted")
+                    .metaType(HttpMimeType.JSON)
+                    .message(Map.of("id", id, "matchExpression", expr.getMatchExpression()))
+                    .build()
+                    .send();
+            return new IntermediateResponse<Void>().statusCode(200);
+        }
+        throw new ApiException(500);
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandler.java
@@ -100,7 +100,7 @@ public class MatchExpressionDeleteHandler extends AbstractV2RequestHandler<Void>
 
     @Override
     public String path() {
-        return basePath() + "matchExpressions/:id";
+        return basePath() + MatchExpressionGetHandler.PATH;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
+
+class MatchExpressionGetHandler extends AbstractV2RequestHandler<MatchedMatchExpression> {
+
+    private final MatchExpressionManager expressionManager;
+
+    @Inject
+    MatchExpressionGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            MatchExpressionManager expressionManager,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
+        this.expressionManager = expressionManager;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.READ_MATCH_EXPRESSION);
+    }
+
+    @Override
+    public String path() {
+        return basePath() + "matchExpressions/:id";
+    }
+
+    @Override
+    public List<HttpMimeType> produces() {
+        return List.of(HttpMimeType.JSON);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public IntermediateResponse<MatchedMatchExpression> handle(RequestParameters params)
+            throws ApiException {
+        String matches = params.getQueryParams().get("matches");
+        int id = Integer.parseInt(params.getPathParams().get("id"));
+        Optional<MatchExpression> opt = expressionManager.get(id);
+        if (opt.isEmpty()) {
+            return new IntermediateResponse<MatchedMatchExpression>().statusCode(404);
+        }
+        MatchExpression expr = opt.get();
+        if (StringUtils.isNotBlank(matches)) {
+            Set<ServiceRef> matched =
+                    expressionManager.resolveMatchingTargets(expr.getMatchExpression());
+            return new IntermediateResponse<MatchedMatchExpression>()
+                    .body(new MatchedMatchExpression(expr, matched));
+        }
+        return new IntermediateResponse<MatchedMatchExpression>()
+                .body(new MatchedMatchExpression(expr));
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandler.java
@@ -60,9 +60,10 @@ import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
 
 import com.google.gson.Gson;
 import io.vertx.core.http.HttpMethod;
-import org.apache.commons.lang3.StringUtils;
 
 class MatchExpressionGetHandler extends AbstractV2RequestHandler<MatchedMatchExpression> {
+
+    static final String PATH = "matchExpressions/:id";
 
     private final MatchExpressionManager expressionManager;
 
@@ -98,7 +99,7 @@ class MatchExpressionGetHandler extends AbstractV2RequestHandler<MatchedMatchExp
 
     @Override
     public String path() {
-        return basePath() + "matchExpressions/:id";
+        return basePath() + PATH;
     }
 
     @Override
@@ -121,9 +122,8 @@ class MatchExpressionGetHandler extends AbstractV2RequestHandler<MatchedMatchExp
             return new IntermediateResponse<MatchedMatchExpression>().statusCode(404);
         }
         MatchExpression expr = opt.get();
-        if (StringUtils.isNotBlank(matches)) {
-            Set<ServiceRef> matched =
-                    expressionManager.resolveMatchingTargets(expr.getMatchExpression());
+        if (Boolean.parseBoolean(matches)) {
+            Set<ServiceRef> matched = expressionManager.resolveMatchingTargets(expr);
             return new IntermediateResponse<MatchedMatchExpression>()
                     .body(new MatchedMatchExpression(expr, matched));
         }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandler.java
@@ -94,7 +94,7 @@ class MatchExpressionsGetHandler extends AbstractV2RequestHandler<List<MatchExpr
 
     @Override
     public String path() {
-        return basePath() + "matchExpressions";
+        return basePath() + MatchExpressionsPostHandler.PATH;
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+
+class MatchExpressionsGetHandler extends AbstractV2RequestHandler<List<MatchExpression>> {
+
+    private final MatchExpressionManager expressionManager;
+
+    @Inject
+    MatchExpressionsGetHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            MatchExpressionManager expressionManager,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
+        this.expressionManager = expressionManager;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.READ_MATCH_EXPRESSION);
+    }
+
+    @Override
+    public String path() {
+        return basePath() + "matchExpressions";
+    }
+
+    @Override
+    public List<HttpMimeType> produces() {
+        return List.of(HttpMimeType.JSON);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public IntermediateResponse<List<MatchExpression>> handle(RequestParameters params)
+            throws ApiException {
+        List<MatchExpression> expressions = expressionManager.getAll();
+        return new IntermediateResponse<List<MatchExpression>>().body(expressions);
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostBodyHandler.java
@@ -35,16 +35,61 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.security;
 
-public enum ResourceType {
-    TARGET,
-    RECORDING,
-    TEMPLATE,
-    REPORT,
-    MATCH_EXPRESSION,
-    CREDENTIALS,
-    RULE,
-    CERTIFICATE,
-    ;
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class MatchExpressionsPostBodyHandler extends AbstractAuthenticatedRequestHandler {
+
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
+
+    @Inject
+    MatchExpressionsPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
+    }
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return ResourceAction.NONE;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + MatchExpressionsPostHandler.PATH;
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        BODY_HANDLER.handle(ctx);
+    }
 }

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
@@ -63,6 +63,7 @@ import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
 import io.cryostat.rules.MatchExpressionValidationException;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import org.apache.commons.lang3.StringUtils;
@@ -171,6 +172,8 @@ public class MatchExpressionsPostHandler extends AbstractV2RequestHandler<Matche
                         .addHeader(HttpHeaders.LOCATION, String.format("%s/%d", path(), id))
                         .body(new MatchedMatchExpression(expr));
             }
+        } catch (JsonParseException e) {
+            throw new ApiException(400, "JSON formatting error", e);
         } catch (RollbackException e) {
             if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
                 throw new ApiException(400, "Duplicate matchExpression", e);

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.persistence.RollbackException;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
+import io.cryostat.rules.MatchExpressionValidationException;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hibernate.exception.ConstraintViolationException;
+
+public class MatchExpressionsPostHandler extends AbstractV2RequestHandler<MatchedMatchExpression> {
+
+    static final String PATH = "matchExpressions";
+
+    private final MatchExpressionManager expressionManager;
+    private final NotificationFactory notificationFactory;
+
+    @Inject
+    MatchExpressionsPostHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            MatchExpressionManager expressionManager,
+            NotificationFactory notificationFactory,
+            Gson gson) {
+        super(auth, credentialsManager, gson);
+        this.expressionManager = expressionManager;
+        this.notificationFactory = notificationFactory;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.CREATE_MATCH_EXPRESSION);
+    }
+
+    @Override
+    public String path() {
+        return basePath() + PATH;
+    }
+
+    @Override
+    public List<HttpMimeType> produces() {
+        return List.of(HttpMimeType.JSON);
+    }
+
+    @Override
+    public List<HttpMimeType> consumes() {
+        return List.of(HttpMimeType.MULTIPART_FORM, HttpMimeType.URLENCODED_FORM);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
+    public IntermediateResponse<MatchedMatchExpression> handle(RequestParameters params)
+            throws ApiException {
+        String matchExpression = params.getFormAttributes().get("matchExpression");
+        String targets = params.getFormAttributes().get("targets");
+        if (StringUtils.isBlank(matchExpression)) {
+            throw new ApiException(400, "'matchExpression' is required.");
+        }
+        try {
+            if (StringUtils.isNotBlank(targets)) {
+                Set<ServiceRef> matched;
+                List<String> parsedTargets = this.expressionManager.parseTargets(targets);
+                matched =
+                        this.expressionManager.resolveMatchingTargets(
+                                matchExpression, parsedTargets);
+
+                return new IntermediateResponse<MatchedMatchExpression>()
+                        .statusCode(200)
+                        .body(new MatchedMatchExpression(matchExpression, matched));
+            } else {
+                int id = this.expressionManager.addMatchExpression(matchExpression);
+                Optional<MatchExpression> opt = this.expressionManager.get(id);
+                if (opt.isEmpty()) {
+                    throw new ApiException(500, "Failed to add match expression");
+                }
+                MatchExpression expr = opt.get();
+                notificationFactory
+                        .createBuilder()
+                        .metaCategory("MatchExpressionAdded")
+                        .metaType(HttpMimeType.JSON)
+                        .message(Map.of("id", id, "matchExpression", expr.getMatchExpression()))
+                        .build()
+                        .send();
+                return new IntermediateResponse<MatchedMatchExpression>()
+                        .statusCode(201)
+                        .addHeader(HttpHeaders.LOCATION, String.format("%s/%d", path(), id))
+                        .body(new MatchedMatchExpression(expr));
+            }
+        } catch (RollbackException e) {
+            if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
+                throw new ApiException(400, "Duplicate matchExpression", e);
+            }
+            throw new ApiException(500, e);
+        } catch (MatchExpressionValidationException e) {
+            throw new ApiException(400, e);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
@@ -144,7 +144,7 @@ public class MatchExpressionsPostHandler extends AbstractV2RequestHandler<Matche
         try {
             if (StringUtils.isNotBlank(targets)) {
                 Set<ServiceRef> matched;
-                List<String> parsedTargets = this.expressionManager.parseTargets(targets);
+                List<ServiceRef> parsedTargets = this.expressionManager.parseTargets(targets);
                 matched =
                         this.expressionManager.resolveMatchingTargets(
                                 matchExpression, parsedTargets);

--- a/src/main/java/io/cryostat/rules/MatchExpression.java
+++ b/src/main/java/io/cryostat/rules/MatchExpression.java
@@ -35,16 +35,64 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.security;
 
-public enum ResourceType {
-    TARGET,
-    RECORDING,
-    TEMPLATE,
-    REPORT,
-    MATCH_EXPRESSION,
-    CREDENTIALS,
-    RULE,
-    CERTIFICATE,
-    ;
+package io.cryostat.rules;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class MatchExpression {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(updatable = false)
+    private int id;
+
+    @Column(unique = true, nullable = false)
+    private String matchExpression;
+
+    MatchExpression() {}
+
+    MatchExpression(int id, String matchExpression) {
+        this.id = id;
+        this.matchExpression = matchExpression;
+    }
+
+    MatchExpression(String matchExpression) {
+        this(0, matchExpression);
+    }
+
+    public String getMatchExpression() {
+        return this.matchExpression;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(matchExpression);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MatchExpression other = (MatchExpression) obj;
+        return Objects.equals(matchExpression, other.matchExpression);
+    }
 }

--- a/src/main/java/io/cryostat/rules/MatchExpressionDao.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionDao.java
@@ -35,16 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.cryostat.net.security;
+package io.cryostat.rules;
 
-public enum ResourceType {
-    TARGET,
-    RECORDING,
-    TEMPLATE,
-    REPORT,
-    MATCH_EXPRESSION,
-    CREDENTIALS,
-    RULE,
-    CERTIFICATE,
-    ;
+import javax.persistence.EntityManager;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.storage.AbstractDao;
+
+class MatchExpressionDao extends AbstractDao<Integer, MatchExpression> {
+    MatchExpressionDao(EntityManager em, Logger logger) {
+        super(MatchExpression.class, em, logger);
+    }
 }

--- a/src/main/java/io/cryostat/rules/MatchExpressionManager.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionManager.java
@@ -55,6 +55,8 @@ import io.cryostat.platform.ServiceRef;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import dagger.Lazy;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class MatchExpressionManager {
     private final MatchExpressionValidator matchExpressionValidator;
@@ -184,16 +186,26 @@ public class MatchExpressionManager {
         }
 
         @Override
-        // override equals to allow for comparison of MatchedMatchExpression objects
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
+        public boolean equals(Object other) {
+            if (other == null) {
                 return false;
             }
-            MatchedMatchExpression that = (MatchedMatchExpression) o;
-            return expression.equals(that.expression) && targets.equals(that.targets);
+            if (other == this) {
+                return true;
+            }
+            if (!(other instanceof MatchedMatchExpression)) {
+                return false;
+            }
+            MatchedMatchExpression mme = (MatchedMatchExpression) other;
+            return new EqualsBuilder()
+                    .append(expression, mme.expression)
+                    .append(targets, mme.targets)
+                    .build();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder().append(expression).append(targets).toHashCode();
         }
     }
 }

--- a/src/main/java/io/cryostat/rules/MatchExpressionManager.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionManager.java
@@ -122,15 +122,16 @@ public class MatchExpressionManager {
         return matchedTargets;
     }
 
-    public Set<ServiceRef> resolveMatchingTargets(MatchExpression expr, List<String> targets) {
+    public Set<ServiceRef> resolveMatchingTargets(
+            MatchExpression expr, Collection<ServiceRef> targets) {
         return resolveMatchingTargets(expr.getMatchExpression(), targets);
     }
 
-    public Set<ServiceRef> resolveMatchingTargets(String expr, List<String> targets) {
+    public Set<ServiceRef> resolveMatchingTargets(String expr, Collection<ServiceRef> targets) {
         Set<ServiceRef> matchedTargets = new HashSet<>();
         for (ServiceRef target :
                 platformClient.listDiscoverableServices().stream()
-                        .filter(t -> targets.contains(t.getServiceUri().toString()))
+                        .filter(t -> targets.contains(t))
                         .toList()) {
             try {
                 if (matchExpressionEvaluator.get().applies(expr, target)) {
@@ -144,12 +145,12 @@ public class MatchExpressionManager {
         return matchedTargets;
     }
 
-    public List<String> parseTargets(String targets) throws IllegalArgumentException {
+    public List<ServiceRef> parseTargets(String targets) throws IllegalArgumentException {
         Objects.requireNonNull(targets, "Targets must not be null");
 
         try {
-            Type mapType = new TypeToken<List<String>>() {}.getType();
-            List<String> parsedTargets = gson.fromJson(targets, mapType);
+            Type mapType = new TypeToken<List<ServiceRef>>() {}.getType();
+            List<ServiceRef> parsedTargets = gson.fromJson(targets, mapType);
             if (parsedTargets == null) {
                 throw new IllegalArgumentException(targets);
             }

--- a/src/main/java/io/cryostat/rules/MatchExpressionManager.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionManager.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.rules;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.script.ScriptException;
+
+import io.cryostat.core.log.Logger;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.platform.ServiceRef;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import dagger.Lazy;
+
+public class MatchExpressionManager {
+    private final MatchExpressionValidator matchExpressionValidator;
+    private final Lazy<MatchExpressionEvaluator> matchExpressionEvaluator;
+    private final PlatformClient platformClient;
+    private final MatchExpressionDao dao;
+    private final Gson gson;
+    private final Logger logger;
+
+    MatchExpressionManager(
+            MatchExpressionValidator matchExpressionValidator,
+            Lazy<MatchExpressionEvaluator> matchExpressionEvaluator,
+            PlatformClient platformClient,
+            MatchExpressionDao dao,
+            Gson gson,
+            Logger logger) {
+        this.matchExpressionValidator = matchExpressionValidator;
+        this.matchExpressionEvaluator = matchExpressionEvaluator;
+        this.platformClient = platformClient;
+        this.dao = dao;
+        this.gson = gson;
+        this.logger = logger;
+    }
+
+    public int addMatchExpression(String matchExpression)
+            throws MatchExpressionValidationException {
+        matchExpressionValidator.validate(matchExpression);
+        MatchExpression expression = dao.save(new MatchExpression(matchExpression));
+        return expression.getId();
+    }
+
+    public Optional<MatchExpression> get(int id) {
+        return dao.get(id);
+    }
+
+    public List<MatchExpression> getAll() {
+        return dao.getAll();
+    }
+
+    public boolean delete(int id) {
+        return dao.delete(id);
+    }
+
+    public Set<ServiceRef> resolveMatchingTargets(int id) {
+        Optional<MatchExpression> matchExpression = dao.get(id);
+        if (matchExpression.isEmpty()) {
+            return Set.of();
+        }
+        return resolveMatchingTargets(matchExpression.get().getMatchExpression());
+    }
+
+    public Set<ServiceRef> resolveMatchingTargets(String matchExpression) {
+        Set<ServiceRef> matchedTargets = new HashSet<>();
+        for (ServiceRef target : platformClient.listDiscoverableServices()) {
+            try {
+                if (matchExpressionEvaluator.get().applies(matchExpression, target)) {
+                    matchedTargets.add(target);
+                }
+            } catch (ScriptException e) {
+                logger.error(e);
+                break;
+            }
+        }
+        return matchedTargets;
+    }
+
+    public Set<ServiceRef> resolveMatchingTargets(String matchExpression, List<String> targets) {
+        Set<ServiceRef> matchedTargets = new HashSet<>();
+        for (ServiceRef target :
+                platformClient.listDiscoverableServices().stream()
+                        .filter(t -> targets.contains(t.getServiceUri().toString()))
+                        .toList()) {
+            try {
+                if (matchExpressionEvaluator.get().applies(matchExpression, target)) {
+                    matchedTargets.add(target);
+                }
+            } catch (ScriptException e) {
+                logger.error(e);
+                break;
+            }
+        }
+        return matchedTargets;
+    }
+
+    public List<String> parseTargets(String targets) throws IllegalArgumentException {
+        Objects.requireNonNull(targets, "Targets must not be null");
+
+        try {
+            Type mapType = new TypeToken<List<String>>() {}.getType();
+            List<String> parsedTargets = gson.fromJson(targets, mapType);
+            if (parsedTargets == null) {
+                throw new IllegalArgumentException(targets);
+            }
+            return parsedTargets;
+        } catch (JsonSyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static class MatchedMatchExpression {
+        private final String expression;
+        private final Collection<ServiceRef> targets;
+
+        public MatchedMatchExpression(String expression) {
+            this.expression = expression;
+            this.targets = Collections.emptySet();
+        }
+
+        public MatchedMatchExpression(String expression, Collection<ServiceRef> targets) {
+            this.expression = expression;
+            this.targets = new HashSet<>(targets);
+        }
+
+        public MatchedMatchExpression(MatchExpression expression) {
+            this.expression = expression.getMatchExpression();
+            this.targets = Collections.emptySet();
+        }
+
+        public MatchedMatchExpression(MatchExpression expression, Set<ServiceRef> targets) {
+            this.expression = expression.getMatchExpression();
+            this.targets = new HashSet<>(targets);
+        }
+
+        public String getExpression() {
+            return expression;
+        }
+
+        public Collection<ServiceRef> getTargets() {
+            return Collections.unmodifiableCollection(targets);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/rules/MatchExpressionManager.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionManager.java
@@ -104,14 +104,14 @@ public class MatchExpressionManager {
         if (matchExpression.isEmpty()) {
             return Set.of();
         }
-        return resolveMatchingTargets(matchExpression.get().getMatchExpression());
+        return resolveMatchingTargets(matchExpression.get());
     }
 
-    public Set<ServiceRef> resolveMatchingTargets(String matchExpression) {
+    public Set<ServiceRef> resolveMatchingTargets(MatchExpression expr) {
         Set<ServiceRef> matchedTargets = new HashSet<>();
         for (ServiceRef target : platformClient.listDiscoverableServices()) {
             try {
-                if (matchExpressionEvaluator.get().applies(matchExpression, target)) {
+                if (matchExpressionEvaluator.get().applies(expr.getMatchExpression(), target)) {
                     matchedTargets.add(target);
                 }
             } catch (ScriptException e) {
@@ -122,14 +122,18 @@ public class MatchExpressionManager {
         return matchedTargets;
     }
 
-    public Set<ServiceRef> resolveMatchingTargets(String matchExpression, List<String> targets) {
+    public Set<ServiceRef> resolveMatchingTargets(MatchExpression expr, List<String> targets) {
+        return resolveMatchingTargets(expr.getMatchExpression(), targets);
+    }
+
+    public Set<ServiceRef> resolveMatchingTargets(String expr, List<String> targets) {
         Set<ServiceRef> matchedTargets = new HashSet<>();
         for (ServiceRef target :
                 platformClient.listDiscoverableServices().stream()
                         .filter(t -> targets.contains(t.getServiceUri().toString()))
                         .toList()) {
             try {
-                if (matchExpressionEvaluator.get().applies(matchExpression, target)) {
+                if (matchExpressionEvaluator.get().applies(expr, target)) {
                     matchedTargets.add(target);
                 }
             } catch (ScriptException e) {

--- a/src/main/java/io/cryostat/rules/MatchExpressionManager.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionManager.java
@@ -53,7 +53,6 @@ import io.cryostat.platform.PlatformClient;
 import io.cryostat.platform.ServiceRef;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import dagger.Lazy;
 
@@ -145,19 +144,11 @@ public class MatchExpressionManager {
         return matchedTargets;
     }
 
-    public List<ServiceRef> parseTargets(String targets) throws IllegalArgumentException {
+    public List<ServiceRef> parseTargets(String targets) {
         Objects.requireNonNull(targets, "Targets must not be null");
-
-        try {
-            Type mapType = new TypeToken<List<ServiceRef>>() {}.getType();
-            List<ServiceRef> parsedTargets = gson.fromJson(targets, mapType);
-            if (parsedTargets == null) {
-                throw new IllegalArgumentException(targets);
-            }
-            return parsedTargets;
-        } catch (JsonSyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Type mapType = new TypeToken<List<ServiceRef>>() {}.getType();
+        List<ServiceRef> parsedTargets = gson.fromJson(targets, mapType);
+        return parsedTargets;
     }
 
     public static class MatchedMatchExpression {
@@ -190,6 +181,19 @@ public class MatchExpressionManager {
 
         public Collection<ServiceRef> getTargets() {
             return Collections.unmodifiableCollection(targets);
+        }
+
+        @Override
+        // override equals to allow for comparison of MatchedMatchExpression objects
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MatchedMatchExpression that = (MatchedMatchExpression) o;
+            return expression.equals(that.expression) && targets.equals(that.targets);
         }
     }
 }

--- a/src/main/java/io/cryostat/rules/RulesModule.java
+++ b/src/main/java/io/cryostat/rules/RulesModule.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.persistence.EntityManager;
 import javax.script.ScriptEngine;
 
 import io.cryostat.configuration.ConfigurationModule;
@@ -95,6 +96,25 @@ public abstract class RulesModule {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Provides
+    @Singleton
+    static MatchExpressionDao provideMatchExpressionDao(EntityManager em, Logger logger) {
+        return new MatchExpressionDao(em, logger);
+    }
+
+    @Provides
+    @Singleton
+    static MatchExpressionManager provideMatchExpressionManager(
+            MatchExpressionValidator matchExpressionValidator,
+            Lazy<MatchExpressionEvaluator> matchExpressionEvaluator,
+            DiscoveryStorage discovery,
+            MatchExpressionDao dao,
+            Gson gson,
+            Logger logger) {
+        return new MatchExpressionManager(
+                matchExpressionValidator, matchExpressionEvaluator, discovery, dao, gson, logger);
     }
 
     @Provides

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,7 @@
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <class>io.cryostat.discovery.PluginInfo</class>
     <class>io.cryostat.configuration.StoredCredentials</class>
+    <class>io.cryostat.rules.MatchExpression</class>
     <exclude-unlisted-classes>false</exclude-unlisted-classes>
 </persistence-unit>
 </persistence>

--- a/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionDeleteHandlerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.messaging.notifications.Notification;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchExpressionDeleteHandlerTest {
+    MatchExpressionDeleteHandler handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock MatchExpressionManager expressionManager;
+    @Mock NotificationFactory notificationFactory;
+    @Mock Notification.Builder notificationBuilder;
+    @Mock Notification notification;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient().when(notificationFactory.createBuilder()).thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.meta(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaCategory(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(Notification.MetaType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(HttpMimeType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.message(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
+        this.handler =
+                new MatchExpressionDeleteHandler(
+                        auth, credentialsManager, expressionManager, notificationFactory, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBeDELETEHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.DELETE));
+        }
+
+        @Test
+        void shouldBeAPIBeta() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.BETA));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/beta/matchExpressions/:id"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.DELETE_MATCH_EXPRESSION)));
+        }
+
+        @Test
+        void shouldProduceJson() {
+            MatcherAssert.assertThat(
+                    handler.produces(), Matchers.equalTo(List.of(HttpMimeType.JSON)));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldDelegateToMatchExpressionManager() throws Exception {
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", "10"));
+            MatchExpression expr = Mockito.mock(MatchExpression.class);
+            Mockito.when(expr.getMatchExpression()).thenReturn("target.alias == \"foo\"");
+            Mockito.when(expressionManager.get(Mockito.eq(10))).thenReturn(Optional.of(expr));
+            Mockito.when(expressionManager.delete(Mockito.eq(10))).thenReturn(true);
+
+            IntermediateResponse<Void> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+            Mockito.verify(expressionManager).delete(10);
+        }
+
+        @Test
+        void shouldRespond404IfIdUnknown() throws Exception {
+            Mockito.when(expressionManager.get(Mockito.anyInt())).thenReturn(Optional.empty());
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", "10"));
+
+            IntermediateResponse<?> resp = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(resp.getStatusCode(), Matchers.equalTo(404));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionGetHandlerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchExpressionGetHandlerTest {
+    MatchExpressionGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock MatchExpressionManager expressionManager;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new MatchExpressionGetHandler(auth, credentialsManager, expressionManager, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBeGETHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+        }
+
+        @Test
+        void shouldBeAPIBeta() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.BETA));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/beta/matchExpressions/:id"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.READ_MATCH_EXPRESSION)));
+        }
+
+        @Test
+        void shouldProduceJson() {
+            MatcherAssert.assertThat(
+                    handler.produces(), Matchers.equalTo(List.of(HttpMimeType.JSON)));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldDelegateToMatchExpressionManager() throws Exception {
+            String matchExpression = "target.alias == \"foo\"";
+            ServiceRef serviceRef =
+                    new ServiceRef(
+                            "id",
+                            URI.create("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                            "foo");
+            MatchExpression expr = Mockito.mock(MatchExpression.class);
+            Mockito.when(expr.getMatchExpression()).thenReturn(matchExpression);
+            MultiMap queryMap = MultiMap.caseInsensitiveMultiMap();
+            queryMap.add("matches", "true");
+            Mockito.when(requestParams.getQueryParams()).thenReturn(queryMap);
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", "10"));
+            Mockito.when(expressionManager.get(10)).thenReturn(Optional.of(expr));
+            Set<ServiceRef> targets = Set.of(serviceRef);
+            Mockito.when(expressionManager.resolveMatchingTargets(expr)).thenReturn(targets);
+
+            IntermediateResponse<MatchedMatchExpression> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(
+                    response.getBody(),
+                    Matchers.equalTo(new MatchedMatchExpression(expr, targets)));
+
+            Mockito.verify(expressionManager).get(10);
+            Mockito.verify(expressionManager).resolveMatchingTargets(expr);
+        }
+
+        @Test
+        void shouldRespond404IfIdUnknown() throws Exception {
+            Mockito.when(expressionManager.get(Mockito.anyInt())).thenReturn(Optional.empty());
+            MultiMap queryMap = MultiMap.caseInsensitiveMultiMap();
+            Mockito.when(requestParams.getQueryParams()).thenReturn(queryMap);
+            Mockito.when(requestParams.getPathParams()).thenReturn(Map.of("id", "10"));
+
+            IntermediateResponse<?> resp = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(resp.getStatusCode(), Matchers.equalTo(404));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsGetHandlerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.List;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchExpressionsGetHandlerTest {
+    MatchExpressionsGetHandler handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock MatchExpressionManager expressionManager;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler =
+                new MatchExpressionsGetHandler(auth, credentialsManager, expressionManager, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBeGETHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.GET));
+        }
+
+        @Test
+        void shouldBeAPIBeta() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.BETA));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/beta/matchExpressions"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.READ_MATCH_EXPRESSION)));
+        }
+
+        @Test
+        void shouldProduceJson() {
+            MatcherAssert.assertThat(
+                    handler.produces(), Matchers.equalTo(List.of(HttpMimeType.JSON)));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldDelegateToMatchExpressionManager() throws Exception {
+            MatchExpression expr1 = Mockito.mock(MatchExpression.class);
+            MatchExpression expr2 = Mockito.mock(MatchExpression.class);
+            Mockito.when(expressionManager.getAll()).thenReturn(List.of(expr1, expr2));
+
+            IntermediateResponse<List<MatchExpression>> response = handler.handle(requestParams);
+
+            List<MatchExpression> actual = response.getBody();
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(
+                    actual,
+                    Matchers.containsInAnyOrder(Matchers.equalTo(expr1), Matchers.equalTo(expr2)));
+            MatcherAssert.assertThat(actual, Matchers.hasSize(2));
+
+            Mockito.verify(expressionManager).getAll();
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandlerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.messaging.notifications.Notification;
+import io.cryostat.messaging.notifications.NotificationFactory;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+import io.cryostat.platform.ServiceRef;
+import io.cryostat.rules.MatchExpression;
+import io.cryostat.rules.MatchExpressionManager;
+import io.cryostat.rules.MatchExpressionManager.MatchedMatchExpression;
+import io.cryostat.rules.MatchExpressionValidationException;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchExpressionsPostHandlerTest {
+    MatchExpressionsPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock MatchExpressionManager expressionManager;
+    @Mock NotificationFactory notificationFactory;
+    @Mock Notification.Builder notificationBuilder;
+    @Mock Notification notification;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient().when(notificationFactory.createBuilder()).thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.meta(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaCategory(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(Notification.MetaType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.metaType(Mockito.any(HttpMimeType.class)))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient()
+                .when(notificationBuilder.message(Mockito.any()))
+                .thenReturn(notificationBuilder);
+        Mockito.lenient().when(notificationBuilder.build()).thenReturn(notification);
+        this.handler =
+                new MatchExpressionsPostHandler(
+                        auth, credentialsManager, expressionManager, notificationFactory, gson);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+        }
+
+        @Test
+        void shouldBeAPIBeta() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.BETA));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/beta/matchExpressions"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.CREATE_MATCH_EXPRESSION)));
+        }
+
+        @Test
+        void shouldProduceJson() {
+            MatcherAssert.assertThat(
+                    handler.produces(), Matchers.equalTo(List.of(HttpMimeType.JSON)));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+
+        @Mock RequestParameters requestParams;
+
+        @Test
+        void shouldDelegateToMatchExpressionManager() throws Exception {
+            Optional<MatchExpression> opt = Mockito.mock(Optional.class);
+            MatchExpression expr = Mockito.mock(MatchExpression.class);
+            int id = 10;
+            String matchExpression = "target.alias == \"foo\"";
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("matchExpression", matchExpression);
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+            Mockito.when(expressionManager.addMatchExpression(Mockito.anyString())).thenReturn(id);
+            Mockito.when(expressionManager.get(id)).thenReturn(opt);
+            Mockito.when(opt.get()).thenReturn(expr);
+            Mockito.when(expr.getMatchExpression()).thenReturn(matchExpression);
+
+            IntermediateResponse<MatchedMatchExpression> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(201));
+            Map<CharSequence, CharSequence> headers = response.getHeaders();
+            MatcherAssert.assertThat(headers, Matchers.aMapWithSize(1));
+            MatcherAssert.assertThat(
+                    headers.get(HttpHeaders.LOCATION),
+                    Matchers.equalTo("/api/beta/matchExpressions/" + id));
+
+            Mockito.verify(expressionManager).addMatchExpression(matchExpression);
+        }
+
+        @Test
+        void shouldDryRunWithMatchedTargets() throws Exception {
+            int id = 10;
+            String matchExpression = "target.alias == \"foo\"";
+            String stringifiedTargets =
+                    "[{\"alias\":\"foo\",\"connectUrl\":\"service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi\"}]";
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("matchExpression", matchExpression);
+            form.set("targets", stringifiedTargets);
+            ServiceRef target = Mockito.mock(ServiceRef.class);
+            List<ServiceRef> targets = List.of(target);
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+            Mockito.when(expressionManager.parseTargets(stringifiedTargets)).thenReturn(targets);
+            Mockito.when(expressionManager.resolveMatchingTargets(matchExpression, targets))
+                    .thenReturn(Set.of(target));
+
+            IntermediateResponse<MatchedMatchExpression> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatchedMatchExpression body = response.getBody();
+            MatchedMatchExpression expected =
+                    new MatchedMatchExpression(matchExpression, Set.of(target));
+            MatcherAssert.assertThat(body, Matchers.equalTo(expected));
+
+            Mockito.verify(expressionManager, Mockito.never())
+                    .addMatchExpression(Mockito.anyString());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"invalid", "==", "", " "})
+        void shouldRespond400IfMatchExpressionInvalid(String matchExpression) throws Exception {
+            MultiMap form = MultiMap.caseInsensitiveMultiMap();
+            form.set("matchExpression", matchExpression);
+            Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
+            Mockito.lenient()
+                    .when(expressionManager.addMatchExpression(Mockito.anyString()))
+                    .thenThrow(MatchExpressionValidationException.class);
+
+            ApiException ex =
+                    Assertions.assertThrows(
+                            ApiException.class, () -> handler.handle(requestParams));
+
+            MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
+        }
+    }
+}

--- a/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandlerTest.java
@@ -192,10 +192,11 @@ class MatchExpressionsPostHandlerTest {
             form.set("matchExpression", matchExpression);
             form.set("targets", stringifiedTargets);
             ServiceRef target = Mockito.mock(ServiceRef.class);
-            List<ServiceRef> targets = List.of(target);
+
             Mockito.when(requestParams.getFormAttributes()).thenReturn(form);
-            Mockito.when(expressionManager.parseTargets(stringifiedTargets)).thenReturn(targets);
-            Mockito.when(expressionManager.resolveMatchingTargets(matchExpression, targets))
+            Mockito.when(
+                            expressionManager.resolveMatchingTargets(
+                                    Mockito.anyString(), Mockito.any()))
                     .thenReturn(Set.of(target));
 
             IntermediateResponse<MatchedMatchExpression> response = handler.handle(requestParams);

--- a/src/test/java/io/cryostat/rules/MatchExpressionManagerTest.java
+++ b/src/test/java/io/cryostat/rules/MatchExpressionManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.rules;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.platform.PlatformClient;
+import io.cryostat.platform.ServiceRef;
+
+import com.google.gson.Gson;
+import org.apache.commons.codec.binary.Base32;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchExpressionManagerTest {
+
+    MatchExpressionManager expressionManager;
+    @Mock Path credentialsDir;
+    @Mock MatchExpressionValidator matchExpressionValidator;
+    @Mock MatchExpressionEvaluator matchExpressionEvaluator;
+    @Mock PlatformClient platformClient;
+    @Mock MatchExpressionDao dao;
+    @Mock Logger logger;
+    Gson gson = MainModule.provideGson(logger);
+    Base32 base32 = new Base32();
+
+    @BeforeEach
+    void setup() {
+        this.expressionManager =
+                new MatchExpressionManager(
+                        matchExpressionValidator,
+                        () -> matchExpressionEvaluator,
+                        platformClient,
+                        dao,
+                        gson,
+                        logger);
+    }
+
+    @Test
+    void canAddThenGetThenRemove() throws Exception {
+        String targetId = "foo";
+        String matchExpression = String.format("target.connectUrl == \"%s\"", targetId);
+
+        MatchExpression stored = new MatchExpression(10, matchExpression);
+
+        Mockito.when(dao.save(Mockito.any())).thenReturn(stored);
+
+        expressionManager.addMatchExpression(matchExpression);
+
+        Mockito.verify(dao).save(Mockito.any());
+
+        Mockito.when(dao.get(10)).thenReturn(Optional.of(stored));
+        Optional<MatchExpression> found = expressionManager.get(10);
+
+        MatcherAssert.assertThat(found.get(), Matchers.equalTo(stored));
+
+        Mockito.when(dao.delete(10)).thenReturn(true);
+        boolean removed = expressionManager.delete(10);
+
+        Assertions.assertTrue(removed);
+    }
+
+    @Test
+    void throwMatchExpressionExceptionOnInvalidExpression() throws Exception {
+        String matchExpression = "invalid expression";
+
+        Mockito.when(matchExpressionValidator.validate(matchExpression))
+                .thenThrow(MatchExpressionValidationException.class);
+
+        Assertions.assertThrows(
+                MatchExpressionValidationException.class,
+                () -> expressionManager.addMatchExpression(matchExpression));
+    }
+
+    @Test
+    void canResolveMatchExpressions() throws Exception {
+        String matchExpression = "some expression";
+        MatchExpression stored = new MatchExpression(7, matchExpression);
+
+        ServiceRef serviceRef =
+                new ServiceRef(
+                        "id",
+                        URI.create("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi"),
+                        "mytarget");
+
+        Mockito.when(platformClient.listDiscoverableServices()).thenReturn(List.of(serviceRef));
+        Mockito.when(matchExpressionEvaluator.applies(matchExpression, serviceRef))
+                .thenReturn(true);
+
+        Set<ServiceRef> expected = Set.of(serviceRef);
+
+        Mockito.when(dao.get(Mockito.anyInt())).thenReturn(Optional.of(stored));
+
+        MatcherAssert.assertThat(
+                expressionManager.resolveMatchingTargets(7), Matchers.equalTo(expected));
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat/issues/1386

## Description of the change:
This change adds MatchExpressions as a top level resource to Cryostat. We can use these to query matched targets that are associated with a MatchExpression. This change adds handlers that help with associating targets with rules and targets with credentials and vice versa. 

The endpoints are 

GET /api/beta/matchExpressions (getAll stored MatchExpressions)
GET /""/matchExpression/:id (get stored MatchExpression using id)
POST /""/matchExpressions (add MatchExpression) (with form parameters `matchExpression` and `targets`)
DELETE /""/matchExpressons/:id (delete MatchExpression using id)

#### The POST works like this:
**the `matchExpression` is required**
**the `targets` is optional and if it is a valid array of strings**
- *we do not add the `matchExpression` to the database (simulating a dryrun)*
 - *and we return all the service refs that match the any targetIds in the `targets` string array*

## Motivation for the change:
See https://github.com/cryostatio/cryostat/issues/1386

## How to manually test:
1. Run a smoketest setup.
2. Try these different queries:

**addExpression**
```bash 
https --auth=user:pass -f POST :8181/api/beta/matchExpressions matchExpression="target.alias == 'es.andrewazor.demo.Main'"
```
**getExpression**
```bash
https --auth=user:pass :8181/api/beta/matchExpressions/1?matches=true
```
**getAllExpressions**
```bash
https --auth=user:pass :8181/api/beta/matchExpressions
```
**dryrun getting matchedExpressions** *(also try it without a matching target)*
```bash
https --verify=no --auth=user:pass -f POST :8181/api/beta/matchExpressions matchExpression="target.alias == 'es.andrewazor.demo.Main'" targets="[{\"alias\":\"es.andrewazor.demo.Main\",\"annotations\":{\"cryostat\":{\"HOST\":\"cryostat\",\"JAVA_MAIN\":\"es.andrewazor.demo.Main\",\"PORT\":\"9094\",\"REALM\":\"JDP\"},\"platform\":{}},\"connectUrl\":\"service:jmx:rmi:\/\/\/jndi\/rmi:\/\/cryostat:9094\/jmxrmi\",\"jvmId\":null,\"labels\":{}}]"
```
**deleteExpression**
```bash
https --auth=user:pass DELETE :8181/api/beta/matchExpressions/1
```