### PR TITLE
feat(GraphQL): Add GraphQL filter ability for node name from set

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ActiveRecordingsFetcher.java
@@ -100,6 +100,14 @@ class ActiveRecordingsFetcher extends AbstractPermissionedDataFetcher<Active> {
                             .filter(r -> Objects.equals(r.getName(), recordingName))
                             .collect(Collectors.toList());
         }
+        if (filter.contains(FilterInput.Key.NAMES)) {
+            List<String> recordingNames = filter.get(FilterInput.Key.NAMES);
+            recordings =
+                    recordings.stream()
+                            .filter(r -> recordingNames.contains(r.getName()))
+                            .collect(Collectors.toList());
+        }
+
         if (filter.contains(FilterInput.Key.LABELS)) {
             List<String> labels = filter.get(FilterInput.Key.LABELS);
             for (String label : labels) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/ArchivedRecordingsFetcher.java
@@ -99,6 +99,14 @@ class ArchivedRecordingsFetcher extends AbstractPermissionedDataFetcher<Archived
                             .filter(r -> Objects.equals(r.getName(), recordingName))
                             .collect(Collectors.toList());
         }
+        if (filter.contains(FilterInput.Key.NAMES)) {
+            List<String> names = filter.get(FilterInput.Key.NAMES);
+            recordings =
+                    recordings.stream()
+                            .filter(r -> names.contains(r.getName()))
+                            .collect(Collectors.toList());
+        }
+
         if (filter.contains(FilterInput.Key.LABELS)) {
             List<String> labels = filter.get(FilterInput.Key.LABELS);
             for (String label : labels) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/EnvironmentNodesFetcher.java
@@ -103,6 +103,11 @@ class EnvironmentNodesFetcher extends AbstractPermissionedDataFetcher<List<Envir
             nodes = filter(nodes, n -> Objects.equals(n.getName(), nodeName));
         }
 
+        if (filter.contains(FilterInput.Key.NAMES)) {
+            List<String> names = filter.get(FilterInput.Key.NAMES);
+            nodes = filter(nodes, n -> names.contains(n.getName()));
+        }
+
         if (filter.contains(FilterInput.Key.LABELS)) {
             List<String> labels = filter.get(FilterInput.Key.LABELS);
             for (String label : labels) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/FilterInput.java
@@ -67,6 +67,7 @@ class FilterInput {
     enum Key {
         ID("id"),
         NAME("name"),
+        NAMES("names"),
         LABELS("labels"),
         ANNOTATIONS("annotations"),
         SOURCE_TARGET("sourceTarget"),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcher.java
@@ -110,6 +110,13 @@ class TargetNodesFetcher extends AbstractPermissionedDataFetcher<List<TargetNode
                             .filter(n -> Objects.equals(n.getName(), nodeName))
                             .collect(Collectors.toList());
         }
+        if (filter.contains(FilterInput.Key.NAMES)) {
+            List<String> names = filter.get(FilterInput.Key.NAMES);
+            result =
+                    result.stream()
+                            .filter(n -> names.contains(n.getName()))
+                            .collect(Collectors.toList());
+        }
         if (filter.contains(FilterInput.Key.LABELS)) {
             List<String> labels = filter.get(FilterInput.Key.LABELS);
             for (String label : labels) {

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -10,6 +10,7 @@ scalar Float
 input EnvironmentNodeFilterInput {
     id: Int
     name: String
+    names: [String]
     nodeType: String
     labels: [String]
 }
@@ -17,6 +18,7 @@ input EnvironmentNodeFilterInput {
 input TargetNodesFilterInput {
     id: Int
     name: String
+    names: [String]
     labels: [String]
     annotations: [String]
 }
@@ -24,12 +26,14 @@ input TargetNodesFilterInput {
 input DescendantTargetsFilterInput {
     id: Int
     name: String
+    names: [String]
     labels: [String]
     annotations: [String]
 }
 
 input ActiveRecordingFilterInput {
     name: String
+    names: [String]
     state: String
     continuous: Boolean
     toDisk: Boolean
@@ -42,6 +46,7 @@ input ActiveRecordingFilterInput {
 
 input ArchivedRecordingFilterInput {
     name: String
+    names: [String]
     labels: [String]
     sourceTarget: String
     sizeBytesGreaterThanEqual: Long

--- a/src/test/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcherTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v2/graph/TargetNodesFetcherTest.java
@@ -151,24 +151,28 @@ class TargetNodesFetcherTest {
                         .thenReturn(CompletableFuture.completedFuture(true));
 
                 when(filter.contains(Mockito.any())).thenReturn(false);
-                when(filter.contains(FilterInput.Key.NAME)).thenReturn(true);
-                when(filter.get(FilterInput.Key.NAME)).thenReturn("foo");
+                when(filter.contains(FilterInput.Key.NAMES)).thenReturn(true);
+                when(filter.get(FilterInput.Key.NAMES)).thenReturn(List.of("foo", "bar", "baz"));
 
                 TargetNode target1 = Mockito.mock(TargetNode.class);
                 TargetNode target2 = Mockito.mock(TargetNode.class);
                 TargetNode target3 = Mockito.mock(TargetNode.class);
+                TargetNode target4 = Mockito.mock(TargetNode.class);
+                TargetNode target5 = Mockito.mock(TargetNode.class);
 
                 when(target1.getName()).thenReturn("foo");
                 when(target2.getName()).thenReturn("foobar");
                 when(target3.getName()).thenReturn("foo");
+                when(target4.getName()).thenReturn("bar");
+                when(target5.getName()).thenReturn("baz");
 
                 when(recurseFetcher.get(Mockito.any()))
-                        .thenReturn(List.of(target1, target2, target3));
+                        .thenReturn(List.of(target1, target2, target3, target4, target5));
 
                 List<TargetNode> nodes = fetcher.get(env);
 
                 MatcherAssert.assertThat(nodes, Matchers.notNullValue());
-                MatcherAssert.assertThat(nodes, Matchers.containsInAnyOrder(target1, target3));
+                MatcherAssert.assertThat(nodes, Matchers.hasItems(target1, target4, target5));
             }
         }
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1433

## Description of the change:
*This change adds allows filtering of multiple names instead of just one name*

## Motivation for the change:
*This change is helpful because one can now filter multiple matching names with just one request instead of filtering one name at time for each request*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. * mvn clean verify *
3. * mvn clean verify -Dit=tests=GraphQLIT.java*
