### PR TITLE
feat(discovery): add endpoint for plugins to check their registration

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationCheckHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryRegistrationCheckHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.v2;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.discovery.DiscoveryStorage;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.security.jwt.DiscoveryJwtHelper;
+import io.cryostat.net.web.WebServer;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.util.StringUtil;
+
+import com.nimbusds.jwt.JWT;
+import dagger.Lazy;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+class DiscoveryRegistrationCheckHandler extends AbstractDiscoveryJwtConsumingHandler<Void> {
+
+    static final String PATH = "discovery/:id";
+    private final DiscoveryStorage storage;
+    private final Function<String, UUID> uuidFromString;
+
+    @Inject
+    DiscoveryRegistrationCheckHandler(
+            AuthManager auth,
+            DiscoveryJwtHelper jwtFactory,
+            Lazy<WebServer> webServer,
+            DiscoveryStorage storage,
+            @Named(MainModule.UUID_FROM_STRING) Function<String, UUID> uuidFromString,
+            Logger logger) {
+        super(storage, auth, jwtFactory, webServer, uuidFromString, logger);
+        this.storage = storage;
+        this.uuidFromString = uuidFromString;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.V2_2;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + PATH;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return Set.of();
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    void handleWithValidJwt(RoutingContext ctx, JWT jwt) throws Exception {
+        UUID id = this.uuidFromString.apply(StringUtil.requireNonBlank(ctx.pathParam("id"), "id"));
+        if (storage.getById(id).isPresent()) {
+            writeResponse(ctx, new IntermediateResponse<Void>());
+        } else {
+            throw new ApiException(404);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/HttpApiV2Module.java
@@ -192,6 +192,11 @@ public abstract class HttpApiV2Module {
 
     @Binds
     @IntoSet
+    abstract RequestHandler bindDiscoveryRegistrationCheckHandler(
+            DiscoveryRegistrationCheckHandler handler);
+
+    @Binds
+    @IntoSet
     abstract RequestHandler bindDiscoveryRegistrationHandler(DiscoveryRegistrationHandler handler);
 
     @Binds


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-agent/issues/85

## Description of the change:
This adds a `GET` endpoint that plugins can use with their existing registration ID and token to check their registration status. The API response is 200 if the plugin is registered and the token is still valid, 401 if the token is invalid, and 404 if the token is somehow valid but the plugin is not registered (this should be impossible - if the plugin is not registered then any token it still has should be invalid).

## Motivation for the change:
This is used by the `-agent` to perform its own periodic heartbeat checks on the Cryostat server at a slower cadence. If the plugin notices that it cannot reach Cryostat, or that Cryostat no longer recognizes it as a registered plugin, then the `-agent` re-enters its original unregistered state and begins trying to more quickly re-register itself with the Cryostat server it is configured for.

## How to manually test:
Patch `shometest.sh` like so:

```diff
diff --git a/smoketest.sh b/smoketest.sh
index 4aebf722..6465b53e 100755
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -179,6 +179,7 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="true" \
+        --env CRYOSTAT_AGENT_REGISTRATION_CHECK_MS="15000" \
         --rm -d quay.io/andrewazores/quarkus-test:latest
 
     # copy a jboss-client.jar into /clientlib first
```

to make one of the sample agent applications perform this check more frequently so it's easier to catch.

1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Check the server logs and agent logs. There should be frequent `GET` requests to the new endpoint, which should succeed.
3. TODO figure out a decent way to set up an environment where the Cryostat server can be taken down and restarted without also taking down the agents.
