### PR TITLE
fix(graphql): remove non-null constraints for active recs action

### DIFF
--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -67,16 +67,16 @@ type Annotations {
 
 type TargetNode implements Node {
     target: ServiceRef!
-    recordings: Recordings!
-    mbeanMetrics: MBeanMetrics!
+    recordings: Recordings
+    mbeanMetrics: MBeanMetrics
 
     id: Int!
     name: String!
     nodeType: NodeType!
     labels: Object!
 
-    doStartRecording(recording: RecordingSettings!): ActiveRecording!
-    doSnapshot: ActiveRecording!
+    doStartRecording(recording: RecordingSettings!): ActiveRecording
+    doSnapshot: ActiveRecording
 }
 
 type EnvironmentNode implements Node {
@@ -119,9 +119,9 @@ type ActiveRecording implements Recording {
     metadata: RecordingMetadata!
 
     doArchive: ArchivedRecording!
-    doStop: ActiveRecording!
-    doDelete: ActiveRecording!
-    doPutMetadata(metadata: Object): ActiveRecording!
+    doStop: ActiveRecording
+    doDelete: ActiveRecording
+    doPutMetadata(metadata: Object): ActiveRecording
 }
 
 type ArchivedRecording implements Recording {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/pull/906

## Description of the change:

Remove non-null constraints for active recording actions. This allows data to be returned when an error occurs.

## Motivation for the change:

See https://github.com/cryostatio/cryostat-web/pull/906#discussion_r1137825159

## How to manually test:

Try on JDP group with some targets that cannot start/stop/delete recordings. Check the response for the `data` field.

### Start Recording

```graphql
query StartRecordingForGroup() {
  environmentNodes(filter: { name: "JDP" }) {
    name
    descendantTargets {
      name
      doStartRecording(recording: {
        name: "foo",
        template: "Continuous",
        templateType: "TARGET",
        duration: 0,
        restart: true,
        metadata: {
          labels: [
            {
              key: "cryostat.io.topology-group",
              value: "JDP"
            }
          ]
        },
        }) {
            name
            state
      }
    }
  }
}
```


### Stop Recording

```graphql
query StopRecordingForGroup (){
    environmentNodes(filter: { name: "JDP" }) {
      name
      descendantTargets {
        name
        recordings {
            active(filter: { name: "foo" }) {
                data {
                    doStop {
                      name
                      state
                    }
                }
            }
        }
      }
    }
}
```

### Delete Recording

```graphql
query DeleteRecordingForGroup (){
    environmentNodes(filter: { name: "JDP" }) {
      name
      descendantTargets {
        name
        recordings {
            active(filter: { name: "foo" }) {
                data {
                    doDelete {
                      name
                      state
                    }
                }
            }
        }
      }
    }
}
```
