### PR TITLE
feat(agent): implement HTTP-based event types and templates queries to -agents

### DIFF
--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -127,11 +127,7 @@ class AgentClient {
         Future<HttpResponse<JsonArray>> f =
                 invoke(HttpMethod.GET, "/event-types", BodyCodec.jsonArray());
         return f.map(HttpResponse::body)
-                .map(
-                        arr -> arr.stream()
-                        .map(o -> new AgentEventTypeInfo((JsonObject) o))
-                        .toList()
-                    );
+                .map(arr -> arr.stream().map(o -> new AgentEventTypeInfo((JsonObject) o)).toList());
     }
 
     static class AgentEventTypeInfo implements IEventTypeInfo {
@@ -265,6 +261,12 @@ class AgentClient {
                                     });
                             return result;
                         });
+    }
+
+    Future<List<String>> eventTemplates() {
+        Future<HttpResponse<JsonArray>> f =
+                invoke(HttpMethod.GET, "/event-templates", BodyCodec.jsonArray());
+        return f.map(HttpResponse::body).map(arr -> arr.stream().map(Object::toString).toList());
     }
 
     private <T> Future<HttpResponse<T>> invoke(HttpMethod mtd, String path, BodyCodec<T> codec) {

--- a/src/main/java/io/cryostat/net/AgentConnection.java
+++ b/src/main/java/io/cryostat/net/AgentConnection.java
@@ -39,8 +39,6 @@ package io.cryostat.net;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -49,26 +47,21 @@ import javax.management.IntrospectionException;
 import javax.management.ReflectionException;
 import javax.management.remote.JMXServiceURL;
 
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
-import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.IDException;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.net.MBeanMetrics;
 import io.cryostat.core.sys.Clock;
-import io.cryostat.core.templates.Template;
+import io.cryostat.core.templates.RemoteTemplateService;
 import io.cryostat.core.templates.TemplateService;
-import io.cryostat.core.templates.TemplateType;
 import io.cryostat.recordings.JvmIdHelper;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.jsoup.nodes.Document;
 
 public class AgentConnection implements JFRConnection {
 
@@ -148,25 +141,7 @@ public class AgentConnection implements JFRConnection {
 
     @Override
     public TemplateService getTemplateService() {
-        return new TemplateService() {
-
-            @Override
-            public Optional<IConstrainedMap<EventOptionID>> getEvents(
-                    String name, TemplateType type) throws FlightRecorderException {
-                return Optional.empty();
-            }
-
-            @Override
-            public List<Template> getTemplates() throws FlightRecorderException {
-                return List.of();
-            }
-
-            @Override
-            public Optional<Document> getXml(String name, TemplateType type)
-                    throws FlightRecorderException {
-                return Optional.empty();
-            }
-        };
+        return new RemoteTemplateService(this);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/AgentConnection.java
+++ b/src/main/java/io/cryostat/net/AgentConnection.java
@@ -143,7 +143,7 @@ public class AgentConnection implements JFRConnection {
     @Override
     public IFlightRecorderService getService()
             throws ConnectionException, IOException, ServiceNotAvailableException {
-        return new AgentJFRService(client);
+        return new AgentJFRService(client, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -153,8 +153,12 @@ class AgentJFRService implements IFlightRecorderService {
 
     @Override
     public List<String> getServerTemplates() throws FlightRecorderException {
-        // TODO Auto-generated method stub
-        return List.of();
+        try {
+            return client.eventTemplates().toCompletionStage().toCompletableFuture().get();
+        } catch (ExecutionException | InterruptedException e) {
+            logger.warn(e);
+            return List.of();
+        }
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -41,6 +41,8 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IDescribedMap;
@@ -54,12 +56,16 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import io.cryostat.core.log.Logger;
+
 class AgentJFRService implements IFlightRecorderService {
 
     private final AgentClient client;
+    private final Logger logger;
 
-    AgentJFRService(AgentClient client) {
+    AgentJFRService(AgentClient client, Logger logger) {
         this.client = client;
+        this.logger = logger;
     }
 
     @Override
@@ -79,25 +85,29 @@ class AgentJFRService implements IFlightRecorderService {
 
     @Override
     public void close(IRecordingDescriptor descriptor) throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public void enable() throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public Collection<? extends IEventTypeInfo> getAvailableEventTypes()
             throws FlightRecorderException {
-        return List.of();
+        try {
+            return client.eventTypes().toCompletionStage().toCompletableFuture().get();
+        } catch (ExecutionException | InterruptedException e) {
+            logger.warn(e);
+            return List.of();
+        }
     }
 
     @Override
     public Map<String, IOptionDescriptor<?>> getAvailableRecordingOptions()
             throws FlightRecorderException {
+        // TODO Auto-generated method stub
         return Map.of();
     }
 
@@ -110,8 +120,14 @@ class AgentJFRService implements IFlightRecorderService {
     @Override
     public IConstrainedMap<EventOptionID> getCurrentEventTypeSettings()
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
-        return new DefaultValueMap<>(Map.of());
+        try {
+            return Optional.of(
+                            client.eventSettings().toCompletionStage().toCompletableFuture().get())
+                    .orElse(new DefaultValueMap<>(Map.of()));
+        } catch (ExecutionException | InterruptedException e) {
+            logger.warn(e);
+            return new DefaultValueMap<>(Map.of());
+        }
     }
 
     @Override
@@ -143,7 +159,6 @@ class AgentJFRService implements IFlightRecorderService {
 
     @Override
     public IRecordingDescriptor getSnapshotRecording() throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
@@ -156,21 +171,18 @@ class AgentJFRService implements IFlightRecorderService {
 
     @Override
     public boolean isEnabled() {
-        // TODO Auto-generated method stub
         return true;
     }
 
     @Override
     public InputStream openStream(IRecordingDescriptor arg0, boolean arg1)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public InputStream openStream(IRecordingDescriptor arg0, IQuantity arg1, boolean arg2)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
@@ -178,7 +190,6 @@ class AgentJFRService implements IFlightRecorderService {
     public InputStream openStream(
             IRecordingDescriptor arg0, IQuantity arg1, IQuantity arg2, boolean arg3)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
@@ -186,27 +197,23 @@ class AgentJFRService implements IFlightRecorderService {
     public IRecordingDescriptor start(
             IConstrainedMap<String> arg0, IConstrainedMap<EventOptionID> arg1)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public void stop(IRecordingDescriptor arg0) throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public void updateEventOptions(IRecordingDescriptor arg0, IConstrainedMap<EventOptionID> arg1)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 
     @Override
     public void updateRecordingOptions(IRecordingDescriptor arg0, IConstrainedMap<String> arg1)
             throws FlightRecorderException {
-        // TODO Auto-generated method stub
         throw new UnimplementedException();
     }
 

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -179,7 +179,8 @@ public abstract class NetworkModule {
                             .setSsl(true)
                             .setDefaultHost(netConf.getWebServerHost())
                             .setDefaultPort(netConf.getExternalWebServerPort())
-                            .setFollowRedirects(true);
+                            .setFollowRedirects(true)
+                            .setTryUseCompression(true);
             if (netConf.isUntrustedSslAllowed()) {
                 opts = opts.setTrustAll(true).setVerifyHost(false);
             }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

See #1415
Related to #1416
Related to #1309
Related to #520

## Description of the change:
Just like #1415, but for event types and event templates querying instead of MBean metrics.

## Motivation for the change:
Same as before

## How to manually test:
Needs https://github.com/cryostatio/cryostat-agent/pull/80
Testing procedure is the same as before, but this time go to the Events view. The event types and templates tables should populate.
