### PR TITLE
test(itest): improve container startup health detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -644,7 +644,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -661,7 +661,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep -i health; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -644,7 +644,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep -i health; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -661,7 +661,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep -i health; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -644,7 +644,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.jfr-datasource.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -661,7 +661,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.grafana.containerName} | grep healthy; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -503,12 +503,6 @@
               <argument>--name=${cryostat.itest.jfr-datasource.containerName}</argument>
               <argument>--health-cmd</argument>
               <argument>curl --fail http://localhost:${cryostat.itest.jfr-datasource.port}</argument>
-              <argument>--health-startup-interval</argument>
-              <argument>10s</argument>
-              <argument>--health-startup-retries</argument>
-              <argument>3</argument>
-              <argument>--health-start-period</argument>
-              <argument>10s</argument>
               <argument>--detach</argument>
               <argument>--rm</argument>
               <argument>${cryostat.itest.jfr-datasource.imageStream}:${cryostat.itest.jfr-datasource.version}</argument>
@@ -531,12 +525,6 @@
               <argument>--name=${cryostat.itest.grafana.containerName}</argument>
               <argument>--health-cmd</argument>
               <argument>wget -q --spider http://localhost:${cryostat.itest.grafana.port}</argument>
-              <argument>--health-startup-interval</argument>
-              <argument>10s</argument>
-              <argument>--health-startup-retries</argument>
-              <argument>3</argument>
-              <argument>--health-start-period</argument>
-              <argument>10s</argument>
               <argument>--env</argument>
               <argument>GF_INSTALL_PLUGINS=grafana-simple-json-datasource</argument>
               <argument>--env</argument>
@@ -562,12 +550,6 @@
               <argument>--name=${cryostat.itest.containerName}</argument>
               <argument>--health-cmd</argument>
               <argument>curl --fail http://localhost:8181/health/liveness</argument>
-              <argument>--health-startup-interval</argument>
-              <argument>10s</argument>
-              <argument>--health-startup-retries</argument>
-              <argument>3</argument>
-              <argument>--health-start-period</argument>
-              <argument>10s</argument>
               <argument>--requires</argument>
               <argument>${cryostat.itest.grafana.containerName},${cryostat.itest.jfr-datasource.containerName}</argument>
               <argument>--mount</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,7 @@
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=${cryostat.itest.grafana.containerName}</argument>
               <argument>--health-cmd</argument>
-              <argument>wget -q --spider http://localhost:${cryostat.itest.grafana.port}</argument>
+              <argument>wget -q --spider http://localhost:${cryostat.itest.grafana.port}/api/health</argument>
               <argument>--env</argument>
               <argument>GF_INSTALL_PLUGINS=grafana-simple-json-datasource</argument>
               <argument>--env</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,11 @@
   <cryostat.itest.webHost>localhost</cryostat.itest.webHost>
   <cryostat.itest.podName>cryostat-itests</cryostat.itest.podName>
   <cryostat.itest.containerName>cryostat-itest</cryostat.itest.containerName>
+  <cryostat.itest.grafana.containerName>grafana-itest</cryostat.itest.grafana.containerName>
   <cryostat.itest.grafana.port>3000</cryostat.itest.grafana.port>
   <cryostat.itest.grafana.imageStream>quay.io/cryostat/cryostat-grafana-dashboard</cryostat.itest.grafana.imageStream>
   <cryostat.itest.grafana.version>latest</cryostat.itest.grafana.version>
+  <cryostat.itest.jfr-datasource.containerName>jfr-datasource-itest</cryostat.itest.jfr-datasource.containerName>
   <cryostat.itest.jfr-datasource.port>8080</cryostat.itest.jfr-datasource.port>
   <cryostat.itest.jfr-datasource.imageStream>quay.io/cryostat/jfr-datasource</cryostat.itest.jfr-datasource.imageStream>
   <cryostat.itest.jfr-datasource.version>latest</cryostat.itest.jfr-datasource.version>
@@ -498,7 +500,7 @@
               <argument>run</argument>
               <argument>--pull=${cryostat.itest.pullImages}</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
-              <argument>--name=jfr-datasource-itest</argument>
+              <argument>--name=${cryostat.itest.jfr-datasource.containerName}</argument>
               <argument>--health-cmd</argument>
               <argument>curl --fail http://localhost:${cryostat.itest.jfr-datasource.port}</argument>
               <argument>--health-startup-interval</argument>
@@ -526,7 +528,7 @@
               <argument>run</argument>
               <argument>--pull=${cryostat.itest.pullImages}</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
-              <argument>--name=grafana-itest</argument>
+              <argument>--name=${cryostat.itest.grafana.containerName}</argument>
               <argument>--health-cmd</argument>
               <argument>wget -q --spider http://localhost:${cryostat.itest.grafana.port}</argument>
               <argument>--health-startup-interval</argument>
@@ -567,7 +569,7 @@
               <argument>--health-start-period</argument>
               <argument>10s</argument>
               <argument>--requires</argument>
-              <argument>grafana-itest,jfr-datasource-itest</argument>
+              <argument>${cryostat.itest.grafana.containerName},${cryostat.itest.jfr-datasource.containerName}</argument>
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/opt/cryostat.d/conf.d</argument>
               <argument>--mount</argument>
@@ -643,7 +645,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until sleep 5; curl -sSk -o /dev/null http://${cryostat.itest.webHost}:${cryostat.itest.webPort}/health/liveness; do sleep 2; done</argument>
+              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -660,7 +662,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until curl -sSk -o /dev/null http://${cryostat.itest.webHost}:${cryostat.itest.jfr-datasource.port}; do sleep 2; done</argument>
+              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.jfr-datasource.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -677,7 +679,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until curl -sSk -o /dev/null http://${cryostat.itest.webHost}:${cryostat.itest.grafana.port}; do sleep 2; done</argument>
+              <argument>until podman inspect -f '{{.State.Health.Status}}' ${cryostat.itest.grafana.containerName} | grep healthy; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -644,7 +644,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -661,7 +661,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --filter health=healthy --format '{{.Names}}' | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>
+              <argument>until podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,14 @@
               <argument>--pull=${cryostat.itest.pullImages}</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=jfr-datasource-itest</argument>
+              <argument>--health-cmd</argument>
+              <argument>curl --fail http://localhost:${cryostat.itest.jfr-datasource.port}</argument>
+              <argument>--health-startup-interval</argument>
+              <argument>10s</argument>
+              <argument>--health-startup-retries</argument>
+              <argument>3</argument>
+              <argument>--health-start-period</argument>
+              <argument>10s</argument>
               <argument>--detach</argument>
               <argument>--rm</argument>
               <argument>${cryostat.itest.jfr-datasource.imageStream}:${cryostat.itest.jfr-datasource.version}</argument>
@@ -519,6 +527,14 @@
               <argument>--pull=${cryostat.itest.pullImages}</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=grafana-itest</argument>
+              <argument>--health-cmd</argument>
+              <argument>wget -q --spider http://localhost:${cryostat.itest.grafana.port}</argument>
+              <argument>--health-startup-interval</argument>
+              <argument>10s</argument>
+              <argument>--health-startup-retries</argument>
+              <argument>3</argument>
+              <argument>--health-start-period</argument>
+              <argument>10s</argument>
               <argument>--env</argument>
               <argument>GF_INSTALL_PLUGINS=grafana-simple-json-datasource</argument>
               <argument>--env</argument>
@@ -542,6 +558,16 @@
               <argument>run</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=${cryostat.itest.containerName}</argument>
+              <argument>--health-cmd</argument>
+              <argument>curl --fail http://localhost:8181/health/liveness</argument>
+              <argument>--health-startup-interval</argument>
+              <argument>10s</argument>
+              <argument>--health-startup-retries</argument>
+              <argument>3</argument>
+              <argument>--health-start-period</argument>
+              <argument>10s</argument>
+              <argument>--requires</argument>
+              <argument>grafana-itest,jfr-datasource-itest</argument>
               <argument>--mount</argument>
               <argument>type=tmpfs,target=/opt/cryostat.d/conf.d</argument>
               <argument>--mount</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep -i health; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -644,7 +644,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep -i health; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -661,7 +661,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep -i health; do sleep 5; done</argument>
+              <argument>until podman ps --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName} | grep -E -i '^health'; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1533

## Description of the change:
This adds Podman health probes to the containers started for integration testing, and changes the `wait-for-X` executions to query podman's view of container health as a startup check.

## Motivation for the change:
Rather than running a `timeout` command that forks subprocess shells executing `curl` to try to check the container availability externally, this ends up using a process run within the container to check for the service availability, which is reported to podman. From outside the containers we ask podman what the status is. This is less prone to getting into a bad state with `curl` trying to open a connection to the services in the containers when they are not yet ready to accept connections and causing `curl` to time out and therefore fail the startup check and the integration test run. This should make itest startup much more reliable.

## How to manually test:
1. `bash repeated-integration-tests.bash N SomeTestsIT`, where `N` is some large number and `SomeTestsIT` are a subset of tests run simply to ensure basic startup succeeded. `bash repeated-integration-tests.bash 10 HealthIT` for example.
