### PR TITLE
feat(credentials): add credentials test endpoint

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostBodyHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostBodyHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.AbstractAuthenticatedRequestHandler;
+import io.cryostat.net.web.http.api.ApiVersion;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class CredentialTestPostBodyHandler extends AbstractAuthenticatedRequestHandler {
+
+    static final BodyHandler BODY_HANDLER = BodyHandler.create(true).setHandleFileUploads(false);
+
+    @Inject
+    CredentialTestPostBodyHandler(
+            AuthManager auth, CredentialsManager credentialsManager, Logger logger) {
+        super(auth, credentialsManager, logger);
+    }
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return ResourceAction.NONE;
+    }
+
+    @Override
+    public String path() {
+        return basePath() + CredentialTestPostHandler.PATH;
+    }
+
+    @Override
+    public void handleAuthenticated(RoutingContext ctx) throws Exception {
+        BODY_HANDLER.handle(ctx);
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
@@ -161,10 +161,10 @@ public class CredentialTestPostHandler extends AbstractV2RequestHandler<Credenti
                         return new IntermediateResponse<CredentialTestResult>()
                                 .body(CredentialTestResult.FAILURE);
                     }
-                    throw new ApiException(400, "Invalid credentials", e2);
+                    throw new ApiException(500, e2);
                 }
             }
-            throw new ApiException(400, e);
+            throw new ApiException(500, e);
         }
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.net.web.http.api.beta;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.Credentials;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.ConnectionDescriptor;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.v2.AbstractV2RequestHandler;
+import io.cryostat.net.web.http.api.v2.ApiException;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+
+import com.google.gson.Gson;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
+
+public class CredentialTestPostHandler extends AbstractV2RequestHandler<Boolean> {
+
+    static final String PATH = "credentials/:targetId";
+
+    private final TargetConnectionManager tcm;
+    private final Logger logger;
+
+    @Inject
+    CredentialTestPostHandler(
+            AuthManager auth,
+            CredentialsManager credentialsManager,
+            Gson gson,
+            TargetConnectionManager tcm,
+            Logger logger) {
+        super(auth, credentialsManager, gson);
+        this.tcm = tcm;
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean requiresAuthentication() {
+        return true;
+    }
+
+    @Override
+    public ApiVersion apiVersion() {
+        return ApiVersion.BETA;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
+    }
+
+    @Override
+    public Set<ResourceAction> resourceActions() {
+        return EnumSet.of(ResourceAction.READ_TARGET);
+    }
+
+    @Override
+    public String path() {
+        return basePath() + PATH;
+    }
+
+    @Override
+    public List<HttpMimeType> produces() {
+        return List.of(HttpMimeType.JSON);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return false;
+    }
+
+    @Override
+    public IntermediateResponse<Boolean> handle(RequestParameters params) throws Exception {
+        String targetId = params.getPathParams().get("targetId");
+        String username = params.getFormAttributes().get("username");
+        String password = params.getFormAttributes().get("password");
+        if (StringUtils.isBlank(targetId)) {
+            throw new ApiException(400, "\"targetId\" is required.");
+        }
+        ConnectionDescriptor cd;
+        if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+            cd = new ConnectionDescriptor(targetId, new Credentials(username, password));
+        } else {
+            cd = new ConnectionDescriptor(targetId);
+        }
+        try {
+            return new IntermediateResponse<Boolean>()
+                    .body(
+                            tcm.executeConnectedTask(
+                                    cd,
+                                    (conn) -> {
+                                        conn.connect();
+                                        return true;
+                                    }));
+        } catch (Exception e) {
+            if (e.getCause() instanceof SecurityException) {
+                return new IntermediateResponse<Boolean>().body(false);
+            }
+            throw e;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
@@ -161,10 +161,10 @@ public class CredentialTestPostHandler extends AbstractV2RequestHandler<Credenti
                         return new IntermediateResponse<CredentialTestResult>()
                                 .body(CredentialTestResult.FAILURE);
                     }
-                    throw e2;
+                    throw new ApiException(400, "Invalid credentials", e2);
                 }
             }
-            throw e;
+            throw new ApiException(400, e);
         }
     }
 

--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
@@ -162,21 +162,11 @@ public class CredentialTestPostHandler extends AbstractV2RequestHandler<Credenti
                         return new IntermediateResponse<CredentialTestResult>()
                                 .body(CredentialTestResult.FAILURE);
                     }
-                    throw resolveErrors(e2);
+                    throw e2;
                 }
             }
-            throw resolveErrors(e1);
+            throw e1;
         }
-    }
-
-    ApiException resolveErrors(Exception e) throws Exception {
-        if (AbstractAuthenticatedRequestHandler.isJmxSslFailure(e)) {
-            return new ApiException(502, "Target SSL Untrusted", e);
-        }
-        if (AbstractAuthenticatedRequestHandler.isServiceTypeFailure(e)) {
-            return new ApiException(504, "Non-JMX Port", e);
-        }
-        return new ApiException(500, "Internal Error", e);
     }
 
     static enum CredentialTestResult {

--- a/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandler.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.cryostat.configuration.CredentialsManager;
-import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
 import io.cryostat.net.AuthManager;
 import io.cryostat.net.ConnectionDescriptor;
@@ -67,18 +66,15 @@ public class CredentialTestPostHandler extends AbstractV2RequestHandler<Credenti
     static final String PATH = "credentials/:targetId";
 
     private final TargetConnectionManager tcm;
-    private final Logger logger;
 
     @Inject
     CredentialTestPostHandler(
             AuthManager auth,
             CredentialsManager credentialsManager,
             Gson gson,
-            TargetConnectionManager tcm,
-            Logger logger) {
+            TargetConnectionManager tcm) {
         super(auth, credentialsManager, gson);
         this.tcm = tcm;
-        this.logger = logger;
     }
 
     @Override
@@ -125,7 +121,7 @@ public class CredentialTestPostHandler extends AbstractV2RequestHandler<Credenti
         if (StringUtils.isAnyBlank(targetId, username, password)) {
             StringBuilder sb = new StringBuilder();
             if (StringUtils.isBlank(targetId)) {
-                sb.append("\"matchExpression\" is required.");
+                sb.append("\"targetId\" is required.");
             }
             if (StringUtils.isBlank(username)) {
                 sb.append("\"username\" is required.");

--- a/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/HttpApiBetaModule.java
@@ -161,4 +161,12 @@ public abstract class HttpApiBetaModule {
     @Binds
     @IntoSet
     abstract RequestHandler bindMatchExpressionDeleteHandler(MatchExpressionDeleteHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindCredentialTestPostHandler(CredentialTestPostHandler handler);
+
+    @Binds
+    @IntoSet
+    abstract RequestHandler bindCredentialTestGetBodyHandler(CredentialTestPostBodyHandler handler);
 }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/CredentialTestPostHandlerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.cryostat.net.web.http.api.beta;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.cryostat.MainModule;
+import io.cryostat.configuration.CredentialsManager;
+import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.net.AuthManager;
+import io.cryostat.net.TargetConnectionManager;
+import io.cryostat.net.security.ResourceAction;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.cryostat.net.web.http.api.ApiVersion;
+import io.cryostat.net.web.http.api.beta.CredentialTestPostHandler.CredentialTestResult;
+import io.cryostat.net.web.http.api.v2.IntermediateResponse;
+import io.cryostat.net.web.http.api.v2.RequestParameters;
+
+import com.google.gson.Gson;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialTestPostHandlerTest {
+    CredentialTestPostHandler handler;
+    @Mock AuthManager auth;
+    @Mock CredentialsManager credentialsManager;
+    @Mock Logger logger;
+    @Mock TargetConnectionManager tcm;
+    Gson gson = MainModule.provideGson(logger);
+
+    @BeforeEach
+    void setup() {
+        this.handler = new CredentialTestPostHandler(auth, credentialsManager, gson, tcm);
+    }
+
+    @Nested
+    class BasicHandlerDefinition {
+        @Test
+        void shouldBePOSTHandler() {
+            MatcherAssert.assertThat(handler.httpMethod(), Matchers.equalTo(HttpMethod.POST));
+        }
+
+        @Test
+        void shouldBeAPIBeta() {
+            MatcherAssert.assertThat(handler.apiVersion(), Matchers.equalTo(ApiVersion.BETA));
+        }
+
+        @Test
+        void shouldHaveExpectedPath() {
+            MatcherAssert.assertThat(
+                    handler.path(), Matchers.equalTo("/api/beta/credentials/:targetId"));
+        }
+
+        @Test
+        void shouldHaveExpectedRequiredPermissions() {
+            MatcherAssert.assertThat(
+                    handler.resourceActions(),
+                    Matchers.equalTo(Set.of(ResourceAction.READ_TARGET)));
+        }
+
+        @Test
+        void shouldProduceJson() {
+            MatcherAssert.assertThat(
+                    handler.produces(), Matchers.equalTo(List.of(HttpMimeType.JSON)));
+        }
+
+        @Test
+        void shouldRequireAuthentication() {
+            MatcherAssert.assertThat(handler.requiresAuthentication(), Matchers.is(true));
+        }
+    }
+
+    @Nested
+    class RequestHandling {
+        @Mock RequestParameters requestParams;
+        @Mock JFRConnection connection;
+        MultiMap form = MultiMap.caseInsensitiveMultiMap();
+        String username = "user";
+        String password = "pass";
+        String targetId = "targetId";
+
+        @BeforeEach
+        void setup() {
+            this.form.set("username", username);
+            this.form.set("password", password);
+        }
+
+        @Test
+        void shouldRespondNA() throws Exception {
+            when(requestParams.getFormAttributes()).thenReturn(form);
+            when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+
+            when(tcm.executeConnectedTask(Mockito.any(), Mockito.any()))
+                    .thenAnswer(
+                            arg0 ->
+                                    ((TargetConnectionManager.ConnectedTask<Object>)
+                                                    arg0.getArgument(1))
+                                            .execute(connection));
+
+            IntermediateResponse<CredentialTestResult> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(response.getBody(), Matchers.equalTo(CredentialTestResult.NA));
+        }
+
+        @Test
+        void shouldRespondSUCCESS() throws Exception {
+            when(requestParams.getFormAttributes()).thenReturn(form);
+            when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+
+            when(tcm.executeConnectedTask(Mockito.any(), Mockito.any()))
+                    .thenThrow(
+                            new Exception(
+                                    new SecurityException("first failure without credentials")))
+                    .thenAnswer(
+                            arg0 ->
+                                    ((TargetConnectionManager.ConnectedTask<Object>)
+                                                    arg0.getArgument(1))
+                                            .execute(connection));
+
+            IntermediateResponse<CredentialTestResult> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(
+                    response.getBody(), Matchers.equalTo(CredentialTestResult.SUCCESS));
+        }
+
+        @Test
+        void shouldRespondFAILURE() throws Exception {
+            when(requestParams.getFormAttributes()).thenReturn(form);
+            when(requestParams.getPathParams()).thenReturn(Map.of("targetId", targetId));
+
+            when(tcm.executeConnectedTask(Mockito.any(), Mockito.any()))
+                    .thenThrow(
+                            new Exception(
+                                    new SecurityException("first failure without credentials")))
+                    .thenThrow(
+                            new Exception(
+                                    new SecurityException("second failure with credentials")));
+
+            IntermediateResponse<CredentialTestResult> response = handler.handle(requestParams);
+
+            MatcherAssert.assertThat(response.getStatusCode(), Matchers.equalTo(200));
+            MatcherAssert.assertThat(
+                    response.getBody(), Matchers.equalTo(CredentialTestResult.FAILURE));
+        }
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1431

## Description of the change:
Adds an endpoint to specifically test JMX connection  w/credentials to a target JVM at `/beta/credentials/:targetId`

The endpoint from the backend should query these targets themselves with the supplied credentials, and give a resulting output as the response body.

They should return status=`NA` for "this target does not need credentials, status=`SUCCESS`, this target is authenticated with these supplied credentials, and status=`FAILURE`, which means these credentials can not be authenticated with these credentials. 

## Motivation for the change:
See #1431

## How to manually test:
1. Run with smoketest setup.
2. Try these queries:

```bash
http --form --auth=user:pass POST localhost:8181/api/beta/credentials/service%3Ajmx%3Armi%3A%2F%2F%2Fjndi%2Frmi%3A%2F%2Flocalhost%3A9095%2Fjmxrmi/ username="admin" password="adminpass123"
```

Try on target that doesn't need credentials as well: e.g. `9093 vertx-fib-demo`

