### PR TITLE
fix(archive-directories): fix incorrect data in archived directory get response

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -2431,24 +2431,6 @@ The handler-specific descriptions below describe how each handler populates the
 | Upload a recording from archive to the Grafana datasource                 | [`RecordingUploadPostHandler`](#RecordingUploadPostHandler-1)                           |
 
 ### Miscellaneous
-* #### `JvmIdGetHandler`
-
-    ##### synopsis
-    Get the unique jvmId for a target JVM. This is a unique identifier for the JVM, and is used to map targetIds their corresponding JVMs.
-
-    ##### request
-    `GET /api/beta/targets/:targetId`
-
-    ##### response
-    `200` - The result is the jvmId.
-
-    `500` - The requested target JVM cannot be reached.
-
-    ##### example
-    ```
-    $ curl http://localhost:8181/api/beta/targets/localhost:0
-    {"meta":{"type":"text/plain","status":"OK"},"data":{"result":"bIeUvB77jlm7MpIAPVhDtqesTNX9a63zLW8IUZFfUug="}}
-    ```
 ### Recordings in Target JVMs
 * #### `TargetRecordingMetadataLabelsPostHandler`
 

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -748,7 +748,7 @@ public class RecordingArchiveHelper {
                                         })
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
-                directories.add(new ArchiveDirectory(targetId, subdirectoryName, temp));
+                directories.add(new ArchiveDirectory(targetId, jvmId, temp));
             }
             future.complete(directories);
         } catch (ArchivePathException | IOException | InterruptedException | ExecutionException e) {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -748,7 +748,7 @@ public class RecordingArchiveHelper {
                                         })
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
-                directories.add(new ArchiveDirectory(subdirectoryName, targetId, jvmId, temp));
+                directories.add(new ArchiveDirectory(targetId, jvmId, temp));
             }
             future.complete(directories);
         } catch (ArchivePathException | IOException | InterruptedException | ExecutionException e) {
@@ -1285,24 +1285,15 @@ public class RecordingArchiveHelper {
                         + " constructed upon request so it wouldn't matter even if somehow the List"
                         + " was modified")
     public static class ArchiveDirectory {
-        private final String directoryName;
         private final String connectUrl;
         private final String jvmId;
         private final List<ArchivedRecordingInfo> recordings;
 
         public ArchiveDirectory(
-                String directoryName,
-                String connectUrl,
-                String jvmId,
-                List<ArchivedRecordingInfo> recordings) {
-            this.directoryName = directoryName;
+                String connectUrl, String jvmId, List<ArchivedRecordingInfo> recordings) {
             this.connectUrl = connectUrl;
             this.jvmId = jvmId;
             this.recordings = recordings;
-        }
-
-        public String getDirectoryName() {
-            return directoryName;
         }
 
         public String getConnectUrl() {

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -748,7 +748,7 @@ public class RecordingArchiveHelper {
                                         })
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
-                directories.add(new ArchiveDirectory(targetId, jvmId, temp));
+                directories.add(new ArchiveDirectory(subdirectoryName, targetId, jvmId, temp));
             }
             future.complete(directories);
         } catch (ArchivePathException | IOException | InterruptedException | ExecutionException e) {
@@ -1285,15 +1285,24 @@ public class RecordingArchiveHelper {
                         + " constructed upon request so it wouldn't matter even if somehow the List"
                         + " was modified")
     public static class ArchiveDirectory {
+        private final String directoryName;
         private final String connectUrl;
         private final String jvmId;
         private final List<ArchivedRecordingInfo> recordings;
 
         public ArchiveDirectory(
-                String connectUrl, String jvmId, List<ArchivedRecordingInfo> recordings) {
+                String directoryName,
+                String connectUrl,
+                String jvmId,
+                List<ArchivedRecordingInfo> recordings) {
+            this.directoryName = directoryName;
             this.connectUrl = connectUrl;
             this.jvmId = jvmId;
             this.recordings = recordings;
+        }
+
+        public String getDirectoryName() {
+            return directoryName;
         }
 
         public String getConnectUrl() {

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -484,7 +484,6 @@ class DiscoveryStorageTest {
 
             TargetDiscoveryEvent modifiedEvent =
                     new TargetDiscoveryEvent(EventKind.MODIFIED, nextServiceRef);
-            System.out.println(modifiedEvent.getServiceRef());
             MatcherAssert.assertThat(discoveryEvents, Matchers.contains(modifiedEvent));
         }
     }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ArchivedDirectoriesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ArchivedDirectoriesGetHandlerTest.java
@@ -146,10 +146,7 @@ class ArchivedDirectoriesGetHandlerTest {
         listFuture.complete(
                 List.of(
                         new ArchiveDirectory(
-                                "directory",
-                                "encodedServiceUriFoo",
-                                "someJvmId",
-                                List.of(recording))));
+                                "encodedServiceUriFoo", "someJvmId", List.of(recording))));
         Mockito.when(recordingArchiveHelper.getRecordingsAndDirectories()).thenReturn(listFuture);
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
@@ -164,6 +161,6 @@ class ArchivedDirectoriesGetHandlerTest {
 
         Mockito.verify(resp)
                 .end(
-                        "[{\"directoryName\":\"directory\",\"connectUrl\":\"encodedServiceUriFoo\",\"jvmId\":\"someJvmId\",\"recordings\":[{\"downloadUrl\":\"/some/path/download/recordingFoo\",\"name\":\"recordingFoo\",\"reportUrl\":\"/some/path/archive/recordingFoo\",\"metadata\":{\"labels\":{}},\"size\":0,\"archivedTime\":0}]}]");
+                        "[{\"connectUrl\":\"encodedServiceUriFoo\",\"jvmId\":\"someJvmId\",\"recordings\":[{\"downloadUrl\":\"/some/path/download/recordingFoo\",\"name\":\"recordingFoo\",\"reportUrl\":\"/some/path/archive/recordingFoo\",\"metadata\":{\"labels\":{}},\"size\":0,\"archivedTime\":0}]}]");
     }
 }

--- a/src/test/java/io/cryostat/net/web/http/api/beta/ArchivedDirectoriesGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/beta/ArchivedDirectoriesGetHandlerTest.java
@@ -146,7 +146,10 @@ class ArchivedDirectoriesGetHandlerTest {
         listFuture.complete(
                 List.of(
                         new ArchiveDirectory(
-                                "encodedServiceUriFoo", "someJvmId", List.of(recording))));
+                                "directory",
+                                "encodedServiceUriFoo",
+                                "someJvmId",
+                                List.of(recording))));
         Mockito.when(recordingArchiveHelper.getRecordingsAndDirectories()).thenReturn(listFuture);
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
@@ -161,6 +164,6 @@ class ArchivedDirectoriesGetHandlerTest {
 
         Mockito.verify(resp)
                 .end(
-                        "[{\"connectUrl\":\"encodedServiceUriFoo\",\"jvmId\":\"someJvmId\",\"recordings\":[{\"downloadUrl\":\"/some/path/download/recordingFoo\",\"name\":\"recordingFoo\",\"reportUrl\":\"/some/path/archive/recordingFoo\",\"metadata\":{\"labels\":{}},\"size\":0,\"archivedTime\":0}]}]");
+                        "[{\"directoryName\":\"directory\",\"connectUrl\":\"encodedServiceUriFoo\",\"jvmId\":\"someJvmId\",\"recordings\":[{\"downloadUrl\":\"/some/path/download/recordingFoo\",\"name\":\"recordingFoo\",\"reportUrl\":\"/some/path/archive/recordingFoo\",\"metadata\":{\"labels\":{}},\"size\":0,\"archivedTime\":0}]}]");
     }
 }

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -134,6 +134,8 @@ class RecordingArchiveHelperTest {
                 .thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.message(Mockito.any())).thenReturn(notificationBuilder);
         lenient().when(notificationBuilder.build()).thenReturn(notification);
+
+        /* subdirectoryName is actually the base32 encoded jvmId, but for testing purposes they are equal */
         lenient()
                 .when(jvmIdHelper.jvmIdToSubdirectoryName(Mockito.anyString()))
                 .thenAnswer(
@@ -1141,7 +1143,6 @@ class RecordingArchiveHelperTest {
         List<ArchiveDirectory> expected =
                 List.of(
                         new ArchiveDirectory(
-                                "encodedJvmIdA",
                                 "connectUrlA",
                                 "encodedJvmIdA",
                                 List.of(
@@ -1154,7 +1155,6 @@ class RecordingArchiveHelperTest {
                                                 0,
                                                 0))),
                         new ArchiveDirectory(
-                                "encodedJvmId123",
                                 "connectUrl123",
                                 "encodedJvmId123",
                                 List.of(
@@ -1169,18 +1169,12 @@ class RecordingArchiveHelperTest {
 
         MatcherAssert.assertThat(result, Matchers.hasSize(2));
         MatcherAssert.assertThat(
-                result.get(0).getDirectoryName(),
-                Matchers.equalTo(expected.get(0).getDirectoryName()));
-        MatcherAssert.assertThat(
                 result.get(0).getConnectUrl(), Matchers.equalTo(expected.get(0).getConnectUrl()));
         MatcherAssert.assertThat(
                 result.get(0).getJvmId(), Matchers.equalTo(expected.get(0).getJvmId()));
         MatcherAssert.assertThat(
                 result.get(0).getRecordings(), Matchers.equalTo(expected.get(0).getRecordings()));
 
-        MatcherAssert.assertThat(
-                result.get(1).getDirectoryName(),
-                Matchers.equalTo(expected.get(1).getDirectoryName()));
         MatcherAssert.assertThat(
                 result.get(1).getConnectUrl(), Matchers.equalTo(expected.get(1).getConnectUrl()));
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingArchiveHelperTest.java
@@ -1141,6 +1141,7 @@ class RecordingArchiveHelperTest {
         List<ArchiveDirectory> expected =
                 List.of(
                         new ArchiveDirectory(
+                                "encodedJvmIdA",
                                 "connectUrlA",
                                 "encodedJvmIdA",
                                 List.of(
@@ -1153,6 +1154,7 @@ class RecordingArchiveHelperTest {
                                                 0,
                                                 0))),
                         new ArchiveDirectory(
+                                "encodedJvmId123",
                                 "connectUrl123",
                                 "encodedJvmId123",
                                 List.of(
@@ -1167,19 +1169,24 @@ class RecordingArchiveHelperTest {
 
         MatcherAssert.assertThat(result, Matchers.hasSize(2));
         MatcherAssert.assertThat(
+                result.get(0).getDirectoryName(),
+                Matchers.equalTo(expected.get(0).getDirectoryName()));
+        MatcherAssert.assertThat(
                 result.get(0).getConnectUrl(), Matchers.equalTo(expected.get(0).getConnectUrl()));
         MatcherAssert.assertThat(
                 result.get(0).getJvmId(), Matchers.equalTo(expected.get(0).getJvmId()));
         MatcherAssert.assertThat(
                 result.get(0).getRecordings(), Matchers.equalTo(expected.get(0).getRecordings()));
+
+        MatcherAssert.assertThat(
+                result.get(1).getDirectoryName(),
+                Matchers.equalTo(expected.get(1).getDirectoryName()));
         MatcherAssert.assertThat(
                 result.get(1).getConnectUrl(), Matchers.equalTo(expected.get(1).getConnectUrl()));
         MatcherAssert.assertThat(
                 result.get(1).getJvmId(), Matchers.equalTo(expected.get(1).getJvmId()));
         MatcherAssert.assertThat(
                 result.get(1).getRecordings(), Matchers.equalTo(expected.get(1).getRecordings()));
-
-        recordingArchiveHelper.getRecordingsAndDirectories().get();
     }
 
     @Test

--- a/src/test/java/itest/FileSystemArchivedRequestsIT.java
+++ b/src/test/java/itest/FileSystemArchivedRequestsIT.java
@@ -116,7 +116,7 @@ public class FileSystemArchivedRequestsIT extends JwtAssetsSelfTest {
             MatcherAssert.assertThat(labels, Matchers.equalTo(expectedLabels));
 
             // post metadata fromPath
-            subdirectoryName = dir.getString("jvmId");
+            subdirectoryName = dir.getString("directoryName");
             String recordingName = archivedRecording.getString("name");
             Map<String, String> uploadMetadata = Map.of("label", "test");
             CompletableFuture<JsonObject> metadataFuture = new CompletableFuture<>();

--- a/src/test/java/itest/FileSystemArchivedRequestsIT.java
+++ b/src/test/java/itest/FileSystemArchivedRequestsIT.java
@@ -40,6 +40,7 @@ package itest;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -60,6 +61,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import itest.bases.JwtAssetsSelfTest;
 import itest.util.Podman;
+import org.apache.commons.codec.binary.Base32;
 import org.apache.http.client.utils.URIBuilder;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -68,6 +70,7 @@ import org.junit.jupiter.api.Test;
 
 public class FileSystemArchivedRequestsIT extends JwtAssetsSelfTest {
     private static final Gson gson = MainModule.provideGson(Logger.INSTANCE);
+    private static final Base32 base32 = new Base32();
 
     static final String TEST_RECORDING_NAME = "FileSystemArchivedRequestsIT";
 
@@ -116,7 +119,8 @@ public class FileSystemArchivedRequestsIT extends JwtAssetsSelfTest {
             MatcherAssert.assertThat(labels, Matchers.equalTo(expectedLabels));
 
             // post metadata fromPath
-            subdirectoryName = dir.getString("directoryName");
+            subdirectoryName =
+                    base32.encodeAsString(dir.getString("jvmId").getBytes(StandardCharsets.UTF_8));
             String recordingName = archivedRecording.getString("name");
             Map<String, String> uploadMetadata = Map.of("label", "test");
             CompletableFuture<JsonObject> metadataFuture = new CompletableFuture<>();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related https://github.com/cryostatio/cryostat/pull/1110

## Description of the change:
Prior to this bug fix, the web ui would render the wrong data. (It was rendering the base32 encoding of the jvmId hash in the tooltip instead of the hash itself.)

Fixed: 
![image](https://user-images.githubusercontent.com/69827283/232880504-fb0fa7fa-a7bd-404b-bf2b-400d116abd36.png)
![image](https://user-images.githubusercontent.com/69827283/232880694-e5c5fd08-3121-4b77-a5c3-c525cbdfb308.png)


This should change nothing else other than the http response from the associated get handler.