### PR TITLE
feat(podman): use labels to specify JMX port and optionally host

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -122,8 +122,10 @@ podman run \
     --pod cryostat-pod \
     --name cryostat \
     --user 0 \
+    --label io.cryostat.discovery="true" \
     --label io.cryostat.jmxHost="localhost" \
     --label io.cryostat.jmxPort="0" \
+    --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi" \
     --memory 768M \
     --mount type=bind,source="$(dirname "$0")/archive",destination=/opt/cryostat.d/recordings.d,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/certs",destination=/certs,relabel=shared \

--- a/run.sh
+++ b/run.sh
@@ -122,7 +122,8 @@ podman run \
     --pod cryostat-pod \
     --name cryostat \
     --user 0 \
-    --label io.cryostat.connectUrl="service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi" \
+    --label io.cryostat.jmxHost="localhost" \
+    --label io.cryostat.jmxPort="0" \
     --memory 768M \
     --mount type=bind,source="$(dirname "$0")/archive",destination=/opt/cryostat.d/recordings.d,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/certs",destination=/certs,relabel=shared \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -122,7 +122,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
-        --label io.cryostat.connectUrl="service:jmx:rmi:///jndi/rmi://localhost:9093/jmxrmi" \
+        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxPort="9093" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
 
     podman run \
@@ -140,7 +141,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
-        --label io.cryostat.connectUrl="service:jmx:rmi:///jndi/rmi://localhost:9094/jmxrmi" \
+        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxPort="9094" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
 
     podman run \
@@ -159,7 +161,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
-        --label io.cryostat.connectUrl="service:jmx:rmi:///jndi/rmi://localhost:9095/jmxrmi" \
+        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxPort="9095" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
 
     # this config is broken on purpose (missing required env vars) to test the agent's behaviour
@@ -268,7 +271,8 @@ runReportGenerator() {
         --name reports \
         --pull "${PULL_IMAGES}" \
         --pod cryostat-pod \
-        --label io.cryostat.connectUrl="service:jmx:rmi:///jndi/rmi://localhost:${RJMX_PORT}/jmxrmi" \
+        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxPort="${RJMX_PORT}" \
         --cpus 1 \
         --memory 512M \
         --restart on-failure \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -122,6 +122,7 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
+        --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="9093" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
@@ -141,8 +142,10 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
+        --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="9094" \
+        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9094/jmxrmi" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
 
     podman run \
@@ -161,8 +164,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
-        --label io.cryostat.jmxHost="localhost" \
-        --label io.cryostat.jmxPort="9095" \
+        --label io.cryostat.discovery="true" \
+        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9095/jmxrmi" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
 
     # this config is broken on purpose (missing required env vars) to test the agent's behaviour
@@ -271,6 +274,7 @@ runReportGenerator() {
         --name reports \
         --pull "${PULL_IMAGES}" \
         --pod cryostat-pod \
+        --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="${RJMX_PORT}" \
         --cpus 1 \

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -116,9 +116,11 @@ public abstract class PlatformStrategyModule {
             Lazy<NoopAuthManager> noopAuthManager,
             @Named(UNIX_SOCKET_WEBCLIENT) Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
+            Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
             FileSystem fs) {
-        return new PodmanPlatformStrategy(logger, noopAuthManager, webClient, vertx, gson, fs);
+        return new PodmanPlatformStrategy(
+                logger, noopAuthManager, webClient, vertx, connectionToolkit, gson, fs);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
@@ -270,7 +270,7 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
                     jmxPort = connectUrl.getPort();
                 }
             } else {
-                jmxPort = Integer.valueOf(desc.Labels.get(JMX_PORT_LABEL));
+                jmxPort = Integer.parseInt(desc.Labels.get(JMX_PORT_LABEL));
                 hostname = desc.Labels.get(JMX_HOST_LABEL);
                 if (hostname == null) {
                     try {

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
@@ -305,7 +305,7 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
             serviceRef.setLabels(desc.Labels);
 
             return serviceRef;
-        } catch (URISyntaxException | MalformedURLException e) {
+        } catch (NumberFormatException | URISyntaxException | MalformedURLException e) {
             logger.warn(e);
             return null;
         }

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import io.cryostat.core.log.Logger;
+import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
@@ -64,6 +65,7 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     private final Lazy<? extends AuthManager> authMgr;
     private final Lazy<WebClient> webClient;
     private final Lazy<Vertx> vertx;
+    private final Lazy<JFRConnectionToolkit> connectionToolkit;
     private final Gson gson;
     private final FileSystem fs;
 
@@ -72,12 +74,14 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
             Lazy<? extends AuthManager> authMgr,
             Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
+            Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
             FileSystem fs) {
         this.logger = logger;
         this.authMgr = authMgr;
         this.webClient = webClient;
         this.vertx = vertx;
+        this.connectionToolkit = connectionToolkit;
         this.gson = gson;
         this.fs = fs;
     }
@@ -142,7 +146,14 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     @Override
     public PodmanPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
-        return new PodmanPlatformClient(webClient, vertx, getSocket(), gson, logger);
+        return new PodmanPlatformClient(
+                Executors.newSingleThreadExecutor(),
+                webClient,
+                vertx,
+                getSocket(),
+                connectionToolkit,
+                gson,
+                logger);
     }
 
     @Override


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1513
Depends on #1511
Related to #1503
Related to #1394

## Description of the change:
This updates the `PodmanPlatformClient` to discover target JMX URLs as follows:
1. Query for containers with the `io.cryostat.discovery` label, then:
2. Check for the `io.cryostat.jmxUrl` label. If it is present, use that. Else continue:
3. Check for the `io.cryostat.jmxPort` label. If it is present, use this to construct the JMX URL.
4. Check for the `io.cryostat.jmxHost` label. If it is not present, default to retrieving the container's hostname from the Podman API. Use this with the `jmxPort` above to construct the JMX URL.

Since there are now two main routes (`jmxUrl`, which replaces the previous `connectUrl`, or `jmxHost`+`jmxPort`), and the Podman HTTP API does not support querying for containers that have any of a list of labels applied, there is a new required label: `io.cryostat.discovery`. This label may have any value. This is the label that Cryostat now queries for against the Podman HTTP API to discover containers.

## Motivation for the change:
As described in #1513, this allows for Podman Discovery to be more flexible and support cases where the container hostname is not known statically when the target application container is started.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Check that everything still appears in the various discovery API endpoints and Topology view.
3. Change some applications' `--label`s in `smoketest.sh` or `run.sh` according to the description above and ensure they are still picked up after a restart.
