### PR TITLE
fix(podman): fix blocked thread on container inspection request

### DIFF
--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
@@ -79,7 +79,6 @@ import dagger.Lazy;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.codec.BodyCodec;
 import org.apache.commons.lang3.StringUtils;
@@ -168,53 +167,57 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
 
                     containers.removeAll(removed);
                     removed.stream()
+                            .map(this::convert)
                             .filter(Objects::nonNull)
-                            .forEach(
-                                    spec ->
-                                            notifyAsyncTargetDiscovery(
-                                                    EventKind.LOST, convert(spec)));
+                            .forEach(spec -> notifyAsyncTargetDiscovery(EventKind.LOST, spec));
 
                     containers.addAll(added);
                     added.stream()
+                            .map(this::convert)
                             .filter(Objects::nonNull)
-                            .forEach(
-                                    spec ->
-                                            notifyAsyncTargetDiscovery(
-                                                    EventKind.FOUND, convert(spec)));
+                            .forEach(spec -> notifyAsyncTargetDiscovery(EventKind.FOUND, spec));
                 });
     }
 
     private void doPodmanListRequest(Consumer<List<ContainerSpec>> successHandler) {
         URI requestPath = URI.create("http://d/v3.0.0/libpod/containers/json");
-        executor.submit(
-                () ->
-                        webClient
-                                .get()
-                                .request(
-                                        HttpMethod.GET,
-                                        podmanSocket,
-                                        80,
-                                        "localhost",
-                                        requestPath.toString())
-                                .addQueryParam(
-                                        "filters",
-                                        gson.toJson(Map.of("label", List.of(DISCOVERY_LABEL))))
-                                .timeout(2_000L)
-                                .as(BodyCodec.string())
-                                .send(
-                                        ar -> {
-                                            if (ar.failed()) {
-                                                Throwable t = ar.cause();
-                                                logger.error("Podman API request failed", t);
-                                                return;
-                                            }
-                                            HttpResponse<String> response = ar.result();
-                                            successHandler.accept(
-                                                    gson.fromJson(
-                                                            response.body(),
-                                                            new TypeToken<
-                                                                    List<ContainerSpec>>() {}));
-                                        }));
+        vertx.get()
+                .<String>executeBlocking(
+                        promise -> {
+                            webClient
+                                    .get()
+                                    .request(
+                                            HttpMethod.GET,
+                                            podmanSocket,
+                                            80,
+                                            "localhost",
+                                            requestPath.toString())
+                                    .addQueryParam(
+                                            "filters",
+                                            gson.toJson(Map.of("label", List.of(DISCOVERY_LABEL))))
+                                    .timeout(2_000L)
+                                    .as(BodyCodec.string())
+                                    .send(
+                                            ar -> {
+                                                if (ar.failed()) {
+                                                    Throwable t = ar.cause();
+                                                    promise.fail(t);
+                                                    return;
+                                                }
+                                                promise.complete(ar.result().body());
+                                            });
+                        },
+                        true,
+                        ar -> {
+                            if (ar.failed()) {
+                                Throwable t = ar.cause();
+                                logger.error("Podman API request failed", t);
+                                return;
+                            }
+                            successHandler.accept(
+                                    gson.fromJson(
+                                            ar.result(), new TypeToken<List<ContainerSpec>>() {}));
+                        });
     }
 
     private CompletableFuture<ContainerDetails> doPodmanInspectRequest(ContainerSpec container) {
@@ -232,9 +235,6 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
                                     80,
                                     "localhost",
                                     requestPath.toString())
-                            .addQueryParam(
-                                    "filters",
-                                    gson.toJson(Map.of("label", List.of(JMX_PORT_LABEL))))
                             .timeout(2_000L)
                             .as(BodyCodec.string())
                             .send(
@@ -245,10 +245,10 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
                                             result.completeExceptionally(t);
                                             return;
                                         }
-                                        HttpResponse<String> response = ar.result();
                                         result.complete(
                                                 gson.fromJson(
-                                                        response.body(), ContainerDetails.class));
+                                                        ar.result().body(),
+                                                        ContainerDetails.class));
                                     });
                 });
         return result;
@@ -280,6 +280,7 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
                                         .Config
                                         .Hostname;
                     } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                        containers.remove(desc);
                         logger.warn(e);
                         return null;
                     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1514

## Description of the change:
Executes the Podman API request for listing containers on the Vert.x worker pool, and the subtask request for inspecting individual containers (if needed: no `jmxHost` label or `jmxUrl` label) on a worker thread.

## Motivation for the change:
This fixes a bug where the executor thread gets blocked when it needs to list containers and then further inspect them. This blockage results in failure of the platform client to discover containers.

## How to manually test:
1. Apply the patch below, then:
2. *Run CRYOSTAT_IMAGE=quay.io... sh run.sh...*

```patch
diff --git a/run.sh b/run.sh
index 9d322386..e58ca4f7 100755
--- a/run.sh
+++ b/run.sh
@@ -123,9 +123,7 @@ podman run \
     --name cryostat \
     --user 0 \
     --label io.cryostat.discovery="true" \
-    --label io.cryostat.jmxHost="localhost" \
-    --label io.cryostat.jmxPort="0" \
-    --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi" \
+    --label io.cryostat.jmxPort="${CRYOSTAT_RJMX_PORT}" \
     --memory 768M \
     --mount type=bind,source="$(dirname "$0")/archive",destination=/opt/cryostat.d/recordings.d,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/certs",destination=/certs,relabel=shared \
@@ -136,7 +134,7 @@ podman run \
     --mount type=bind,source="$(dirname "$0")/probes",destination=/opt/cryostat.d/conf.d/probes.d,relabel=shared \
     -v "$XDG_RUNTIME_DIR"/podman/podman.sock:/run/user/0/podman/podman.sock:Z \
     --security-opt label=disable \
-    -e CRYOSTAT_ENABLE_JDP_BROADCAST="true" \
+    -e CRYOSTAT_ENABLE_JDP_BROADCAST="false" \
     -e CRYOSTAT_REPORT_GENERATOR="$CRYOSTAT_REPORT_GENERATOR" \
     -e CRYOSTAT_PLATFORM="$CRYOSTAT_PLATFORM" \
     -e CRYOSTAT_DISABLE_BUILTIN_DISCOVERY="$CRYOSTAT_DISABLE_BUILTIN_DISCOVERY" \
```
