### PR TITLE
chore(vertx): avoid deprecated methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1065,7 +1065,7 @@
                 <goal>yarn</goal>
               </goals>
               <configuration>
-                <arguments>install --immutable --immutable-cache</arguments>
+                <arguments>install --immutable</arguments>
               </configuration>
             </execution>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1065,9 +1065,7 @@
                 <goal>yarn</goal>
               </goals>
               <configuration>
-                <arguments>
-                  install --frozen-lockfile
-                </arguments>
+                <arguments>install --immutable --immutable-cache</arguments>
               </configuration>
             </execution>
             <execution>

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandler.java
@@ -114,7 +114,7 @@ public class TargetRecordingPatchHandler extends AbstractAuthenticatedRequestHan
 
     @Override
     public void handleAuthenticated(RoutingContext ctx) throws Exception {
-        String mtd = ctx.getBodyAsString();
+        String mtd = ctx.body().asString();
 
         if (mtd == null) {
             throw new HttpException(400, "Unsupported null operation");

--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
@@ -121,7 +121,7 @@ class DiscoveryPostHandler extends AbstractDiscoveryJwtConsumingHandler<Void> {
             UUID id =
                     this.uuidFromString.apply(
                             StringUtil.requireNonBlank(ctx.pathParam("id"), "id"));
-            String body = ctx.getBodyAsString();
+            String body = ctx.body().asString();
             Set<AbstractNode> nodes =
                     gson.fromJson(
                             StringUtil.requireNonBlank(body, "body"),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/RequestParameters.java
@@ -128,7 +128,7 @@ public class RequestParameters {
             fileUploads.addAll(ctx.fileUploads());
         }
 
-        String body = ctx.getBodyAsString();
+        String body = ctx.body().asString();
 
         return new RequestParameters(
                 acceptableContentType,

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/GraphQLPostHandler.java
@@ -110,7 +110,7 @@ class GraphQLPostHandler implements RequestHandler {
         } catch (InterruptedException | ExecutionException e) {
             throw new ApiException(500, e);
         }
-        JsonObject body = ctx.getBodyAsJson();
+        JsonObject body = ctx.body().asJsonObject();
         logger.info("GraphQL query: {}", body.getString("query"));
         this.handler.handle(ctx);
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingPatchHandlerTest.java
@@ -50,6 +50,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
 import org.hamcrest.MatcherAssert;
@@ -130,7 +131,9 @@ class TargetRecordingPatchHandlerTest {
     void shouldThrow400InvalidOperations(String mtd) {
         Mockito.when(authManager.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
-        Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
+        Mockito.when(body.asString()).thenReturn(mtd);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(
                         resp.putHeader(
@@ -149,7 +152,9 @@ class TargetRecordingPatchHandlerTest {
         Mockito.when(ctx.pathParam("targetId")).thenReturn("fooHost:1234");
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-        Mockito.when(ctx.getBodyAsString()).thenReturn(mtd);
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
+        Mockito.when(body.asString()).thenReturn(mtd);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(
                         resp.putHeader(

--- a/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/AbstractV2RequestHandlerTest.java
@@ -69,6 +69,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -109,6 +110,7 @@ class AbstractV2RequestHandlerTest {
         Mockito.lenient().when(req.headers()).thenReturn(headers);
         Mockito.lenient().when(ctx.request()).thenReturn(req);
         Mockito.lenient().when(ctx.response()).thenReturn(resp);
+        Mockito.lenient().when(ctx.body()).thenReturn(Mockito.mock(RequestBody.class));
 
         this.handler = new AuthenticatedHandler(auth, credentialsManager, gson);
     }

--- a/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/CertificatePostHandlerTest.java
@@ -72,6 +72,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -148,6 +149,8 @@ class CertificatePostHandlerTest {
     @Test
     void shouldThrow400IfNoCertInRequest() {
         Mockito.when(ctx.fileUploads()).thenReturn(List.of());
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
         MatcherAssert.assertThat(ex.getStatusCode(), Matchers.equalTo(400));
     }
@@ -155,6 +158,8 @@ class CertificatePostHandlerTest {
     @Test
     void shouldThrow500IfNoTruststoreDirSet() {
         Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(env.hasEnv(Mockito.any())).thenReturn(false);
         ApiException ex = Assertions.assertThrows(ApiException.class, () -> handler.handle(ctx));
@@ -164,6 +169,8 @@ class CertificatePostHandlerTest {
     @Test
     void shouldThrow409IfCertAlreadyExists() {
         Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -181,6 +188,8 @@ class CertificatePostHandlerTest {
     @Test
     void shouldThrowExceptionIfCertIsMalformed() throws Exception {
         Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");
@@ -205,6 +214,8 @@ class CertificatePostHandlerTest {
     @Test
     void shouldAddCertToTruststore() throws Exception {
         Mockito.when(ctx.fileUploads()).thenReturn(List.of(fu));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
         Mockito.when(fu.name()).thenReturn("cert");
         Mockito.when(fu.fileName()).thenReturn("certificate.cer");
         Mockito.when(fu.uploadedFileName()).thenReturn("/temp/temp.cer");

--- a/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandlerTest.java
@@ -60,6 +60,7 @@ import com.google.gson.Gson;
 import com.nimbusds.jwt.JWT;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -156,7 +157,9 @@ class DiscoveryPostHandlerTest {
         void shouldThrowIfBodyJsonInvalid(String json) throws Exception {
             UUID uuid = UUID.randomUUID();
             Mockito.when(ctx.pathParam("id")).thenReturn(uuid.toString());
-            Mockito.when(ctx.getBodyAsString()).thenReturn(json);
+            RequestBody body = Mockito.mock(RequestBody.class);
+            Mockito.when(ctx.body()).thenReturn(body);
+            Mockito.when(body.asString()).thenReturn(json);
 
             ApiException ex =
                     Assertions.assertThrows(

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
@@ -37,9 +37,6 @@
  */
 package io.cryostat.net.web.http.api.v2;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -65,6 +62,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -114,21 +112,21 @@ class TargetRecordingOptionsListGetHandlerTest {
 
     @Test
     void shouldRespondWithRecordingOptionsList() throws Exception {
-        IOptionDescriptor<String> descriptor = mock(IOptionDescriptor.class);
-        when(descriptor.getName()).thenReturn("foo");
-        when(descriptor.getDescription()).thenReturn("Foo Option");
-        when(descriptor.getDefault()).thenReturn("bar");
+        IOptionDescriptor<String> descriptor = Mockito.mock(IOptionDescriptor.class);
+        Mockito.when(descriptor.getName()).thenReturn("foo");
+        Mockito.when(descriptor.getDescription()).thenReturn("Foo Option");
+        Mockito.when(descriptor.getDefault()).thenReturn("bar");
         Map<String, IOptionDescriptor<?>> options = Map.of("foo-option", descriptor);
 
-        when(targetConnectionManager.executeConnectedTask(
+        Mockito.when(targetConnectionManager.executeConnectedTask(
                         Mockito.any(ConnectionDescriptor.class), Mockito.any()))
                 .thenAnswer(
                         arg0 ->
                                 ((TargetConnectionManager.ConnectedTask<Object>)
                                                 arg0.getArgument(1))
                                         .execute(connection));
-        when(connection.getService()).thenReturn(service);
-        when(service.getAvailableRecordingOptions()).thenReturn(options);
+        Mockito.when(connection.getService()).thenReturn(service);
+        Mockito.when(service.getAvailableRecordingOptions()).thenReturn(options);
 
         RoutingContext ctx = Mockito.mock(RoutingContext.class);
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
@@ -137,6 +135,8 @@ class TargetRecordingOptionsListGetHandlerTest {
         HttpServerRequest req = Mockito.mock(HttpServerRequest.class);
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
 
         Mockito.when(auth.validateHttpHeader(Mockito.any(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(true));

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetRecordingOptionsListGetHandlerTest.java
@@ -118,8 +118,9 @@ class TargetRecordingOptionsListGetHandlerTest {
         Mockito.when(descriptor.getDefault()).thenReturn("bar");
         Map<String, IOptionDescriptor<?>> options = Map.of("foo-option", descriptor);
 
-        Mockito.when(targetConnectionManager.executeConnectedTask(
-                        Mockito.any(ConnectionDescriptor.class), Mockito.any()))
+        Mockito.when(
+                        targetConnectionManager.executeConnectedTask(
+                                Mockito.any(ConnectionDescriptor.class), Mockito.any()))
                 .thenAnswer(
                         arg0 ->
                                 ((TargetConnectionManager.ConnectedTask<Object>)

--- a/src/test/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/TargetSnapshotPostHandlerTest.java
@@ -64,6 +64,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -113,6 +114,8 @@ class TargetSnapshotPostHandlerTest {
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", "someHost"));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
 
         IRecordingDescriptor minimalDescriptor = createDescriptor("snapshot-1");
         HyperlinkedSerializableRecordingDescriptor snapshotDescriptor =
@@ -182,6 +185,8 @@ class TargetSnapshotPostHandlerTest {
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", "someHost"));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
 
         CompletableFuture<HyperlinkedSerializableRecordingDescriptor> future1 =
                 Mockito.mock(CompletableFuture.class);
@@ -207,6 +212,8 @@ class TargetSnapshotPostHandlerTest {
         Mockito.when(ctx.request()).thenReturn(req);
         Mockito.when(req.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
         Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", "someHost"));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
 
         IRecordingDescriptor minimalDescriptor = createDescriptor("snapshot-1");
         HyperlinkedSerializableRecordingDescriptor snapshotDescriptor =
@@ -248,6 +255,8 @@ class TargetSnapshotPostHandlerTest {
         HttpServerResponse resp = Mockito.mock(HttpServerResponse.class);
         Mockito.when(ctx.response()).thenReturn(resp);
         Mockito.when(ctx.pathParams()).thenReturn(Map.of("targetId", "someHost"));
+        RequestBody body = Mockito.mock(RequestBody.class);
+        Mockito.when(ctx.body()).thenReturn(body);
 
         IRecordingDescriptor minimalDescriptor = createDescriptor("snapshot-1");
         HyperlinkedSerializableRecordingDescriptor snapshotDescriptor =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1203

## Description of the change:
This clears deprecation warnings from the Vert.x 4.3.0 upgrade.

## Motivation for the change:
Deprecated code may be removed so we should no longer rely on it.

## How to manually test:
1. `mvn compile compile`
2. Verify output that no deprecation warnings appear for Vert.x Web methods.
