### PR TITLE
fix(graphql): use array format as label input

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -38,6 +38,8 @@
 package io.cryostat.net.web.http.api.v2.graph;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +59,7 @@ import io.cryostat.net.ConnectionDescriptor;
 import io.cryostat.net.TargetConnectionManager;
 import io.cryostat.net.security.ResourceAction;
 import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.v2.graph.PutActiveRecordingMetadataMutator.InputRecordingLabel;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.discovery.TargetNode;
 import io.cryostat.recordings.RecordingMetadataManager;
@@ -161,11 +164,21 @@ class StartRecordingOnTargetMutator
                     }
                     Metadata m = new Metadata();
                     if (settings.containsKey("metadata")) {
-                        m =
-                                (Metadata)
-                                        gson.fromJson(
-                                                settings.get("metadata").toString(),
-                                                new TypeToken<Metadata>() {}.getType());
+                        Map<String, Object> _metadata =
+                                gson.fromJson(
+                                        settings.get("metadata").toString(),
+                                        new TypeToken<Map<String, Object>>() {}.getType());
+
+                        Map<String, String> labels = new HashMap<>();
+                        List<InputRecordingLabel> inputLabels =
+                                gson.fromJson(
+                                        _metadata.get("labels").toString(),
+                                        new TypeToken<List<InputRecordingLabel>>() {}.getType());
+
+                        for (InputRecordingLabel l : inputLabels) {
+                            labels.put(l.getKey(), l.getValue());
+                        }
+                        m = new Metadata(labels);
                     }
                     IRecordingDescriptor desc =
                             recordingTargetHelper.startRecording(

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -278,10 +278,10 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
-                        + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
-                        + " metadata: { labels: { newLabel: someValue } }  }) { name state duration"
-                        + " archiveOnStop }} }");
+                    + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
+                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
+                    + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
+                    + " name state duration archiveOnStop }} }");
         Map<String, String> expectedLabels =
                 Map.of(
                         "template.name",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1407 

## Description of the change:

Use array format for label input similar to metadata mutator.

## Motivation for the change:

See #1407 


## How to test

Try this query:

```graphql
query StartRecordingForGroup() {
  environmentNodes(filter: { name: "JDP" }) {
    descendantTargets {
      doStartRecording(recording: {
        name: "foo",
        template: "Continuous",
        templateType: "TARGET",
        duration: 0,
        restart: true,
        metadata: {
          labels: [
            {
              key: "cryostat.io.topology-group",
              value: "JDP"
            }
          ]
        },
        }) {
            name
            state
      }
    }
  }
}
```
