### PR TITLE
test(smoketest): add native image sample app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
   <com.google.dagger.version>2.45</com.google.dagger.version>
   <com.google.dagger.compiler.version>2.45</com.google.dagger.compiler.version>
 
-  <io.cryostat.core.version>2.20.0</io.cryostat.core.version>
+  <io.cryostat.core.version>2.21.0</io.cryostat.core.version>
 
   <org.openjdk.nashorn.core.version>15.4</org.openjdk.nashorn.core.version>
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -310,7 +310,6 @@ createPod() {
         --publish 8081:8081 \
         --publish 8082:8082 \
         --publish 8083:8083 \
-        --publish 9091:9091 \
         --publish 9093:9093 \
         --publish 9094:9094 \
         --publish 9095:9095 \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -293,8 +293,7 @@ runReportGenerator() {
 }
 
 createPod() {
-    local jmxPort; local webPort; local datasourcePort; local grafanaPort;
-    jmxPort="$(getPomProperty cryostat.rjmxPort)"
+    local webPort; local datasourcePort; local grafanaPort;
     webPort="$(getPomProperty cryostat.webPort)"
     datasourcePort="$(getPomProperty cryostat.itest.jfr-datasource.port)"
     grafanaPort="$(getPomProperty cryostat.itest.grafana.port)"
@@ -302,7 +301,6 @@ createPod() {
         --replace \
         --hostname cryostat \
         --name cryostat-pod \
-        --publish "${jmxPort}:${jmxPort}" \
         --publish "${webPort}:${webPort}" \
         --publish "${datasourcePort}:${datasourcePort}" \
         --publish "${grafanaPort}:${grafanaPort}" \
@@ -310,37 +308,18 @@ createPod() {
         --publish 8081:8081 \
         --publish 8082:8082 \
         --publish 8083:8083 \
-        --publish 9093:9093 \
-        --publish 9094:9094 \
-        --publish 9095:9095 \
-        --publish 9096:9096 \
-        --publish 9999:9999 \
         --publish 8082:8082 \
         --publish 9990:9990 \
-        --publish 9991:9991 \
-        --publish 10000:10000 \
         --publish 10001:10001 \
-        --publish 10010:10010 \
-        --publish 51423:51423
+        --publish 10010:10010
     # 5432: postgres
     # 8081: vertx-fib-demo-1 HTTP
     # 8082: vertx-fib-demo-2 HTTP
     # 8083: vertx-fib-demo-3 HTTP
-    # 9093: vertx-fib-demo-1 RJMX
-    # 9094: vertx-fib-demo-2 RJMX
-    # 9095: vertx-fib-demo-3 RJMX
-    # 9097: quarkus-test-agent-1 RJMX
-    # 9098: quarkus-test-agent-2 RJMX
-    # 8082: Wildfly HTTP
     # 9990: Wildfly Admin Console
-    # 9991: Wildfly RJMX
-    # 9977: quarkus-test-agent-1 Agent-HTTP
-    # 9988: quarkus-test-agent-2 Agent-HTTP
-    # 10000: cryostat-reports RJMX
     # 10001: cryostat-reports HTTP
     # 10010: quarkus-test-agent-1 HTTP
     # 10011: quarkus-test-agent-2 HTTP
-    # 51423: jmxquarkus RJMX
 }
 
 destroyPod() {

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -109,6 +109,13 @@ runDemoApps() {
     fi
 
     podman run \
+        --name jmxquarkus \
+        --pod cryostat-pod \
+        --label io.cryostat.discovery="true" \
+        --label io.cryostat.jmxPort="51423" \
+        --rm -d quay.io/roberttoyonaga/jmx:jmxquarkus@sha256:b067f29faa91312d20d43c55d194a2e076de7d0d094da3d43ee7d2b2b5a6f100
+
+    podman run \
         --name vertx-fib-demo-1 \
         --env HTTP_PORT=8081 \
         --env JMX_PORT=9093 \
@@ -303,6 +310,7 @@ createPod() {
         --publish 8081:8081 \
         --publish 8082:8082 \
         --publish 8083:8083 \
+        --publish 9091:9091 \
         --publish 9093:9093 \
         --publish 9094:9094 \
         --publish 9095:9095 \
@@ -313,7 +321,8 @@ createPod() {
         --publish 9991:9991 \
         --publish 10000:10000 \
         --publish 10001:10001 \
-        --publish 10010:10010
+        --publish 10010:10010 \
+        --publish 51423:51423
     # 5432: postgres
     # 8081: vertx-fib-demo-1 HTTP
     # 8082: vertx-fib-demo-2 HTTP
@@ -332,6 +341,7 @@ createPod() {
     # 10001: cryostat-reports HTTP
     # 10010: quarkus-test-agent-1 HTTP
     # 10011: quarkus-test-agent-2 HTTP
+    # 51423: jmxquarkus RJMX
 }
 
 destroyPod() {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-core/issues/217

## Description of the change:
Adds a Quarkus native image sample application to the smoketest.sh.

## Motivation for the change:
This makes it visible and convenient to test Cryostat functionality against a native image target.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
