### PR TITLE
chore(pom): add native dependency for netty on arm64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,9 @@
   <org.apache.httpcomponents.version>4.5.14</org.apache.httpcomponents.version>
   <io.fabric8.client.version>6.3.1</io.fabric8.client.version>
   <io.vertx.web.version>4.4.4</io.vertx.web.version>
+  <!-- https://repo1.maven.org/maven2/io/vertx/vertx-dependencies/${io.vertx.web.version}/vertx-dependencies-${io.vertx.web.version}.pom -->
+  <!-- https://groups.google.com/g/vertx/c/uzzcgw-YuOg -->
+  <io.netty.netty-transport-native-epoll.version>4.1.94.Final</io.netty.netty-transport-native-epoll.version><!-- FIXME this should be tied to the vertx version -->
   <!--
     FIXME this needs to be synced with the vertx version - is there a BOM to use or something?
     https://github.com/vert-x3/vertx-web/blob/${io.vertx.web.version}/vertx-web-graphql/pom.xml#L35
@@ -211,22 +214,6 @@
     <groupId>org.jasypt</groupId>
     <artifactId>jasypt-hibernate5</artifactId>
     <version>${org.jasypt-hibernate5.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-transport-native-epoll</artifactId>
-    <classifier>linux-x86_64</classifier>
-    <version>4.1.94.Final</version><!-- FIXME this should be tied to the vertx version -->
-    <!-- https://repo1.maven.org/maven2/io/vertx/vertx-dependencies/${io.vertx.web.version}/vertx-dependencies-${io.vertx.web.version}.pom -->
-    <!-- https://groups.google.com/g/vertx/c/uzzcgw-YuOg -->
-  </dependency>
-  <dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-transport-native-epoll</artifactId>
-    <classifier>linux-aarch_64</classifier>
-    <version>4.1.86.Final</version><!-- FIXME this should be tied to the vertx version -->
-    <!-- https://repo1.maven.org/maven2/io/vertx/vertx-dependencies/${io.vertx.web.version}/vertx-dependencies-${io.vertx.web.version}.pom -->
-    <!-- https://groups.google.com/g/vertx/c/uzzcgw-YuOg -->
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>
@@ -995,6 +982,85 @@
 </reporting>
 
 <profiles>
+  <profile>
+    <id>default-arch</id>
+    <activation>
+      <property>
+        <name>!build.arch</name>
+      </property>
+    </activation>
+    <properties>
+      <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
+      <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+    </properties>
+  </profile>
+  <profile>
+    <id>amd64</id>
+    <activation>
+      <property>
+        <name>build.arch</name>
+        <value>amd64</value>
+      </property>
+    </activation>
+    <properties>
+      <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
+      <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+    </properties>
+  </profile>
+  <profile>
+    <id>arm64</id>
+    <activation>
+      <property>
+        <name>build.arch</name>
+        <value>arm64</value>
+      </property>
+    </activation>
+    <properties>
+      <io.netty.netty-transport-native-epoll.classifier>linux-aarch_64</io.netty.netty-transport-native-epoll.classifier>
+      <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+    </properties>
+  </profile>
+  <profile>
+    <id>with-epoll</id>
+    <activation>
+      <property>
+        <name>!build.exclude-epoll</name>
+      </property>
+    </activation>
+    <properties>
+      <io.netty.netty-transport-native-epoll.scope>compile</io.netty.netty-transport-native-epoll.scope>
+    </properties>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <classifier>${io.netty.netty-transport-native-epoll.classifier}</classifier>
+        <version>${io.netty.netty-transport-native-epoll.version}</version>
+        <scope>${io.netty.netty-transport-native-epoll.scope}</scope>
+      </dependency>
+    </dependencies>
+  </profile>
+  <profile>
+    <id>no-epoll</id>
+    <activation>
+      <property>
+        <name>build.exclude-epoll</name>
+      </property>
+    </activation>
+    <properties>
+      <io.netty.netty-transport-native-epoll.classifier>linux-x86_64</io.netty.netty-transport-native-epoll.classifier>
+      <io.netty.netty-transport-native-epoll.scope>provided</io.netty.netty-transport-native-epoll.scope>
+    </properties>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <classifier>${io.netty.netty-transport-native-epoll.classifier}</classifier>
+        <version>${io.netty.netty-transport-native-epoll.version}</version>
+        <scope>${io.netty.netty-transport-native-epoll.scope}</scope>
+      </dependency>
+    </dependencies>
+  </profile>
   <profile>
     <id>headless</id>
     <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,14 @@
     <!-- https://groups.google.com/g/vertx/c/uzzcgw-YuOg -->
   </dependency>
   <dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-transport-native-epoll</artifactId>
+    <classifier>linux-aarch_64</classifier>
+    <version>4.1.86.Final</version><!-- FIXME this should be tied to the vertx version -->
+    <!-- https://repo1.maven.org/maven2/io/vertx/vertx-dependencies/${io.vertx.web.version}/vertx-dependencies-${io.vertx.web.version}.pom -->
+    <!-- https://groups.google.com/g/vertx/c/uzzcgw-YuOg -->
+  </dependency>
+  <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-jdk14</artifactId>
     <version>${org.slf4j.version}</version>

--- a/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
@@ -72,8 +72,13 @@ class DockerPlatformStrategy implements PlatformDetectionStrategy<DockerPlatform
         boolean socketExists = fs.isReadable(fs.pathOf(DOCKER_SOCKET_PATH));
         boolean nativeEnabled = vertx.get().isNativeTransportEnabled();
 
-        if (!nativeEnabled && !Epoll.isAvailable()) {
-            Epoll.unavailabilityCause().printStackTrace();
+        try {
+            if (!nativeEnabled && !Epoll.isAvailable()) {
+                Epoll.unavailabilityCause().printStackTrace();
+            }
+        } catch (NoClassDefFoundError noClassDefFoundError) {
+            logger.warn(new UnsupportedOperationException(noClassDefFoundError));
+            return false;
         }
 
         boolean serviceReachable = false;

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -72,8 +72,13 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
         boolean socketExists = fs.isReadable(fs.pathOf(socketPath));
         boolean nativeEnabled = vertx.get().isNativeTransportEnabled();
 
-        if (!nativeEnabled && !Epoll.isAvailable()) {
-            Epoll.unavailabilityCause().printStackTrace();
+        try {
+            if (!nativeEnabled && !Epoll.isAvailable()) {
+                Epoll.unavailabilityCause().printStackTrace();
+            }
+        } catch (NoClassDefFoundError noClassDefFoundError) {
+            logger.warn(new UnsupportedOperationException(noClassDefFoundError));
+            return false;
         }
 
         boolean serviceReachable = false;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1547

## Description of the change:
This adds properties+profiles for including/excluding Netty native transport (epoll), with x86_64/aarch_64 classifiers.

## Motivation for the change:
This dependency is used to enable the Vert.x web-client to communicate over Unix domain sockets, which is required for the Podman and Docker built-in discovery mechanisms to work via querying the respective container engines over Unix sockets

## How to manually test:
1. `$ dnf install qemu-user-static`
2. `$ mvn -Dbuild.arch=amd64 clean package ; podman image prune -f`
3. Run `CRYOSTAT_IMAGE=quay.io/... CRYOSTAT_PLATFORM=io.cryostat.platform.internal.PodmanPlatformStrategy sh smoketest.sh` with the new ARM64 Cryostat image
4. Verify that the `Podman` discovery `Realm` exists and is populated with sample applications
5. Check the server startup logs for the `exec java` line, like:

```
+ exec java -XX:+CrashOnOutOfMemoryError -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djavax.net.ssl.trustStore=/opt/cryostat.d/truststore.p12 -Djavax.net.ssl.trustStorePassword=8Ypp7aOSoxJZP680yT09tT0hg_iUdlbc -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.password.file=/tmp/jmxremote.password -Dcom.sun.management.jmxremote.access.file=/tmp/jmxremote.access -Dcom.sun.management.jmxremote.ssl.need.client.auth=true -Djavax.net.ssl.keyStore=/certs/cryostat-keystore.p12 -Djavax.net.ssl.keyStorePassword=Fb3O5XGCuYf203FDDQxZH3RleI5oRLPA -Dcom.sun.management.jmxremote.ssl=true -Dcom.sun.management.jmxremote.registry.ssl=true -cp '/app/resources:/app/classes:/app/libs/cryostat-core-2.21.0.jar:/app/libs/common-8.2.0.jar:/app/libs/encoder-1.2.3.jar:/app/libs/lz4-java-1.8.0.jar:/app/libs/flightrecorder-8.2.0.jar:/app/libs/flightrecorder.rules-8.2.0.jar:/app/libs/flightrecorder.rules.jdk-8.2.0.jar:/app/libs/jdp-8.2.0.jar:/app/libs/nashorn-core-15.4.jar:/app/libs/asm-7.3.1.jar:/app/libs/asm-commons-7.3.1.jar:/app/libs/asm-analysis-7.3.1.jar:/app/libs/asm-tree-7.3.1.jar:/app/libs/asm-util-7.3.1.jar:/app/libs/openshift-client-6.3.1.jar:/app/libs/openshift-client-api-6.3.1.jar:/app/libs/openshift-model-6.3.1.jar:/app/libs/kubernetes-model-common-6.3.1.jar:/app/libs/jackson-annotations-2.14.1.jar:/app/libs/openshift-model-clusterautoscaling-6.3.1.jar:/app/libs/openshift-model-operator-6.3.1.jar:/app/libs/openshift-model-operatorhub-6.3.1.jar:/app/libs/openshift-model-machine-6.3.1.jar:/app/libs/openshift-model-whereabouts-6.3.1.jar:/app/libs/openshift-model-monitoring-6.3.1.jar:/app/libs/openshift-model-storageversionmigrator-6.3.1.jar:/app/libs/openshift-model-tuned-6.3.1.jar:/app/libs/openshift-model-console-6.3.1.jar:/app/libs/openshift-model-config-6.3.1.jar:/app/libs/openshift-model-machineconfig-6.3.1.jar:/app/libs/openshift-model-miscellaneous-6.3.1.jar:/app/libs/openshift-model-hive-6.3.1.jar:/app/libs/openshift-model-installer-6.3.1.jar:/app/libs/generex-1.0.2.jar:/app/libs/automaton-1.11-8.jar:/app/libs/kubernetes-client-6.3.1.jar:/app/libs/kubernetes-client-api-6.3.1.jar:/app/libs/kubernetes-model-core-6.3.1.jar:/app/libs/kubernetes-model-gatewayapi-6.3.1.jar:/app/libs/kubernetes-model-rbac-6.3.1.jar:/app/libs/kubernetes-model-admissionregistration-6.3.1.jar:/app/libs/kubernetes-model-apps-6.3.1.jar:/app/libs/kubernetes-model-autoscaling-6.3.1.jar:/app/libs/kubernetes-model-apiextensions-6.3.1.jar:/app/libs/kubernetes-model-batch-6.3.1.jar:/app/libs/kubernetes-model-certificates-6.3.1.jar:/app/libs/kubernetes-model-coordination-6.3.1.jar:/app/libs/kubernetes-model-discovery-6.3.1.jar:/app/libs/kubernetes-model-events-6.3.1.jar:/app/libs/kubernetes-model-extensions-6.3.1.jar:/app/libs/kubernetes-model-flowcontrol-6.3.1.jar:/app/libs/kubernetes-model-networking-6.3.1.jar:/app/libs/kubernetes-model-metrics-6.3.1.jar:/app/libs/kubernetes-model-policy-6.3.1.jar:/app/libs/kubernetes-model-scheduling-6.3.1.jar:/app/libs/kubernetes-model-storageclass-6.3.1.jar:/app/libs/kubernetes-model-node-6.3.1.jar:/app/libs/snakeyaml-1.33.jar:/app/libs/jackson-dataformat-yaml-2.14.1.jar:/app/libs/jackson-datatype-jsr310-2.14.1.jar:/app/libs/jackson-databind-2.14.1.jar:/app/libs/jackson-core-2.14.1.jar:/app/libs/kubernetes-httpclient-okhttp-6.3.1.jar:/app/libs/okhttp-3.12.12.jar:/app/libs/okio-1.15.0.jar:/app/libs/logging-interceptor-3.12.12.jar:/app/libs/zjsonpatch-0.3.0.jar:/app/libs/dagger-2.45.jar:/app/libs/javax.inject-1.jar:/app/libs/commons-lang3-3.12.0.jar:/app/libs/commons-codec-1.15.jar:/app/libs/commons-io-2.11.0.jar:/app/libs/commons-validator-1.7.jar:/app/libs/commons-beanutils-1.9.4.jar:/app/libs/commons-digester-2.1.jar:/app/libs/commons-logging-1.2.jar:/app/libs/commons-collections-3.2.2.jar:/app/libs/httpclient-4.5.14.jar:/app/libs/httpcore-4.4.16.jar:/app/libs/vertx-web-4.3.7.jar:/app/libs/vertx-web-common-4.3.7.jar:/app/libs/vertx-auth-common-4.3.7.jar:/app/libs/vertx-bridge-common-4.3.7.jar:/app/libs/vertx-core-4.3.7.jar:/app/libs/netty-handler-4.1.86.Final.jar:/app/libs/netty-codec-4.1.86.Final.jar:/app/libs/netty-handler-proxy-4.1.86.Final.jar:/app/libs/netty-codec-socks-4.1.86.Final.jar:/app/libs/netty-codec-http-4.1.86.Final.jar:/app/libs/netty-codec-http2-4.1.86.Final.jar:/app/libs/netty-resolver-4.1.86.Final.jar:/app/libs/netty-resolver-dns-4.1.86.Final.jar:/app/libs/netty-codec-dns-4.1.86.Final.jar:/app/libs/vertx-web-client-4.3.7.jar:/app/libs/vertx-uri-template-4.3.7.jar:/app/libs/vertx-web-graphql-4.3.7.jar:/app/libs/graphql-java-19.2.jar:/app/libs/java-dataloader-3.2.0.jar:/app/libs/reactive-streams-1.0.3.jar:/app/libs/graphql-java-extended-scalars-19.0.jar:/app/libs/nimbus-jose-jwt-9.31.jar:/app/libs/jcip-annotations-1.0-1.jar:/app/libs/bcprov-jdk18on-1.72.jar:/app/libs/jasypt-1.9.3.jar:/app/libs/jasypt-hibernate5-1.9.3.jar:/app/libs/netty-transport-native-epoll-4.1.86.Final-linux-x86_64.jar:/app/libs/netty-common-4.1.86.Final.jar:/app/libs/netty-buffer-4.1.86.Final.jar:/app/libs/netty-transport-4.1.86.Final.jar:/app/libs/netty-transport-native-unix-common-4.1.86.Final.jar:/app/libs/netty-transport-classes-epoll-4.1.86.Final.jar:/app/libs/slf4j-jdk14-1.7.36.jar:/app/libs/slf4j-api-1.7.36.jar:/app/libs/gson-2.10.1.jar:/app/libs/caffeine-3.1.1.jar:/app/libs/jsoup-1.15.4.jar:/app/libs/hibernate-core-5.6.14.Final.jar:/app/libs/jboss-logging-3.4.3.Final.jar:/app/libs/javax.persistence-api-2.2.jar:/app/libs/byte-buddy-1.12.18.jar:/app/libs/antlr-2.7.7.jar:/app/libs/jboss-transaction-api_1.2_spec-1.1.1.Final.jar:/app/libs/jandex-2.4.2.Final.jar:/app/libs/classmate-1.5.1.jar:/app/libs/javax.activation-api-1.2.0.jar:/app/libs/hibernate-commons-annotations-5.1.2.Final.jar:/app/libs/jaxb-api-2.3.1.jar:/app/libs/jaxb-runtime-2.3.1.jar:/app/libs/txw2-2.3.1.jar:/app/libs/istack-commons-runtime-3.0.7.jar:/app/libs/stax-ex-1.8.jar:/app/libs/FastInfoset-1.2.15.jar:/app/libs/hibernate-types-55-2.21.1.jar:/app/libs/h2-2.1.214.jar:/app/libs/postgresql-42.5.1.jar:/clientlib/*' @/app/jib-main-class-file
```

and verify that the `epoll` dependency is on the classpath and matches the image arch.

----

Then, try:
1. `$ mvn -Dbuild.arch=amd64 -Dbuild.exclude-epoll clean package ; podman image prune -f`
2. `$ CRYOSTAT_IMAGE=quay.io/... CRYOSTAT_PLATFORM=io.cryostat.platform.internal.PodmanPlatformStrategy sh smoketest.sh` with the just-built x86_64 image *without epoll*
3. Check the logs for:

```
SEVERE: Podman API request failed
java.lang.IllegalArgumentException: The Vertx instance must be created with the preferNativeTransport option set to true to create domain sockets
	at io.vertx.core.net.impl.transport.Transport.channelFactory(Transport.java:183)
	at io.vertx.core.net.impl.ChannelProvider.connect(ChannelProvider.java:98)
	at io.vertx.core.net.impl.ChannelProvider.connect(ChannelProvider.java:92)
	at io.vertx.core.net.impl.NetClientImpl.connectInternal2(NetClientImpl.java:273)
	at io.vertx.core.net.impl.NetClientImpl.lambda$connectInternal$1(NetClientImpl.java:240)
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141)
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

4. Verify that the server is still running and responds to requests. Target discovery with custom targets, or external discovery plugins (ex. Cryostat Agent instances) should still work.

----

Then, try:
1. `$ mvn -Dbuild.arch=amd64 -Dbuild.exclude-epoll clean package ; podman image prune -f`
2. `$ CRYOSTAT_IMAGE=quay.io/... sh smoketest.sh` with the just-built x86_64 image *without epoll* and without forcing the Podman discovery platform selection
3. Check the logs for:

```
java.lang.UnsupportedOperationException: java.lang.NoClassDefFoundError: io/netty/channel/epoll/Epoll
	at io.cryostat.platform.internal.PodmanPlatformStrategy.isAvailable(PodmanPlatformStrategy.java:102)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.cryostat.platform.PlatformModule.provideSelectedPlatformStrategies(PlatformModule.java:121)
	at io.cryostat.platform.PlatformModule_ProvideSelectedPlatformStrategiesFactory.provideSelectedPlatformStrategies(PlatformModule_ProvideSelectedPlatformStrategiesFactory.java:59)
	at io.cryostat.platform.PlatformModule_ProvideSelectedPlatformStrategiesFactory.get(PlatformModule_ProvideSelectedPlatformStrategiesFactory.java:46)
	at io.cryostat.platform.PlatformModule_ProvideSelectedPlatformStrategiesFactory.get(PlatformModule_ProvideSelectedPlatformStrategiesFactory.java:15)
	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
	at io.cryostat.platform.PlatformModule_ProvidePlatformStrategyFactory.get(PlatformModule_ProvidePlatformStrategyFactory.java:40)
	at io.cryostat.platform.PlatformModule_ProvidePlatformStrategyFactory.get(PlatformModule_ProvidePlatformStrategyFactory.java:13)
	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
	at io.cryostat.platform.PlatformModule_ProvideAuthManagerFactory.get(PlatformModule_ProvideAuthManagerFactory.java:50)
	at io.cryostat.platform.PlatformModule_ProvideAuthManagerFactory.get(PlatformModule_ProvideAuthManagerFactory.java:16)
	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
	at io.cryostat.DaggerCryostat_Client$ClientImpl.recordingMetadataLabelsPostHandler(DaggerCryostat_Client.java:1002)
	at io.cryostat.DaggerCryostat_Client$ClientImpl.setOfRequestHandler(DaggerCryostat_Client.java:1471)
	at io.cryostat.DaggerCryostat_Client$ClientImpl.webServer(DaggerCryostat_Client.java:1780)
	at io.cryostat.Cryostat.lambda$start$1(Cryostat.java:97)
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38)
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:262)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211)
	at io.vertx.core.impl.future.Mapping.onSuccess(Mapping.java:40)
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NoClassDefFoundError: io/netty/channel/epoll/Epoll
	at io.cryostat.platform.internal.PodmanPlatformStrategy.isAvailable(PodmanPlatformStrategy.java:98)
	... 40 more
Caused by: java.lang.ClassNotFoundException: io.netty.channel.epoll.Epoll
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 41 more
```

4. Verify that the server is still running and responds to requests. Target discovery with custom targets, or external discovery plugins (ex. Cryostat Agent instances) should still work.