### PR TITLE
chore(smoketest): update container versions for latest cryostat-agent

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -125,7 +125,7 @@ runDemoApps() {
         --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="9093" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.3
 
     podman run \
         --name vertx-fib-demo-2 \
@@ -146,7 +146,7 @@ runDemoApps() {
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="9094" \
         --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9094/jmxrmi" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.3
 
     podman run \
         --name vertx-fib-demo-3 \
@@ -166,7 +166,7 @@ runDemoApps() {
         --pod cryostat-pod \
         --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9095/jmxrmi" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.2
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.12.3
 
     # this config is broken on purpose (missing required env vars) to test the agent's behaviour
     # when not properly set up


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-agent/pull/135

## Description of the change:
Updates `vertx-fib-demo` container images to one that includes latest `cryostat-agent` version.

## Motivation for the change:
See linked issue

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Check Security view and ensure that the agents' stored credentials refer to their own callback URLs / HTTP API URLs, not the target JVM ID
