### PR TITLE
fix(custom-targets): fix adding jmx-auth custom targets 

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -203,6 +203,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                     credentialsManager.setSessionCredentials(uri.toString(), credentials.get());
                 }
             }
+
             String jvmId = jvmIdHelper.getJvmId(uri.toString(), false, credentials);
             ServiceRef serviceRef = new ServiceRef(jvmId, uri, alias);
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -195,9 +195,7 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                         .build()
                         .send();
             }
-
-            String jvmId = jvmIdHelper.getJvmId(uri.toString(), !dryRun, credentials);
-            ServiceRef serviceRef = new ServiceRef(jvmId, uri, alias);
+            ServiceRef serviceRef = new ServiceRef(null, uri, alias);
 
             Map<AnnotationKey, String> cryostatAnnotations = new HashMap<>();
             for (AnnotationKey ak : AnnotationKey.values()) {
@@ -211,14 +209,16 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             cryostatAnnotations.put(AnnotationKey.REALM, CustomTargetPlatformClient.REALM);
             serviceRef.setCryostatAnnotations(cryostatAnnotations);
 
+            ServiceRef resolved = jvmIdHelper.resolveId(serviceRef);
+
             if (!dryRun) {
-                boolean v = customTargetPlatformClient.addTarget(serviceRef);
+                boolean v = customTargetPlatformClient.addTarget(resolved);
                 if (!v) {
                     throw new ApiException(400, "Duplicate connectUrl");
                 }
             } else {
-                if (storage.contains(serviceRef)) {
-                    return new IntermediateResponse<ServiceRef>().statusCode(202).body(serviceRef);
+                if (storage.contains(resolved)) {
+                    return new IntermediateResponse<ServiceRef>().statusCode(202).body(resolved);
                 }
             }
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -68,6 +68,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -79,6 +80,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.nashorn.internal.runtime.ParserException;
 
+@Disabled("Disabled temporarily")
 @ExtendWith(MockitoExtension.class)
 class TargetsPostHandlerTest {
 

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetsPostHandlerTest.java
@@ -68,7 +68,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -80,7 +79,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openjdk.nashorn.internal.runtime.ParserException;
 
-@Disabled("Disabled temporarily")
 @ExtendWith(MockitoExtension.class)
 class TargetsPostHandlerTest {
 
@@ -206,9 +204,10 @@ class TargetsPostHandlerTest {
     @Test
     void testSuccessfulRequestWithCredentials() throws Exception {
         MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        MultiMap queries = MultiMap.caseInsensitiveMultiMap();
         RequestParameters params = Mockito.mock(RequestParameters.class);
         Mockito.when(params.getFormAttributes()).thenReturn(attrs);
-        Mockito.when(params.getQueryParams()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        Mockito.when(params.getQueryParams()).thenReturn(queries);
         Mockito.when(
                         credentialsManager.addCredentials(
                                 Mockito.anyString(), Mockito.any(Credentials.class)))
@@ -231,6 +230,8 @@ class TargetsPostHandlerTest {
         attrs.set("alias", alias);
         attrs.set("username", username);
         attrs.set("password", password);
+
+        queries.set("storeCredentials", String.valueOf(true));
 
         IntermediateResponse<ServiceRef> response = handler.handle(params);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
@@ -477,6 +478,49 @@ class TargetsPostHandlerTest {
         IntermediateResponse<ServiceRef> response = handler.handle(params);
         MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(202));
 
+        Mockito.verify(credentialsManager).setSessionCredentials(Mockito.any(), Mockito.any());
+
+        ServiceRef respRef = response.getBody();
+        MatcherAssert.assertThat(respRef.getServiceUri(), Matchers.equalTo(new URI(connectUrl)));
+        MatcherAssert.assertThat(respRef.getAlias(), Matchers.equalTo(Optional.of(alias)));
+        MatcherAssert.assertThat(respRef.getPlatformAnnotations(), Matchers.equalTo(Map.of()));
+        MatcherAssert.assertThat(
+                respRef.getCryostatAnnotations(),
+                Matchers.equalTo(Map.of(AnnotationKey.REALM, "Custom Targets")));
+    }
+
+    @Test
+    void testRequestWithStoreCredentialsQuery() throws Exception {
+        MultiMap attrs = MultiMap.caseInsensitiveMultiMap();
+        MultiMap queries = MultiMap.caseInsensitiveMultiMap();
+        RequestParameters params = Mockito.mock(RequestParameters.class);
+        Mockito.when(params.getFormAttributes()).thenReturn(attrs);
+        Mockito.when(params.getQueryParams()).thenReturn(queries);
+        Mockito.when(storage.listDiscoverableServices()).thenReturn(List.of());
+        Mockito.when(customTargetPlatformClient.addTarget(Mockito.any())).thenReturn(true);
+        Mockito.when(
+                        jvmIdHelper.getJvmId(
+                                Mockito.anyString(),
+                                Mockito.anyBoolean(),
+                                Mockito.any(Optional.class)))
+                .thenReturn("id");
+
+        String connectUrl = "service:jmx:rmi:///jndi/rmi://cryostat:9099/jmxrmi";
+        String alias = "TestTarget";
+        String username = "username";
+        String password = "password";
+
+        attrs.set("connectUrl", connectUrl);
+        attrs.set("alias", alias);
+        attrs.set("username", username);
+        attrs.set("password", password);
+
+        queries.set("storeCredentials", "true");
+
+        IntermediateResponse<ServiceRef> response = handler.handle(params);
+        MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+
+        Mockito.verify(credentialsManager).addCredentials(Mockito.any(), Mockito.any());
         ServiceRef respRef = response.getBody();
         MatcherAssert.assertThat(respRef.getServiceUri(), Matchers.equalTo(new URI(connectUrl)));
         MatcherAssert.assertThat(respRef.getAlias(), Matchers.equalTo(Optional.of(alias)));
@@ -538,6 +582,8 @@ class TargetsPostHandlerTest {
         attrs.set("alias", alias);
         attrs.set("username", username);
         attrs.set("password", password);
+
+        queries.set("storeCredentials", String.valueOf(true));
 
         Exception cause = new ParserException("Parse failed");
         Exception matchExpressionValidationException =

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -226,7 +226,7 @@ public class CustomTargetsIT extends StandardSelfTest {
 
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
-                .post("/api/v2/targets")
+                .post("/api/v2/targets?storeCredentials=true")
                 .sendForm(
                         form,
                         ar -> {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1404 

## Description of the change:
This change allows the Custom Target creation post handler to use credentials in the dao directly (also check session credentials if any). This is because before, the handler would query existing targets in the database and find and use any credentials that match a target using the credentials match expression. 

Tests not fixed yet just to confirm that this implementation is what is needed for the web-client to use. 

## How to manually test:
1. Run the pr.
2. Create a credential with a match expression that matches a custom target that you want to add (e.g. `target.connectUrl == "service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi"`)
3. Go to topology view to add custom target.
4. Use the connectUrl (e.g. `service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi`), test the connection, and add the target and notice that it passes.
5. Try with no existing credentials and see that the creation fails.
