### PR TITLE
fix(rules): credential-activated rules no longer activate on targets with the rule already active

### DIFF
--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -345,10 +345,11 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
             boolean sameTarget = Objects.equals(entry.getKey().getLeft(), serviceRef);
             if (sameRule || sameTarget) {
                 Set<Long> ids = entry.getValue();
-                ids.forEach((id) -> {
-                    vertx.cancelTimer(id);
-                    logger.trace("Cancelled timer {}", id);
-                });
+                ids.forEach(
+                        (id) -> {
+                            vertx.cancelTimer(id);
+                            logger.trace("Cancelled timer {}", id);
+                        });
                 it.remove();
             }
         }

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -251,6 +251,13 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                     rule.isEnabled());
             return;
         }
+        if (tasks.containsKey(Pair.of(serviceRef, rule))) {
+            this.logger.trace(
+                    "Activating rule {} for target {} aborted, rule is already active",
+                    rule.getName(),
+                    serviceRef.getServiceUri());
+            return;
+        }
         this.logger.trace(
                 "Activating rule {} for target {}", rule.getName(), serviceRef.getServiceUri());
 
@@ -338,7 +345,10 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
             boolean sameTarget = Objects.equals(entry.getKey().getLeft(), serviceRef);
             if (sameRule || sameTarget) {
                 Set<Long> ids = entry.getValue();
-                ids.forEach(vertx::cancelTimer);
+                ids.forEach((id) -> {
+                    vertx.cancelTimer(id);
+                    logger.trace("Cancelled timer {}", id);
+                });
                 it.remove();
             }
         }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1288 

## Description of the change:
The change fixes a bug where a listener which listened for the adding of new credentials, actually activated rules on matched targets even if they were already active.

## How to manually test:
Follow the steps outlined in #1288 
