### PR TITLE
ci(multiarch): better status checks and logging

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -108,6 +108,9 @@ jobs:
     - name: Print itest logs
       if: failure()
       run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat
+    - name: Print itest container logs
+      if: failure()
+      run: ls -1dt target/cryostat-*.server.log | head -n1 | xargs cat
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=${cryostat.itest.containerName}</argument>
               <argument>--health-cmd</argument>
-              <argument>curl --fail http://localhost:8181/health/liveness</argument>
+              <argument>curl --fail http://localhost:${cryostat.itest.webPort}/health/liveness</argument>
               <argument>--requires</argument>
               <argument>${cryostat.itest.grafana.containerName},${cryostat.itest.jfr-datasource.containerName}</argument>
               <argument>--mount</argument>
@@ -631,7 +631,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until if ! podman inspect ${cryostat.itest.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
+              <argument>until if ! podman inspect --type container ${cryostat.itest.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -648,7 +648,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until if ! podman inspect ${cryostat.itest.jfr-datasource.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
+              <argument>until if ! podman inspect --type container ${cryostat.itest.jfr-datasource.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.jfr-datasource.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>
@@ -665,7 +665,7 @@
               <argument>5m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
-              <argument>until if ! podman inspect ${cryostat.itest.grafana.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --format '{{.Names}} {{.Status}}' | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>
+              <argument>until if ! podman inspect --type container ${cryostat.itest.grafana.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.grafana.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,7 @@
           <configuration>
             <executable>timeout</executable>
             <arguments>
-              <argument>5m</argument>
+              <argument>15m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
               <argument>until if ! podman inspect --type container ${cryostat.itest.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.containerName}; do sleep 5; done</argument>
@@ -645,7 +645,7 @@
           <configuration>
             <executable>timeout</executable>
             <arguments>
-              <argument>5m</argument>
+              <argument>15m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
               <argument>until if ! podman inspect --type container ${cryostat.itest.jfr-datasource.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.jfr-datasource.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.jfr-datasource.containerName}; do sleep 5; done</argument>
@@ -662,7 +662,7 @@
           <configuration>
             <executable>timeout</executable>
             <arguments>
-              <argument>5m</argument>
+              <argument>15m</argument>
               <argument>sh</argument>
               <argument>-c</argument>
               <argument>until if ! podman inspect --type container ${cryostat.itest.grafana.containerName} > /dev/null; then exit 1; fi ; podman ps --filter health=healthy --filter name=${cryostat.itest.grafana.containerName} --format '{{.Names}} {{.Status}}' | tee /dev/stderr | grep ${cryostat.itest.grafana.containerName}; do sleep 5; done</argument>

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -59,9 +59,9 @@ STARTFLAGS=(
     "exec:exec@start-jfr-datasource"
     "exec:exec@start-grafana"
     "exec:exec@start-cryostat"
-    "exec:exec@wait-for-cryostat"
     "exec:exec@wait-for-jfr-datasource"
     "exec:exec@wait-for-grafana"
+    "exec:exec@wait-for-cryostat"
     "failsafe:integration-test"
     "failsafe:verify"
 )

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -64,6 +64,7 @@ STARTFLAGS=(
     "exec:exec@wait-for-cryostat"
     "failsafe:integration-test"
     "failsafe:verify"
+    "exec:exec@capture-oci-logs"
 )
 
 if [ -n "$2" ]; then

--- a/repeated-integration-tests.bash
+++ b/repeated-integration-tests.bash
@@ -42,14 +42,6 @@ if [ -z "${PULL_IMAGES}" ]; then
     PULL_IMAGES="always"
 fi
 
-function cleanup() {
-    if podman pod exists "${POD_NAME}"; then
-        "${MVN}" exec:exec@destroy-pod
-    fi
-}
-trap cleanup EXIT
-cleanup
-
 STARTFLAGS=(
     "-DfailIfNoTests=true"
     "-Dcryostat.imageVersion=${ITEST_IMG_VERSION}"
@@ -82,6 +74,14 @@ if command -v ansi2txt >/dev/null; then
 else
     PIPECLEANER="cat"
 fi
+
+function cleanup() {
+    if podman pod exists "${POD_NAME}"; then
+        "${MVN}" "${STOPFLAGS[@]}"
+    fi
+}
+trap cleanup EXIT
+cleanup
 
 DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/run.sh
+++ b/run.sh
@@ -121,6 +121,7 @@ podman run \
     --pod cryostat-pod \
     --name cryostat \
     --user 0 \
+    --health-cmd 'curl -k --fail "http://localhost:${CRYOSTAT_WEB_PORT}/health/liveness" || curl -k --fail "https://localhost:${CRYOSTAT_WEB_PORT}/health/liveness"' \
     --label io.cryostat.discovery="true" \
     --label io.cryostat.jmxHost="localhost" \
     --label io.cryostat.jmxPort="0" \


### PR DESCRIPTION
- test(run.sh): add healthcheck for cryostat container
- test(itest): poll only for relevant container status, echo to stderr for visibility
- fix(itest): wait for container health in same order as startup
- chore(itest): ensure container logs are captured in location expected by CI
- chore(itest): refactor
- ci(logs): print container log file on run failure

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1541
