### PR TITLE
fix(matchexpr): include jvmId in js binding

### DIFF
--- a/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
@@ -162,21 +162,19 @@ public class MatchExpressionEvaluator {
                     serviceRef.getCryostatAnnotations().entrySet()) {
                 cryostatAnnotations.put(entry.getKey().name(), entry.getValue());
             }
-            bindings.put(
-                    "target",
+            Map<String, Object> target = new HashMap<>();
+            target.put("connectUrl", serviceRef.getServiceUri().toString());
+            target.put("jvmId", serviceRef.getJvmId());
+            target.put("alias", serviceRef.getAlias().orElse(null));
+            target.put("labels", serviceRef.getLabels());
+            target.put(
+                    "annotations",
                     Map.of(
-                            "connectUrl",
-                            serviceRef.getServiceUri(),
-                            "alias",
-                            serviceRef.getAlias().orElse(null),
-                            "labels",
-                            serviceRef.getLabels(),
-                            "annotations",
-                            Map.of(
-                                    "platform",
-                                    serviceRef.getPlatformAnnotations(),
-                                    "cryostat",
-                                    cryostatAnnotations)));
+                            "platform",
+                            serviceRef.getPlatformAnnotations(),
+                            "cryostat",
+                            cryostatAnnotations));
+            bindings.put("target", target);
             return bindings;
         } finally {
             evt.end();

--- a/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
+++ b/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
@@ -142,6 +142,13 @@ class MatchExpressionEvaluatorTest {
         }
 
         @Test
+        void targetShouldHaveJvmIdAsString() {
+            String jvmId = (String) (((Map<String, Object>) bindings.get("target")).get("jvmId"));
+            MatcherAssert.assertThat(
+                    jvmId, Matchers.equalTo(MatchExpressionEvaluatorTest.this.jvmId));
+        }
+
+        @Test
         void targetShouldHaveLabels() {
             Map<String, String> labels =
                     (Map<String, String>)
@@ -208,6 +215,19 @@ class MatchExpressionEvaluatorTest {
             String expr =
                     String.format("target.alias == '%s'", MatchExpressionEvaluatorTest.this.alias);
             Assertions.assertTrue(ruleMatcher.applies(expr, serviceRef));
+        }
+
+        @Test
+        void shouldMatchOnJvmId() throws Exception {
+            String expr =
+                    String.format("target.jvmId == '%s'", MatchExpressionEvaluatorTest.this.jvmId);
+            Assertions.assertTrue(ruleMatcher.applies(expr, serviceRef));
+        }
+
+        @Test
+        void shouldNotMatchOnWrongJvmId() throws Exception {
+            String expr = "target.jvmId == \"hello-world\"";
+            Assertions.assertFalse(ruleMatcher.applies(expr, serviceRef));
         }
 
         @ParameterizedTest

--- a/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
+++ b/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
@@ -76,6 +76,7 @@ class MatchExpressionEvaluatorTest {
     @Mock RuleRegistry rules;
 
     URI serviceUri;
+    String jvmId;
     String alias;
     Map<String, String> labels;
     Map<String, String> platformAnnotations;
@@ -88,12 +89,14 @@ class MatchExpressionEvaluatorTest {
                         MainModule.provideScriptEngine(), credentials, rules, logger);
 
         this.serviceUri = new URI("service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi");
+        this.jvmId = "-some1234HashId=";
         this.alias = "someAlias";
         this.labels = Map.of("label1", "someLabel");
         this.platformAnnotations = Map.of("annotation1", "someAnnotation");
         this.cryostatAnnotations = Map.of(AnnotationKey.JAVA_MAIN, "io.cryostat.Cryostat");
 
         Mockito.when(serviceRef.getServiceUri()).thenReturn(this.serviceUri);
+        Mockito.when(serviceRef.getJvmId()).thenReturn(this.jvmId);
         Mockito.when(serviceRef.getAlias()).thenReturn(Optional.of(this.alias));
         Mockito.when(serviceRef.getLabels()).thenReturn(this.labels);
         Mockito.when(serviceRef.getPlatformAnnotations()).thenReturn(this.platformAnnotations);
@@ -119,14 +122,16 @@ class MatchExpressionEvaluatorTest {
         void targetShouldHaveExpectedKeys() {
             Set<String> keys = ((Map<String, Object>) bindings.get("target")).keySet();
             MatcherAssert.assertThat(
-                    keys, Matchers.equalTo(Set.of("connectUrl", "alias", "labels", "annotations")));
+                    keys,
+                    Matchers.equalTo(
+                            Set.of("connectUrl", "jvmId", "alias", "labels", "annotations")));
         }
 
         @Test
         void targetShouldHaveServiceUriAsUri() {
-            URI uri = (URI) ((Map<String, Object>) bindings.get("target")).get("connectUrl");
+            String uri = (String) ((Map<String, Object>) bindings.get("target")).get("connectUrl");
             MatcherAssert.assertThat(
-                    uri, Matchers.equalTo(MatchExpressionEvaluatorTest.this.serviceUri));
+                    uri, Matchers.equalTo(MatchExpressionEvaluatorTest.this.serviceUri.toString()));
         }
 
         @Test

--- a/src/test/java/io/cryostat/rules/MatchExpressionValidatorTest.java
+++ b/src/test/java/io/cryostat/rules/MatchExpressionValidatorTest.java
@@ -68,6 +68,8 @@ class MatchExpressionValidatorTest {
                 "target.alias == 'io.cryostat.Cryostat' || target.annotations.cryostat.JAVA_MAIN =="
                         + " 'io.cryostat.Cryostat'",
                 "target.connectUrl != '' && target.labels.SOMETHING == 'other'",
+                "taret.jvmId == \"abcd1234\"",
+                "taret.jvmId != \"hello world\"",
                 "/^[a-z]+$/.test(target.alias)",
                 "/^[a-z]+$/.test(target.noSuchProperty)",
                 "/^[a-z]+$/.test([].length)",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1377
Related to #1389

## Description of the change:
This copies the `jvmId` field from the `ServiceRef` object representing a target application into the object binding passed into the JS engine when evaluating a match expression.

## Motivation for the change:
Without this, the `jvmId` property tested in the `matchExpression` will always be an undefined value, leading to expressions that do not properly test and evaluate against the intended targets. In #1377 Cryostat is still able to use the credentials to authenticate to -agents because the lookup is direct by stored credential ID rather than evaluating the associated expression, but this bug does actually manifest in the web-client since it is visible on the `/security` view that the agents' stored credentials display as matching against 0 targets.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Open web-client and go to `/security`
3. Observe that the two -agent instances' stored credentials should report 1 match each, and expanding the rows should show that each match is for the expected agent target.
