### PR TITLE
fix(discovery): fix broken DISABLE_BUILTIN_DISCOVERY env var

### DIFF
--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -82,6 +82,9 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
     public void start(Promise<Void> start) {
         storage.addTargetDiscoveryListener(this);
 
+        logger.info("unselected: {}", unselectedStrategies);
+        logger.info("selected: {}", selectedStrategies);
+
         unselectedStrategies.stream()
                 .map(PlatformDetectionStrategy::getPlatformClient)
                 .forEach(

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -82,9 +82,6 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
     public void start(Promise<Void> start) {
         storage.addTargetDiscoveryListener(this);
 
-        logger.info("unselected: {}", unselectedStrategies);
-        logger.info("selected: {}", selectedStrategies);
-
         unselectedStrategies.stream()
                 .map(PlatformDetectionStrategy::getPlatformClient)
                 .forEach(

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -68,8 +67,8 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
 
     BuiltInDiscovery(
             DiscoveryStorage storage,
-            SortedSet<PlatformDetectionStrategy<?>> selectedStrategies,
-            SortedSet<PlatformDetectionStrategy<?>> unselectedStrategies,
+            Set<PlatformDetectionStrategy<?>> selectedStrategies,
+            Set<PlatformDetectionStrategy<?>> unselectedStrategies,
             NotificationFactory notificationFactory,
             Logger logger) {
         this.storage = storage;

--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -53,7 +53,6 @@ import io.cryostat.core.sys.Environment;
 import io.cryostat.messaging.notifications.NotificationFactory;
 import io.cryostat.platform.PlatformModule;
 import io.cryostat.platform.discovery.AbstractNode;
-import io.cryostat.platform.internal.CustomTargetPlatformClient;
 import io.cryostat.platform.internal.PlatformDetectionStrategy;
 import io.cryostat.recordings.JvmIdHelper;
 import io.cryostat.rules.MatchExpressionEvaluator;
@@ -122,16 +121,10 @@ public abstract class DiscoveryModule {
                     SortedSet<PlatformDetectionStrategy<?>> selectedStrategies,
             @Named(PlatformModule.UNSELECTED_PLATFORMS)
                     SortedSet<PlatformDetectionStrategy<?>> unselectedStrategies,
-            Lazy<CustomTargetPlatformClient> customTargets,
             NotificationFactory notificationFactory,
             Logger logger) {
         return new BuiltInDiscovery(
-                storage,
-                selectedStrategies,
-                unselectedStrategies,
-                customTargets,
-                notificationFactory,
-                logger);
+                storage, selectedStrategies, unselectedStrategies, notificationFactory, logger);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -39,7 +39,6 @@ package io.cryostat.discovery;
 
 import java.time.Duration;
 import java.util.Set;
-import java.util.SortedSet;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -118,9 +117,9 @@ public abstract class DiscoveryModule {
     static BuiltInDiscovery provideBuiltInDiscovery(
             DiscoveryStorage storage,
             @Named(PlatformModule.SELECTED_PLATFORMS)
-                    SortedSet<PlatformDetectionStrategy<?>> selectedStrategies,
+                    Set<PlatformDetectionStrategy<?>> selectedStrategies,
             @Named(PlatformModule.UNSELECTED_PLATFORMS)
-                    SortedSet<PlatformDetectionStrategy<?>> unselectedStrategies,
+                    Set<PlatformDetectionStrategy<?>> unselectedStrategies,
             NotificationFactory notificationFactory,
             Logger logger) {
         return new BuiltInDiscovery(

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -165,7 +165,7 @@ public abstract class NetworkModule {
 
     @Provides
     @Singleton
-    static Vertx provideVertx(Logger logger) {
+    static Vertx provideVertx() {
         return Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
     }
 

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -166,7 +166,6 @@ public abstract class NetworkModule {
     @Provides
     @Singleton
     static Vertx provideVertx(Logger logger) {
-        logger.info("providing vertx with native transport");
         return Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
     }
 

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -165,7 +165,8 @@ public abstract class NetworkModule {
 
     @Provides
     @Singleton
-    static Vertx provideVertx() {
+    static Vertx provideVertx(Logger logger) {
+        logger.info("providing vertx with native transport");
         return Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
     }
 

--- a/src/main/java/io/cryostat/platform/PlatformModule.java
+++ b/src/main/java/io/cryostat/platform/PlatformModule.java
@@ -44,6 +44,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -105,8 +107,6 @@ public abstract class PlatformModule {
             CustomTargetPlatformStrategy customTargets,
             Set<PlatformDetectionStrategy<?>> platformStrategies,
             Environment env) {
-        Set<PlatformDetectionStrategy<?>> selectedStrategies = new HashSet<>();
-        selectedStrategies.add(customTargets);
         Predicate<PlatformDetectionStrategy<?>> fn;
         if (env.hasEnv(Variables.PLATFORM_STRATEGY_ENV_VAR)) {
             List<String> platforms =
@@ -117,8 +117,8 @@ public abstract class PlatformModule {
         } else {
             fn = PlatformDetectionStrategy::isAvailable;
         }
-        platformStrategies.stream().filter(fn).forEach(selectedStrategies::add);
-        return selectedStrategies;
+        return Stream.concat(Stream.of(customTargets), platformStrategies.stream().filter(fn))
+                .collect(Collectors.toSet());
     }
 
     @Provides

--- a/src/main/java/io/cryostat/platform/PlatformModule.java
+++ b/src/main/java/io/cryostat/platform/PlatformModule.java
@@ -117,11 +117,7 @@ public abstract class PlatformModule {
         } else {
             fn = PlatformDetectionStrategy::isAvailable;
         }
-        for (PlatformDetectionStrategy<?> s : platformStrategies) {
-            if (fn.test(s)) {
-                selectedStrategies.add(s);
-            }
-        }
+        platformStrategies.stream().filter(fn).forEach(selectedStrategies::add);
         return selectedStrategies;
     }
 

--- a/src/main/java/io/cryostat/platform/PlatformModule.java
+++ b/src/main/java/io/cryostat/platform/PlatformModule.java
@@ -38,12 +38,11 @@
 package io.cryostat.platform;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import javax.inject.Named;
@@ -102,13 +101,11 @@ public abstract class PlatformModule {
     @Provides
     @Singleton
     @Named(SELECTED_PLATFORMS)
-    static SortedSet<PlatformDetectionStrategy<?>> provideSelectedPlatformStrategies(
+    static Set<PlatformDetectionStrategy<?>> provideSelectedPlatformStrategies(
             CustomTargetPlatformStrategy customTargets,
             Set<PlatformDetectionStrategy<?>> platformStrategies,
             Environment env) {
-        // reverse sort, higher priorities should be earlier in the stream
-        SortedSet<PlatformDetectionStrategy<?>> selectedStrategies =
-                new TreeSet<>((a, b) -> Integer.compare(b.getPriority(), a.getPriority()));
+        Set<PlatformDetectionStrategy<?>> selectedStrategies = new HashSet<>();
         selectedStrategies.add(customTargets);
         Predicate<PlatformDetectionStrategy<?>> fn;
         if (env.hasEnv(Variables.PLATFORM_STRATEGY_ENV_VAR)) {
@@ -131,11 +128,10 @@ public abstract class PlatformModule {
     @Provides
     @Singleton
     @Named(UNSELECTED_PLATFORMS)
-    static SortedSet<PlatformDetectionStrategy<?>> provideUnselectedPlatformStrategies(
-            @Named(SELECTED_PLATFORMS) SortedSet<PlatformDetectionStrategy<?>> selectedStrategies,
+    static Set<PlatformDetectionStrategy<?>> provideUnselectedPlatformStrategies(
+            @Named(SELECTED_PLATFORMS) Set<PlatformDetectionStrategy<?>> selectedStrategies,
             Set<PlatformDetectionStrategy<?>> platformStrategies) {
-        SortedSet<PlatformDetectionStrategy<?>> unselected =
-                new TreeSet<>((a, b) -> Integer.compare(b.getPriority(), a.getPriority()));
+        Set<PlatformDetectionStrategy<?>> unselected = new HashSet<>();
         unselected.addAll(platformStrategies);
         unselected.removeAll(selectedStrategies);
         return unselected;
@@ -144,7 +140,7 @@ public abstract class PlatformModule {
     @Provides
     @Singleton
     static PlatformDetectionStrategy<?> providePlatformStrategy(
-            @Named(SELECTED_PLATFORMS) SortedSet<PlatformDetectionStrategy<?>> selectedStrategies,
+            @Named(SELECTED_PLATFORMS) Set<PlatformDetectionStrategy<?>> selectedStrategies,
             Set<PlatformDetectionStrategy<?>> strategies) {
         return selectedStrategies.stream()
                 .findFirst()
@@ -155,11 +151,6 @@ public abstract class PlatformModule {
                                                 "No selected platforms found. Available platforms:"
                                                         + " %s",
                                                 strategies.stream()
-                                                        .sorted(
-                                                                (a, b) ->
-                                                                        Integer.compare(
-                                                                                b.getPriority(),
-                                                                                a.getPriority()))
                                                         .map(s -> s.getClass().getCanonicalName())
                                                         .toList())));
     }

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformStrategy.java
@@ -59,11 +59,6 @@ public class CustomTargetPlatformStrategy
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_DEFAULT;
-    }
-
-    @Override
     public boolean isAvailable() {
         return true;
     }

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
@@ -59,11 +59,6 @@ class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatfo
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_DEFAULT;
-    }
-
-    @Override
     public boolean isAvailable() {
         return true;
     }

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -81,11 +81,6 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_PLATFORM + 10;
-    }
-
-    @Override
     public boolean isAvailable() {
         logger.trace("Testing {} Availability", getClass().getSimpleName());
         try (KubernetesClient client = createClient()) {

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -59,11 +59,6 @@ class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_PLATFORM + 15;
-    }
-
-    @Override
     protected boolean testAvailability(KubernetesClient client) {
         return super.testAvailability(client) && (((OpenShiftClient) client).isSupported());
     }

--- a/src/main/java/io/cryostat/platform/internal/PlatformDetectionStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformDetectionStrategy.java
@@ -41,11 +41,6 @@ import io.cryostat.net.AuthManager;
 import io.cryostat.platform.PlatformClient;
 
 public interface PlatformDetectionStrategy<T extends PlatformClient> {
-    int PRIORITY_DEFAULT = 0;
-    int PRIORITY_PLATFORM = 50;
-
-    int getPriority();
-
     boolean isAvailable();
 
     T getPlatformClient();

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -51,14 +51,14 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
 
     private final Logger logger;
     private final Lazy<? extends AuthManager> authMgr;
-    private final Vertx vertx;
+    private final Lazy<Vertx> vertx;
     private final Gson gson;
     private final FileSystem fs;
 
     PodmanPlatformStrategy(
             Logger logger,
             Lazy<? extends AuthManager> authMgr,
-            Vertx vertx,
+            Lazy<Vertx> vertx,
             Gson gson,
             FileSystem fs) {
         this.logger = logger;

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -69,11 +69,6 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_PLATFORM + 5;
-    }
-
-    @Override
     public boolean isAvailable() {
         String socketPath = getSocketPath();
         logger.info("Testing {} Availability via {}", getClass().getSimpleName(), socketPath);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1505

## Description of the change:
This does some refactoring to ensure that the Custom Targets functionality is always available, even when the environment variable `CRYOSTAT_DISABLE_BUILTIN_DISCOVERY` is set, and so that setting that environment variable does not result in a startup-blocking exception.

## Motivation for the change:
It may be useful in some situations to disable the built-in discovery mechanisms entirely. A Cryostat instance locked down in this way can be sure to never discover any target applications other than ones registered manually using Custom Targets, or ones configured using the Cryostat Agent.

## How to manually test:
1. `CRYOSTAT_IMAGE=quay.io... CRYOSTAT_DISABLE_BUILTIN_DISCOVERY=true sh smoketest.sh`
2. Verify that the container started successfully
3. `https :8181/api/v2.1/discovery` to ensure that only the Custom Targets Realm is reported
