### PR TITLE
feat(agent): implement HTTP-based recordings queries to -agents

### DIFF
--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -288,15 +288,16 @@ class AgentClient {
         }
 
         @Override
-        public IQuantity getDataEndTime() {
-            // TODO
-            return UnitLookup.EPOCH_MS.quantity(-1L);
+        public IQuantity getDataStartTime() {
+            return getStartTime();
         }
 
         @Override
-        public IQuantity getDataStartTime() {
-            // TODO
-            return UnitLookup.EPOCH_MS.quantity(-1L);
+        public IQuantity getDataEndTime() {
+            if (isContinuous()) {
+                return UnitLookup.EPOCH_MS.quantity(0);
+            }
+            return getDataStartTime().add(getDuration());
         }
 
         @Override
@@ -326,7 +327,6 @@ class AgentClient {
 
         @Override
         public ObjectName getObjectName() {
-            // TODO Auto-generated method stub
             return null;
         }
 

--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -47,17 +47,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 
+import javax.management.ObjectName;
 import javax.script.ScriptException;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IConstraint;
 import org.openjdk.jmc.common.unit.IOptionDescriptor;
+import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.common.unit.SimpleConstrainedMap;
+import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
 import org.openjdk.jmc.flightrecorder.configuration.internal.EventTypeIDV2;
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
@@ -123,90 +127,26 @@ class AgentClient {
                 .map(s -> gson.fromJson(s, MBeanMetrics.class));
     }
 
+    Future<List<IRecordingDescriptor>> activeRecordings() {
+        Future<HttpResponse<JsonArray>> f =
+                invoke(HttpMethod.GET, "/recordings", BodyCodec.jsonArray());
+        return f.map(HttpResponse::body)
+                .map(
+                        arr ->
+                                arr.stream()
+                                        .map(
+                                                o ->
+                                                        (IRecordingDescriptor)
+                                                                new AgentRecordingDescriptor(
+                                                                        (JsonObject) o))
+                                        .toList());
+    }
+
     Future<Collection<? extends IEventTypeInfo>> eventTypes() {
         Future<HttpResponse<JsonArray>> f =
                 invoke(HttpMethod.GET, "/event-types", BodyCodec.jsonArray());
         return f.map(HttpResponse::body)
                 .map(arr -> arr.stream().map(o -> new AgentEventTypeInfo((JsonObject) o)).toList());
-    }
-
-    static class AgentEventTypeInfo implements IEventTypeInfo {
-
-        final JsonObject json;
-
-        AgentEventTypeInfo(JsonObject json) {
-            this.json = json;
-        }
-
-        @Override
-        public String getDescription() {
-            return json.getString("description");
-        }
-
-        @Override
-        public IEventTypeID getEventTypeID() {
-            return new EventTypeIDV2(json.getString("name"));
-        }
-
-        @Override
-        public String[] getHierarchicalCategory() {
-            return ((List<String>)
-                            json.getJsonArray("categories").getList().stream()
-                                    .map(Object::toString)
-                                    .toList())
-                    .toArray(new String[0]);
-        }
-
-        @Override
-        public String getName() {
-            return json.getString("name");
-        }
-
-        static <T, V> V capture(T t) {
-            // TODO clean up this generics hack
-            return (V) t;
-        }
-
-        @Override
-        public Map<String, ? extends IOptionDescriptor<?>> getOptionDescriptors() {
-            Map<String, ? extends IOptionDescriptor<?>> result = new HashMap<>();
-            JsonArray settings = json.getJsonArray("settings");
-            settings.forEach(
-                    setting -> {
-                        String name = ((JsonObject) setting).getString("name");
-                        String defaultValue = ((JsonObject) setting).getString("defaultValue");
-                        result.put(
-                                name,
-                                capture(
-                                        new IOptionDescriptor<String>() {
-                                            @Override
-                                            public String getName() {
-                                                return name;
-                                            }
-
-                                            @Override
-                                            public String getDescription() {
-                                                return null;
-                                            }
-
-                                            @Override
-                                            public IConstraint<String> getConstraint() {
-                                                return null;
-                                            }
-
-                                            @Override
-                                            public String getDefault() {
-                                                return defaultValue;
-                                            }
-                                        }));
-                    });
-            return result;
-        }
-
-        @Override
-        public IOptionDescriptor<?> getOptionInfo(String s) {
-            return getOptionDescriptors().get(s);
-        }
     }
 
     Future<IConstrainedMap<EventOptionID>> eventSettings() {
@@ -336,6 +276,176 @@ class AgentClient {
         AgentClient create(URI agentUri) {
             return new AgentClient(
                     vertx, gson, httpTimeout, webClient, credentialsManager, agentUri, logger);
+        }
+    }
+
+    private static class AgentRecordingDescriptor implements IRecordingDescriptor {
+
+        final JsonObject json;
+
+        AgentRecordingDescriptor(JsonObject json) {
+            this.json = json;
+        }
+
+        @Override
+        public IQuantity getDataEndTime() {
+            // TODO
+            return UnitLookup.EPOCH_MS.quantity(-1L);
+        }
+
+        @Override
+        public IQuantity getDataStartTime() {
+            // TODO
+            return UnitLookup.EPOCH_MS.quantity(-1L);
+        }
+
+        @Override
+        public IQuantity getDuration() {
+            return UnitLookup.MILLISECOND.quantity(json.getLong("duration"));
+        }
+
+        @Override
+        public Long getId() {
+            return json.getLong("id");
+        }
+
+        @Override
+        public IQuantity getMaxAge() {
+            return UnitLookup.MILLISECOND.quantity(json.getLong("maxAge"));
+        }
+
+        @Override
+        public IQuantity getMaxSize() {
+            return UnitLookup.BYTE.quantity(json.getLong("maxSize"));
+        }
+
+        @Override
+        public String getName() {
+            return json.getString("name");
+        }
+
+        @Override
+        public ObjectName getObjectName() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Map<String, ?> getOptions() {
+            return json.getJsonObject("options").getMap();
+        }
+
+        @Override
+        public IQuantity getStartTime() {
+            return UnitLookup.EPOCH_MS.quantity(json.getLong("startTime"));
+        }
+
+        @Override
+        public RecordingState getState() {
+            // avoid using Enum.valueOf() since that throws an exception if the name isn't part of
+            // the type, and it's nicer to not throw and catch exceptions
+            String state = json.getString("state");
+            switch (state) {
+                case "CREATED":
+                    return RecordingState.CREATED;
+                case "RUNNING":
+                    return RecordingState.RUNNING;
+                case "STOPPING":
+                    return RecordingState.STOPPING;
+                case "STOPPED":
+                    return RecordingState.STOPPED;
+                default:
+                    return RecordingState.RUNNING;
+            }
+        }
+
+        @Override
+        public boolean getToDisk() {
+            return json.getBoolean("toDisk");
+        }
+
+        @Override
+        public boolean isContinuous() {
+            return json.getBoolean("isContinuous");
+        }
+    }
+
+    private static class AgentEventTypeInfo implements IEventTypeInfo {
+
+        final JsonObject json;
+
+        AgentEventTypeInfo(JsonObject json) {
+            this.json = json;
+        }
+
+        @Override
+        public String getDescription() {
+            return json.getString("description");
+        }
+
+        @Override
+        public IEventTypeID getEventTypeID() {
+            return new EventTypeIDV2(json.getString("name"));
+        }
+
+        @Override
+        public String[] getHierarchicalCategory() {
+            return ((List<String>)
+                            json.getJsonArray("categories").getList().stream()
+                                    .map(Object::toString)
+                                    .toList())
+                    .toArray(new String[0]);
+        }
+
+        @Override
+        public String getName() {
+            return json.getString("name");
+        }
+
+        static <T, V> V capture(T t) {
+            // TODO clean up this generics hack
+            return (V) t;
+        }
+
+        @Override
+        public Map<String, ? extends IOptionDescriptor<?>> getOptionDescriptors() {
+            Map<String, ? extends IOptionDescriptor<?>> result = new HashMap<>();
+            JsonArray settings = json.getJsonArray("settings");
+            settings.forEach(
+                    setting -> {
+                        String name = ((JsonObject) setting).getString("name");
+                        String defaultValue = ((JsonObject) setting).getString("defaultValue");
+                        result.put(
+                                name,
+                                capture(
+                                        new IOptionDescriptor<String>() {
+                                            @Override
+                                            public String getName() {
+                                                return name;
+                                            }
+
+                                            @Override
+                                            public String getDescription() {
+                                                return null;
+                                            }
+
+                                            @Override
+                                            public IConstraint<String> getConstraint() {
+                                                return null;
+                                            }
+
+                                            @Override
+                                            public String getDefault() {
+                                                return defaultValue;
+                                            }
+                                        }));
+                    });
+            return result;
+        }
+
+        @Override
+        public IOptionDescriptor<?> getOptionInfo(String s) {
+            return getOptionDescriptors().get(s);
         }
     }
 }

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -113,8 +113,12 @@ class AgentJFRService implements IFlightRecorderService {
 
     @Override
     public List<IRecordingDescriptor> getAvailableRecordings() throws FlightRecorderException {
-        // TODO Auto-generated method stub
-        return List.of();
+        try {
+            return client.activeRecordings().toCompletionStage().toCompletableFuture().get();
+        } catch (ExecutionException | InterruptedException e) {
+            logger.warn(e);
+            return List.of();
+        }
     }
 
     @Override


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

See #1415 #1419
Related to #1416
Related to #1309
Related to #520

## Description of the change:
Like #1415 and #1419. This one queries information about active recordings.

## Motivation for the change:
Same as before

## How to manually test:
Needs https://github.com/cryostatio/cryostat-agent/pull/82
Apply the following patch:
```diff
diff --git a/smoketest.sh b/smoketest.sh
index 4aebf722..15dbd3f4 100755
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -158,7 +158,7 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
-        --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="true" \
+        --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="false" \
         --env CRYOSTAT_AGENT_HARVESTER_PERIOD_MS=60000 \
         --env CRYOSTAT_AGENT_HARVESTER_MAX_FILES=10 \
         --rm -d quay.io/andrewazores/quarkus-test:latest
```
Testing procedure is the same as before, but this time go to the Recordings view. Select the `quarkus-test-agent` with port `9977` sample application. The active recordings table should populate.
