### PR TITLE
fix(podman): fix blocked thread on container inspection request

### DIFF
--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -40,7 +40,7 @@ package io.cryostat.platform.internal;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -111,7 +111,7 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     private boolean testPodmanApi() {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         URI requestPath = URI.create("http://d/info");
-        Executors.newSingleThreadExecutor()
+        ForkJoinPool.commonPool()
                 .submit(
                         () -> {
                             webClient
@@ -147,7 +147,7 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     public PodmanPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         return new PodmanPlatformClient(
-                Executors.newSingleThreadExecutor(),
+                ForkJoinPool.commonPool(),
                 webClient,
                 vertx,
                 getSocket(),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1514

## Description of the change:
Executes the Podman API request for listing containers on the Vert.x context, and the subtask request for inspecting individual containers (if needed: no jmxHost label or jmxUrl label) on a worker thread.

## Motivation for the change:
This fixes a bug where the executor thread gets blocked when it needs to list containers and then further inspect them. This blockage results in failure of the platform client to discover containers.

## How to manually test:
1. Apply the patch below, then:
2. Run CRYOSTAT_IMAGE=quay.io... sh run.sh...

```patch
diff --git a/run.sh b/run.sh
index 9d322386..e58ca4f7 100755
--- a/run.sh
+++ b/run.sh
@@ -123,9 +123,7 @@ podman run \
     --name cryostat \
     --user 0 \
     --label io.cryostat.discovery="true" \
-    --label io.cryostat.jmxHost="localhost" \
-    --label io.cryostat.jmxPort="0" \
-    --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi" \
+    --label io.cryostat.jmxPort="${CRYOSTAT_RJMX_PORT}" \
     --memory 768M \
     --mount type=bind,source="$(dirname "$0")/archive",destination=/opt/cryostat.d/recordings.d,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/certs",destination=/certs,relabel=shared \
@@ -136,7 +134,7 @@ podman run \
     --mount type=bind,source="$(dirname "$0")/probes",destination=/opt/cryostat.d/conf.d/probes.d,relabel=shared \
     -v "$XDG_RUNTIME_DIR"/podman/podman.sock:/run/user/0/podman/podman.sock:Z \
     --security-opt label=disable \
-    -e CRYOSTAT_ENABLE_JDP_BROADCAST="true" \
+    -e CRYOSTAT_ENABLE_JDP_BROADCAST="false" \
     -e CRYOSTAT_REPORT_GENERATOR="$CRYOSTAT_REPORT_GENERATOR" \
     -e CRYOSTAT_PLATFORM="$CRYOSTAT_PLATFORM" \
     -e CRYOSTAT_DISABLE_BUILTIN_DISCOVERY="$CRYOSTAT_DISABLE_BUILTIN_DISCOVERY" \
```
