### PR TITLE
fix(itests): Fixing integration tests after jmc core upgrade

### DIFF
--- a/src/test/java/itest/ReportIT.java
+++ b/src/test/java/itest/ReportIT.java
@@ -203,12 +203,13 @@ public class ReportIT extends StandardSelfTest {
                             });
             JsonObject jsonResponse = getUnformattedResponse.get();
             MatcherAssert.assertThat(jsonResponse, Matchers.notNullValue());
-            MatcherAssert.assertThat(jsonResponse.getMap(), Matchers.is(Matchers.aMapWithSize(7)));
+            MatcherAssert.assertThat(jsonResponse.getMap(), Matchers.is(Matchers.aMapWithSize(8)));
             Assertions.assertTrue(jsonResponse.containsKey("HeapContent"));
             Assertions.assertTrue(jsonResponse.containsKey("StringDeduplication"));
             Assertions.assertTrue(jsonResponse.containsKey("PrimitiveToObjectConversion"));
             Assertions.assertTrue(jsonResponse.containsKey("GcFreedRatio"));
             Assertions.assertTrue(jsonResponse.containsKey("HighGc"));
+            Assertions.assertTrue(jsonResponse.containsKey("HeapDump"));
             Assertions.assertTrue(jsonResponse.containsKey("Allocations.class"));
             Assertions.assertTrue(jsonResponse.containsKey("LowOnPhysicalMemory"));
             for (var obj : jsonResponse.getMap().entrySet()) {

--- a/src/test/java/itest/TargetReportIT.java
+++ b/src/test/java/itest/TargetReportIT.java
@@ -182,7 +182,7 @@ public class TargetReportIT extends StandardSelfTest {
 
             JsonObject jsonResponse = getUnformattedResponse.get();
             MatcherAssert.assertThat(jsonResponse, Matchers.notNullValue());
-            MatcherAssert.assertThat(jsonResponse.getMap(), Matchers.is(Matchers.aMapWithSize(7)));
+            MatcherAssert.assertThat(jsonResponse.getMap(), Matchers.is(Matchers.aMapWithSize(8)));
             Assertions.assertTrue(jsonResponse.containsKey("HeapContent"));
             Assertions.assertTrue(jsonResponse.containsKey("StringDeduplication"));
             Assertions.assertTrue(jsonResponse.containsKey("PrimitiveToObjectConversion"));
@@ -190,6 +190,7 @@ public class TargetReportIT extends StandardSelfTest {
             Assertions.assertTrue(jsonResponse.containsKey("HighGc"));
             Assertions.assertTrue(jsonResponse.containsKey("Allocations.class"));
             Assertions.assertTrue(jsonResponse.containsKey("LowOnPhysicalMemory"));
+            Assertions.assertTrue(jsonResponse.containsKey("HeapDump"));
             for (var obj : jsonResponse.getMap().entrySet()) {
                 var value = JsonObject.mapFrom(obj.getValue());
                 Assertions.assertTrue(value.containsKey("score"));


### PR DESCRIPTION
Fixes the integration tests after upgrading to jmc-core 8.2.0, there's an extra rule being run (the heap dump rule) so this adjusts the integration tests to check for it.

Depends on https://github.com/cryostatio/cryostat-core/pull/201