### PR TITLE
fix(podman): more reliable and informative platform check

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ appended to Cryostat's classpath. This path should be a directory within a
 volume mounted to the Cryostat container and containing library JARs (ex.
 `jboss-client.jar`) in a flat structure.
 
+In the particular case of WildFly `remote+http`, you might do something like
+the following to add this capability:
+
+```bash
+$ podman cp wildfly:/opt/jboss/wildfly/bin/client/jboss-client.jar clientlib/
+```
+
 ## EVENT TEMPLATES
 
 JDK Flight Recorder has event templates, which are preset definition of a set of

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -39,6 +39,7 @@ package io.cryostat.platform.internal;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.cryostat.core.log.Logger;
@@ -56,9 +57,19 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.ElementsIntoSet;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 
 @Module
 public abstract class PlatformStrategyModule {
+
+    public static final String UNIX_SOCKET_WEBCLIENT = "UNIX_SOCKET_WEBCLIENT";
+
+    @Provides
+    @Singleton
+    @Named(UNIX_SOCKET_WEBCLIENT)
+    static WebClient provideUnixSocketWebClient(Vertx vertx) {
+        return WebClient.create(vertx);
+    }
 
     @Provides
     @Singleton
@@ -103,10 +114,11 @@ public abstract class PlatformStrategyModule {
     static PodmanPlatformStrategy providePodmanPlatformStrategy(
             Logger logger,
             Lazy<NoopAuthManager> noopAuthManager,
+            @Named(UNIX_SOCKET_WEBCLIENT) Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             Gson gson,
             FileSystem fs) {
-        return new PodmanPlatformStrategy(logger, noopAuthManager, vertx, gson, fs);
+        return new PodmanPlatformStrategy(logger, noopAuthManager, webClient, vertx, gson, fs);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
@@ -83,8 +83,8 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
     public static final String REALM = "Podman";
     public static final String CRYOSTAT_LABEL = "io.cryostat.connectUrl";
 
+    private final Lazy<WebClient> webClient;
     private final Lazy<Vertx> vertx;
-    private WebClient webClient;
     private final Gson gson;
     private final SocketAddress podmanSocket;
     private final Logger logger;
@@ -92,7 +92,13 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
 
     private final CopyOnWriteArrayList<ContainerSpec> containers = new CopyOnWriteArrayList<>();
 
-    PodmanPlatformClient(Lazy<Vertx> vertx, SocketAddress podmanSocket, Gson gson, Logger logger) {
+    PodmanPlatformClient(
+            Lazy<WebClient> webClient,
+            Lazy<Vertx> vertx,
+            SocketAddress podmanSocket,
+            Gson gson,
+            Logger logger) {
+        this.webClient = webClient;
         this.vertx = vertx;
         this.podmanSocket = podmanSocket;
         this.gson = gson;
@@ -161,7 +167,8 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
         vertx.get()
                 .executeBlocking(
                         promise ->
-                                webClient()
+                                webClient
+                                        .get()
                                         .request(
                                                 HttpMethod.GET,
                                                 podmanSocket,
@@ -266,13 +273,6 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
         }
         children.addAll(pods.values());
         return new EnvironmentNode(REALM, BaseNodeType.REALM, Collections.emptyMap(), children);
-    }
-
-    private WebClient webClient() {
-        if (this.webClient == null) {
-            this.webClient = WebClient.create(this.vertx.get());
-        }
-        return webClient;
     }
 
     static record PortSpec(

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -37,6 +37,13 @@
  */
 package io.cryostat.platform.internal;
 
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
@@ -44,9 +51,12 @@ import io.cryostat.net.AuthManager;
 import com.google.gson.Gson;
 import com.sun.security.auth.module.UnixSystem;
 import dagger.Lazy;
+import io.netty.channel.epoll.Epoll;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
 
 class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatformClient> {
 
@@ -76,10 +86,57 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     public boolean isAvailable() {
         String socketPath = getSocketPath();
         logger.info("Testing {} Availability via {}", getClass().getSimpleName(), socketPath);
-        // TODO check that the service is actually available on the socket using an HTTP request
-        boolean available = fs.isReadable(fs.pathOf(socketPath));
+
+        boolean socketExists = fs.isReadable(fs.pathOf(socketPath));
+        boolean nativeEnabled = vertx.get().isNativeTransportEnabled();
+
+        if (!nativeEnabled && !Epoll.isAvailable()) {
+            Epoll.unavailabilityCause().printStackTrace();
+        }
+
+        boolean serviceReachable = false;
+        if (socketExists && nativeEnabled) {
+            serviceReachable = testPodmanApi();
+        }
+
+        boolean available = socketExists && nativeEnabled && serviceReachable;
         logger.info("{} available? {}", getClass().getSimpleName(), available);
         return available;
+    }
+
+    private boolean testPodmanApi() {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        URI requestPath = URI.create("http://d/info");
+        Executors.newSingleThreadExecutor()
+                .submit(
+                        () -> {
+                            webClient
+                                    .get()
+                                    .request(
+                                            HttpMethod.GET,
+                                            getSocket(),
+                                            80,
+                                            "localhost",
+                                            requestPath.toString())
+                                    .timeout(2_000L)
+                                    .as(BodyCodec.none())
+                                    .send(
+                                            ar -> {
+                                                if (ar.failed()) {
+                                                    Throwable t = ar.cause();
+                                                    logger.info("Podman API request failed", t);
+                                                    result.complete(false);
+                                                    return;
+                                                }
+                                                result.complete(true);
+                                            });
+                        });
+        try {
+            return result.get(2, TimeUnit.SECONDS);
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            logger.error(e);
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1510
Related to #1503

## Description of the change:
This does some cleanup and refactoring around the Podman platform strategy/client.

## Motivation for the change:
After this change, Podman strategy selection is more reliable since it checks more required factors before assuming that the `libpod` API is really reachable. If the check cannot be performed due to unavailability of Unix sockets (via netty native transport) then an informative stack trace will be printed.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. `https :8181/api/v2.1/discovery` and ensure that the Podman Realm is still populated as normal.
3. Follow the directions in the `README` to put a `jboss-client.jar` into `clientlib/` and restart the Cryostat server. There is already a `wildfly` container in the `smoketest.sh` setup.
4. Check the logs for an exception about a conflict between the `netty` JAR and the `jboss-client.jar`.
