### PR TITLE
fix(startup): be tolerant of built-in discovery mechanism failures

### DIFF
--- a/src/main/java/io/cryostat/Cryostat.java
+++ b/src/main/java/io/cryostat/Cryostat.java
@@ -135,7 +135,7 @@ class Cryostat extends AbstractVerticle {
             if (!(cause instanceof Exception)) {
                 cause = new RuntimeException(cause);
             }
-            logger.error((RuntimeException) cause);
+            logger.error((Exception) cause);
         }
         logger.info("{} shutting down...", instanceName());
         client.vertx().close().onComplete(n -> logger.info("Shutdown complete"));

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -135,7 +135,7 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
                                 platform.load(promise);
                                 enabledClients.add(platform);
                             } catch (Exception e) {
-                                start.fail(e);
+                                logger.warn(e);
                             }
                         });
         start.tryComplete();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1546

## Description of the change:
This fixes a class cast exception that can occur when startup fails, and changes behaviour from failing startup if any built-in discovery mechanism fails to start to simply logging the cause.

## Motivation for the change:
Since all built-in discovery mechanisms are now tested by default and then automatically started, it is surprising/annoying when one of these failing (such as JDP on aarch64 at the moment) causes the whole server to not start.

## How to manually test:
1. `dnf install qemu-user-static`
2. `mvn clean package -Dbuild.arch=arm64 ; podman image prune -f`
3. `CRYOSTAT_IMAGE=quay.io/cryostat/cryostat:2.4.0-snapshot-linux-arm64 sh run.sh # or other image tag as produced above`
