### PR TITLE
feat(discovery): add int id property to nodes

### DIFF
--- a/src/main/java/io/cryostat/discovery/AbstractNodeTypeAdapter.java
+++ b/src/main/java/io/cryostat/discovery/AbstractNodeTypeAdapter.java
@@ -88,6 +88,10 @@ public class AbstractNodeTypeAdapter extends PluggableTypeAdapter<AbstractNode> 
         while (reader.hasNext()) {
             String tokenName = reader.nextName();
             switch (tokenName) {
+                case "id":
+                    // ignore this if it's provided. We will (re)calculate the ID on our own.
+                    reader.nextInt();
+                    break;
                 case "name":
                     name = reader.nextString();
                     break;
@@ -235,6 +239,7 @@ public class AbstractNodeTypeAdapter extends PluggableTypeAdapter<AbstractNode> 
     public void write(JsonWriter writer, AbstractNode node) throws IOException {
         writer.beginObject();
 
+        writer.name("id").value(node.getId());
         writer.name("name").value(node.getName());
         writer.name("nodeType").value(node.getNodeType().getKind());
         writeMap(writer, "labels", node.getLabels());

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -97,6 +97,11 @@ class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<Envir
         EnvironmentNode root = rootNodeFetcher.get(environment);
         Set<EnvironmentNode> nodes = flattenEnvNodes(root);
 
+        if (filter.contains(FilterInput.Key.ID)) {
+            int id = filter.get(FilterInput.Key.ID);
+            nodes = filter(nodes, n -> n.getId() == id);
+        }
+
         if (filter.contains(FilterInput.Key.NAME)) {
             String nodeName = filter.get(FilterInput.Key.NAME);
             nodes = filter(nodes, n -> Objects.equals(n.getName(), nodeName));

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
@@ -65,6 +65,7 @@ class FilterInput {
     }
 
     enum Key {
+        ID("id"),
         NAME("name"),
         LABELS("labels"),
         ANNOTATIONS("annotations"),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodeRecurseFetcher.java
@@ -105,6 +105,11 @@ class TargetNodeRecurseFetcher extends AbstractPermissionedDataFetcher<List<Targ
         } else {
             throw new IllegalStateException(node.getClass().toString());
         }
+
+        if (filter.contains(FilterInput.Key.ID)) {
+            int id = filter.get(FilterInput.Key.ID);
+            result = result.stream().filter(n -> n.getId() == id).collect(Collectors.toList());
+        }
         if (filter.contains(FilterInput.Key.NAME)) {
             String nodeName = filter.get(FilterInput.Key.NAME);
             result =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -101,6 +101,10 @@ class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode
                         DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment)
                                 .source(rootNodeFetcher.get(environment))
                                 .build());
+        if (filter.contains(FilterInput.Key.ID)) {
+            int id = filter.get(FilterInput.Key.ID);
+            result = result.stream().filter(n -> n.getId() == id).collect(Collectors.toList());
+        }
         if (filter.contains(FilterInput.Key.NAME)) {
             String nodeName = filter.get(FilterInput.Key.NAME);
             result =

--- a/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
@@ -68,7 +68,6 @@ public abstract class AbstractNode implements Comparable<AbstractNode> {
         this.name = name;
         this.nodeType = nodeType;
         this.labels = new HashMap<>(labels);
-        this.id = hashCode();
     }
 
     public int getId() {

--- a/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/AbstractNode.java
@@ -51,6 +51,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public abstract class AbstractNode implements Comparable<AbstractNode> {
 
+    // this currently just holds a value from hashCode(). In the future it should be a database ID
+    protected int id;
+
     protected String name;
 
     protected NodeType nodeType;
@@ -65,6 +68,11 @@ public abstract class AbstractNode implements Comparable<AbstractNode> {
         this.name = name;
         this.nodeType = nodeType;
         this.labels = new HashMap<>(labels);
+        this.id = hashCode();
+    }
+
+    public int getId() {
+        return id;
     }
 
     public String getName() {

--- a/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/EnvironmentNode.java
@@ -70,6 +70,7 @@ public class EnvironmentNode extends AbstractNode {
         super(name, nodeType, labels);
         this.children = new ArrayList<>(children);
         Collections.sort(this.children);
+        this.id = hashCode();
     }
 
     public List<AbstractNode> getChildren() {
@@ -79,11 +80,13 @@ public class EnvironmentNode extends AbstractNode {
     public void addChildNode(AbstractNode child) {
         this.children.add(child);
         Collections.sort(this.children);
+        this.id = hashCode();
     }
 
     public void addChildren(Collection<? extends AbstractNode> children) {
         this.children.addAll(children);
         Collections.sort(this.children);
+        this.id = hashCode();
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/discovery/TargetNode.java
+++ b/src/main/java/io/cryostat/platform/discovery/TargetNode.java
@@ -54,13 +54,13 @@ public class TargetNode extends AbstractNode {
     }
 
     public TargetNode(NodeType nodeType, ServiceRef target) {
-        super(target.getServiceUri().toString(), nodeType, Collections.emptyMap());
-        this.target = new ServiceRef(target);
+        this(nodeType, target, Collections.emptyMap());
     }
 
     public TargetNode(NodeType nodeType, ServiceRef target, Map<String, String> labels) {
         super(target.getServiceUri().toString(), nodeType, labels);
         this.target = new ServiceRef(target);
+        this.id = hashCode();
     }
 
     public ServiceRef getTarget() {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -8,18 +8,21 @@ scalar Int
 scalar Float
 
 input EnvironmentNodeFilterInput {
+    id: Int
     name: String
     nodeType: String
     labels: [String]
 }
 
 input TargetNodesFilterInput {
+    id: Int
     name: String
     labels: [String]
     annotations: [String]
 }
 
 input DescendantTargetsFilterInput {
+    id: Int
     name: String
     labels: [String]
     annotations: [String]

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -67,6 +67,7 @@ type TargetNode implements Node {
     recordings: Recordings!
     mbeanMetrics: MBeanMetrics!
 
+    id: Int!
     name: String!
     nodeType: NodeType!
     labels: Object!
@@ -78,6 +79,7 @@ type TargetNode implements Node {
 type EnvironmentNode implements Node {
     children: [Node!]!
 
+    id: Int!
     name: String!
     nodeType: NodeType!
     labels: Object!
@@ -86,6 +88,7 @@ type EnvironmentNode implements Node {
 }
 
 interface Node {
+    id: Int!
     name: String!
     nodeType: NodeType!
     labels: Object!

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -553,6 +553,40 @@ class GraphQLIT extends ExternalTargetsTest {
                         "^es-andrewazor-demo-Main_graphql-itest_[0-9]{8}T[0-9]{6}Z\\.jfr$"));
     }
 
+    @Test
+    @Order(8)
+    void testNodesHaveIds() throws Exception {
+        CompletableFuture<EnvironmentNodesResponse> resp = new CompletableFuture<>();
+        JsonObject query = new JsonObject();
+        query.put(
+                "query",
+                "query { environmentNodes(filter: { name: \"JDP\" }) { id descendantTargets { id } } }");
+        webClient
+                .post("/api/v2.2/graphql")
+                .sendJson(
+                        query,
+                        ar -> {
+                            if (assertRequestStatus(ar, resp)) {
+                                resp.complete(
+                                        gson.fromJson(
+                                                ar.result().bodyAsString(),
+                                                EnvironmentNodesResponse.class));
+                            }
+                        });
+        // if any of the nodes in the query did not have an ID property then the request would fail
+        EnvironmentNodesResponse actual = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Set<Integer> observedIds = new HashSet<>();
+        for (var env : actual.data.environmentNodes) {
+            // ids should be unique
+            MatcherAssert.assertThat(observedIds, Matchers.not(Matchers.contains(env.id)));
+            observedIds.add(env.id);
+            for (var target : env.descendantTargets) {
+                MatcherAssert.assertThat(observedIds, Matchers.not(Matchers.contains(target.id)));
+                observedIds.add(target.id);
+            }
+        }
+    }
+
     static class Target {
         String alias;
         String serviceUri;
@@ -1111,17 +1145,18 @@ class GraphQLIT extends ExternalTargetsTest {
     }
 
     static class Node {
+        int id;
         String name;
         String nodeType;
 
         @Override
         public String toString() {
-            return "Node [name=" + name + ", nodeType=" + nodeType + "]";
+            return "Node [id=" + id + ", name=" + name + ", nodeType=" + nodeType + "]";
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, nodeType);
+            return Objects.hash(id, name, nodeType);
         }
 
         @Override
@@ -1136,7 +1171,7 @@ class GraphQLIT extends ExternalTargetsTest {
                 return false;
             }
             Node other = (Node) obj;
-            return Objects.equals(name, other.name) && Objects.equals(nodeType, other.nodeType);
+            return id == other.id && Objects.equals(name, other.name) && Objects.equals(nodeType, other.nodeType);
         }
     }
 

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -560,7 +560,8 @@ class GraphQLIT extends ExternalTargetsTest {
         JsonObject query = new JsonObject();
         query.put(
                 "query",
-                "query { environmentNodes(filter: { name: \"JDP\" }) { id descendantTargets { id } } }");
+                "query { environmentNodes(filter: { name: \"JDP\" }) { id descendantTargets { id }"
+                        + " } }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -1171,7 +1172,9 @@ class GraphQLIT extends ExternalTargetsTest {
                 return false;
             }
             Node other = (Node) obj;
-            return id == other.id && Objects.equals(name, other.name) && Objects.equals(nodeType, other.nodeType);
+            return id == other.id
+                    && Objects.equals(name, other.name)
+                    && Objects.equals(nodeType, other.nodeType);
         }
     }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1410

## Description of the change:
This adds an `id` property to discovery nodes. At the moment this is just the object's `hashCode`, but in the future it should be a database ID that is truly unique and stable. That's a much deeper change since it means each individual node should be registered into the database, not just subtrees as published by discovery plugins. Since the `id` is currently "pseudo-unique" and also not stable for a given node (consider what would happen to a Deployment if it were scaled up), this `id` should right now only be used for a single request to ensure that the correct node is selected in cases where the client wants to perform an action against one specific node that may otherwise be ambiguous. Clients should not retain these `id`s and use them for any other purposes.

## Motivation for the change:
This (mostly) allows for distinction between nodes that may have the same name as each other. Nodes that have entirely identical structures down their subtree hierarchy will have the same hashCode and therefore be indistinguishable. In practice I don't think this matters, because the requirement for uniqueness across nodes is for when actions are being performed at a non-leaf node in the deployment tree, ex. starting recording on all descendants of a Deployment. If there are two identically-named Deployments, it is extremely unlikely that the subtrees below them are also identical, since this would mean that the pods have identical names and labels, and the targets have all identical properties, etc.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Do `https --auth-type=basic --auth=user:pass :8181/api/v2.1/discovery` and verify that there are `id` properties.
3. Do `https --auth-type=basic --auth=user:pass :8181/api/v2.2/graphql query=@node-ids.graphql` with `node-ids.graphql`:

```graphql
query {
    environmentNodes {
        id
        descendantTargets {
            id
        }
    }
}
```
4. 3. Do `https --auth-type=basic --auth=user:pass :8181/api/v2.2/graphql query=@node-ids.graphql` with `node-ids-filtered.graphql`:
5. 
```graphql
query {
    environmentNodes {
        id
        descendantTargets(filter: { id: 1234 }) {
            id
        }
    }
}
```