### PR TITLE
fix(graphql): use boolean parameter for StartRecordingMutator `restart`

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -138,8 +138,7 @@ class StartRecordingOnTargetMutator
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
                     if (settings.containsKey("restart")) {
-                        Boolean v = (Boolean) settings.get("restart");
-                        restart = v != null && v;
+                        restart = Boolean.TRUE.equals(settings.get("restart"));
                     }
                     if (settings.containsKey("duration")) {
                         builder =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -138,7 +138,8 @@ class StartRecordingOnTargetMutator
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
                     if (settings.containsKey("restart")) {
-                        restart = Boolean.parseBoolean((String) settings.get("restart"));
+                        Boolean v = (Boolean) settings.get("restart");
+                        restart = v != null && v;
                     }
                     if (settings.containsKey("duration")) {
                         builder =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1403 

## Description of the change:
Allows restart to be specified by a boolean parameter.

## How to manually test:
Try a query like:
```
// will fail
query($episode: String! = "ASD") { 
    targetNodes(filter: { annotations: "PORT == 9093" }) {
        doStartRecording(recording: { 
            name: "graph-itest", 
            duration: 30,
            template: "Profiling", 
            templateType: "TARGET", 
            metadata: {
                labels: {
                    cryostatiotopologygroup: $episode,
                } 
            },
            restart: "true",
        })
        { 
            name state duration 
        }
    } 
}
```
vs

```
// correct
query($episode: String! = "ASD") { 
    targetNodes(filter: { annotations: "PORT == 9093" }) {
        doStartRecording(recording: { 
            name: "graph-itest", 
            duration: 30,
            template: "Profiling", 
            templateType: "TARGET", 
            metadata: {
                labels: {
                    cryostatiotopologygroup: $episode,
                } 
            },
            restart: true,
        })
        { 
            name state duration 
        }
    } 
}
```