### PR TITLE
ci(multiarch): build multiarch manifest image

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -7,6 +7,9 @@ on:
       checkout-ref:
         required: false
         type: string
+      build-arch:
+        required: true
+        type: string
     outputs:
       image-version:
         description: the Cryostat application version that will be built
@@ -37,6 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-pom-properties]
     steps:
+    - name: Install qemu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-user-static
     - uses: actions/checkout@v2
       with:
         repository: ${{ inputs.checkout-repo }}
@@ -57,15 +64,15 @@ jobs:
         step: restore
     - run: git submodule init
     - run: git submodule update --remote
-    - run: mvn -B -U clean package
+    - run: mvn -B -U -Dbuild.arch=${{ inputs.build-arch }} clean package
       env:
         GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
     - name: Save cryostat image
-      run: podman save -o cryostat.tar --format oci-archive quay.io/cryostat/cryostat
+      run: podman save -o cryostat-${{ inputs.build-arch }}.tar --format oci-archive quay.io/cryostat/cryostat
     - uses: actions/upload-artifact@v3
       with:
-        name: cryostat
-        path: /home/runner/work/cryostat/cryostat/cryostat.tar
+        name: cryostat-${{ inputs.build-arch }}
+        path: /home/runner/work/cryostat/cryostat/cryostat-${{ inputs.build-arch }}.tar
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save
@@ -86,9 +93,9 @@ jobs:
         distribution: 'temurin'
     - uses: actions/download-artifact@v3
       with:
-        name: cryostat
+        name: cryostat-${{ inputs.build-arch }}
     - name: Load cryostat image
-      run: podman load -i cryostat.tar
+      run: podman load -i cryostat-${{ inputs.build-arch }}.tar
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -22,6 +22,7 @@ jobs:
   build-and-test:
     uses: ./.github/workflows/ci-jobs.yml
     with:
+      build-arch: amd64
       checkout-repo: ${{ github.event.pull_request.head.repo.full_name }}
       checkout-ref: ${{ github.event.pull_request.head.ref }}
     secrets: inherit
@@ -39,10 +40,10 @@ jobs:
       run: exit 1
     - uses: actions/download-artifact@v3
       with:
-        name: cryostat
+        name: cryostat-amd64
       if: github.repository_owner == 'cryostatio'
     - name: Load cryostat image
-      run: podman load -i cryostat.tar
+      run: podman load -i cryostat-amd64.tar
       if: github.repository_owner == 'cryostatio'
     - name: Tag cryostat image
       run: podman tag cryostat ghcr.io/${{ github.repository_owner }}/cryostat:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -12,29 +12,44 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
-  build-and-test:
+  build-and-test-amd64:
     uses: ./.github/workflows/ci-jobs.yml
     secrets: inherit
+    with:
+      build-arch: amd64
+    if: github.repository_owner == 'cryostatio'
+  build-and-test-arm64:
+    uses: ./.github/workflows/ci-jobs.yml
+    secrets: inherit
+    with:
+      build-arch: arm64
     if: github.repository_owner == 'cryostatio'
   push-to-quay:
     runs-on: ubuntu-latest
-    needs: [build-and-test]
+    needs: [build-and-test-amd64, build-and-test-arm64]
     env:
       CRYOSTAT_IMG: quay.io/cryostat/cryostat
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: cryostat
+        name: cryostat-amd64
       if: github.repository_owner == 'cryostatio'
-    - name: Load cryostat image
-      run: podman load -i cryostat.tar
+    - name: Load cryostat-amd64 image
+      run: podman load -i cryostat-amd64.tar
       if: github.repository_owner == 'cryostatio'
-    - name: Tag images
-      id: tag-image
+    - uses: actions/download-artifact@v3
+      with:
+        name: cryostat-arm64
+      if: github.repository_owner == 'cryostatio'
+    - name: Load cryostat-arm64 image
+      run: podman load -i cryostat-arm64.tar
+      if: github.repository_owner == 'cryostatio'
+    - name: Create OCI Manifest
+      id: create-manifest
       env:
-        IMAGE_VERSION: ${{ needs.build-and-test.outputs.image-version }}
+        IMAGE_VERSION: ${{ needs.build-and-test-amd64.outputs.image-version }}
       run: |
-        podman tag $CRYOSTAT_IMG $CRYOSTAT_IMG:$IMAGE_VERSION
+        podman create manifest $CRYOSTAT_IMG:$IMAGE_VERSION $CRYOSTAT_IMG:$IMAGE_VERSION-linux-amd64 $CRYOSTAT_IMG:$IMAGE_VERSION-linux-arm64
         if [ "$GITHUB_REF" == "refs/heads/main" ]; then
           podman tag \
           ${{ env.CRYOSTAT_IMG }}:$IMAGE_VERSION \
@@ -48,7 +63,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat
-        tags: ${{ steps.tag-image.outputs.tags }}
+        tags: ${{ steps.create-manifest.outputs.tags }}
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1352

## Description of the change:
Re-incorporates CI workflow updates that somehow got dropped from previous PR.

## Motivation for the change:
This should hopefully result in multiarch manifest images being pushed to the `quay.io` repository on merge to `main`, and single-arch AMD64 images being built for PR review as usual.
