### PR TITLE
fix(fd): close leaked file descriptors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   <com.google.dagger.version>2.45</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.45</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.19.1</io.cryostat.core.version>
+  <io.cryostat.core.version>2.19.2</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>

--- a/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
+++ b/src/main/java/io/cryostat/net/openshift/OpenShiftNetworkModule.java
@@ -37,6 +37,7 @@
  */
 package io.cryostat.net.openshift;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
@@ -80,12 +81,8 @@ public abstract class OpenShiftNetworkModule {
             value = "DMI_HARDCODED_ABSOLUTE_FILENAME",
             justification = "Kubernetes namespace file path is well-known and absolute")
     static String provideNamespace(FileSystem fs) {
-        try {
-            return fs.readFile(Paths.get(Config.KUBERNETES_NAMESPACE_PATH))
-                    .lines()
-                    .filter(StringUtils::isNotBlank)
-                    .findFirst()
-                    .get();
+        try (BufferedReader br = fs.readFile(Paths.get(Config.KUBERNETES_NAMESPACE_PATH))) {
+            return br.lines().filter(StringUtils::isNotBlank).findFirst().get();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -98,12 +95,9 @@ public abstract class OpenShiftNetworkModule {
             value = "DMI_HARDCODED_ABSOLUTE_FILENAME",
             justification = "Kubernetes serviceaccount file path is well-known and absolute")
     static String provideServiceAccountToken(FileSystem fs) {
-        try {
-            return fs.readFile(Paths.get(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH))
-                    .lines()
-                    .filter(StringUtils::isNotBlank)
-                    .findFirst()
-                    .get();
+        try (BufferedReader br =
+                fs.readFile(Paths.get(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH))) {
+            return br.lines().filter(StringUtils::isNotBlank).findFirst().get();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
+++ b/src/main/java/io/cryostat/net/reports/SubprocessReportGenerator.java
@@ -37,6 +37,7 @@
  */
 package io.cryostat.net.reports;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -156,11 +157,12 @@ public class SubprocessReportGenerator extends AbstractReportGeneratorService {
                                         : ExitStatus.byExitCode(proc.exitValue());
 
                         if (fs.exists(reportStatsPath)) {
-                            ReportStats stats =
-                                    gson.fromJson(fs.readFile(reportStatsPath), ReportStats.class);
-                            evt.setRecordingSizeBytes(stats.getRecordingSizeBytes());
-                            evt.setRulesEvaluated(stats.getRulesEvaluated());
-                            evt.setRulesApplicable(stats.getRulesApplicable());
+                            try (BufferedReader br = fs.readFile(reportStatsPath)) {
+                                ReportStats stats = gson.fromJson(br, ReportStats.class);
+                                evt.setRecordingSizeBytes(stats.getRecordingSizeBytes());
+                                evt.setRulesEvaluated(stats.getRulesEvaluated());
+                                evt.setRulesApplicable(stats.getRulesApplicable());
+                            }
                         }
 
                         switch (status) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -38,6 +38,7 @@
 package io.cryostat.recordings;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -354,8 +355,9 @@ public class RecordingArchiveHelper {
                 for (String file : fs.listDirectoryChildren(subdirectory)) {
                     // use metadata file to determine connectUrl to probe for jvmId
                     if (file.equals(CONNECT_URL)) {
-                        connectUrl =
-                                Optional.of(fs.readFile(subdirectory.resolve(file)).readLine());
+                        try (BufferedReader r = fs.readFile(subdirectory.resolve(file))) {
+                            connectUrl = Optional.of(r.readLine());
+                        }
                     }
                 }
                 future.complete(connectUrl.orElseThrow(IOException::new));

--- a/src/main/java/io/cryostat/rules/RuleRegistry.java
+++ b/src/main/java/io/cryostat/rules/RuleRegistry.java
@@ -95,7 +95,16 @@ public class RuleRegistry extends AbstractEventEmitter<RuleEvent, Rule> {
                             }
                         })
                 .filter(Objects::nonNull)
-                .map(reader -> gson.fromJson(reader, Rule.class))
+                .map(
+                        reader -> {
+                            try (reader) {
+                                return gson.fromJson(reader, Rule.class);
+                            } catch (IOException ioe) {
+                                logger.error(ioe);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
                 .forEach(rules::add);
     }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1444
Depends on https://github.com/cryostatio/cryostat-core/pull/207 (these changes are really separate, but I want to update `-core` and include that dependency update in this same PR for simplicity)

## Description of the change:
This simply closes some file descriptors that are currently leaked.

## Motivation for the change:
Don't leak resources over time.

## How to manually test:
See test procedure in https://github.com/cryostatio/cryostat-core/pull/207 . Same thing applies. `ls -l /proc/$pid/fd` is useful for checking which descriptors look like they've been leaked. I used the following to ease tracing where those descriptors got opened:

https://github.com/jenkinsci/lib-file-leak-detector downloaded and placed into my `cryostat/clientlib` project directory, named as `file-leak-detector.jar`.

```diff
diff --git a/src/main/extras/app/entrypoint.bash b/src/main/extras/app/entrypoint.bash
index cd83fb51..2ed548ef 100755
--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -166,6 +166,8 @@ if [ -n "$CRYOSTAT_JUL_CONFIG" ]; then
     FLAGS+=("-Djava.util.logging.config.file=$CRYOSTAT_JUL_CONFIG")
 fi
 
+FLAGS+=("-javaagent:/clientlib/file-leak-detector.jar=threshold=200,trace,strong")
+```
