### PR TITLE
fix(noti): set STOPPED state for ActiveRecordingStopped notifications

### DIFF
--- a/src/main/java/io/cryostat/jmc/serialization/HyperlinkedSerializableRecordingDescriptor.java
+++ b/src/main/java/io/cryostat/jmc/serialization/HyperlinkedSerializableRecordingDescriptor.java
@@ -39,6 +39,7 @@ package io.cryostat.jmc.serialization;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor.RecordingState;
 
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 
@@ -85,6 +86,20 @@ public class HyperlinkedSerializableRecordingDescriptor extends SerializableReco
         this.reportUrl = reportUrl;
         this.metadata = metadata;
         this.archiveOnStop = archiveOnStop;
+    }
+
+    public HyperlinkedSerializableRecordingDescriptor(
+            IRecordingDescriptor original,
+            String downloadUrl,
+            String reportUrl,
+            RecordingState state)
+            throws QuantityConversionException {
+        super(original);
+        this.downloadUrl = downloadUrl;
+        this.reportUrl = reportUrl;
+        this.metadata = new Metadata();
+        this.archiveOnStop = false;
+        this.state = state;
     }
 
     public HyperlinkedSerializableRecordingDescriptor(

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -275,7 +275,8 @@ public class RecordingTargetHelper {
                                 new HyperlinkedSerializableRecordingDescriptor(
                                         d,
                                         webServer.get().getDownloadURL(connection, d.getName()),
-                                        webServer.get().getReportURL(connection, d.getName()));
+                                        webServer.get().getReportURL(connection, d.getName()),
+                                        RecordingState.STOPPED);
                         this.issueNotification(targetId, linkedDesc, STOP_NOTIFICATION_CATEGORY);
                         return getDescriptorByName(connection, recordingName).get();
                     } else {

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -829,9 +829,9 @@ public class RecordingTargetHelperTest {
 
         Mockito.verify(service).stop(descriptor);
 
-        Metadata metadata = new Metadata();
         HyperlinkedSerializableRecordingDescriptor linkedDesc =
-                new HyperlinkedSerializableRecordingDescriptor(descriptor, null, null, metadata);
+                new HyperlinkedSerializableRecordingDescriptor(
+                        descriptor, null, null, RecordingState.STOPPED);
 
         Mockito.verify(notificationFactory).createBuilder();
         Mockito.verify(notificationBuilder).metaCategory("ActiveRecordingStopped");


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes #1428 

## Description of the change:

Correct the descriptor state before sending notifications.

## Motivation for the change:

See #1428 

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Create any recording then stop it. Observe the payload containing a recs that has STOPPED state.
