### PR TITLE
fix(ssl): fixed env var behaves unexpectedly 

### DIFF
--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -141,7 +141,7 @@ else
     FLAGS+=("-Dcom.sun.management.jmxremote.access.file=$USRFILE")
 fi
 
-if [ "$CRYOSTAT_DISABLE_SSL" = "true" ]; then
+if [ "$CRYOSTAT_DISABLE_SSL" = "true" ] || ["$CRYOSTAT_DISABLE_SSL" = "TRUE"]; then
     banner "SSL Disabled"
     FLAGS+=("-Dcom.sun.management.jmxremote.ssl=false")
     FLAGS+=("-Dcom.sun.management.jmxremote.registry.ssl=false")

--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -141,7 +141,7 @@ else
     FLAGS+=("-Dcom.sun.management.jmxremote.access.file=$USRFILE")
 fi
 
-if [ "$CRYOSTAT_DISABLE_SSL" = "true" ] || ["$CRYOSTAT_DISABLE_SSL" = "TRUE"]; then
+if [ "$CRYOSTAT_DISABLE_SSL" = "true" ] || [ "$CRYOSTAT_DISABLE_SSL" = "TRUE" ]; then
     banner "SSL Disabled"
     FLAGS+=("-Dcom.sun.management.jmxremote.ssl=false")
     FLAGS+=("-Dcom.sun.management.jmxremote.registry.ssl=false")

--- a/src/main/extras/app/entrypoint.bash
+++ b/src/main/extras/app/entrypoint.bash
@@ -141,7 +141,7 @@ else
     FLAGS+=("-Dcom.sun.management.jmxremote.access.file=$USRFILE")
 fi
 
-if [ "$CRYOSTAT_DISABLE_SSL" = "true" ] || [ "$CRYOSTAT_DISABLE_SSL" = "TRUE" ]; then
+if [ "$CRYOSTAT_DISABLE_SSL" = "true" ]; then
     banner "SSL Disabled"
     FLAGS+=("-Dcom.sun.management.jmxremote.ssl=false")
     FLAGS+=("-Dcom.sun.management.jmxremote.registry.ssl=false")

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equalsIgnoreCase(disableSslValue.toLowerCase())) {
+            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue)) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue)) {
+            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue )) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,6 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            logger.info("++-" + disableSslValue);
             boolean disableSsl = Boolean.parseBoolean(disableSslValue); // Parse the value as a boolean
             if (disableSsl) {
                 strategy = new NoSslStrategy();

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue)) {
+            if ("true".equals(disableSslValue)) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equalsIgnoreCase(disableSslValue)) {
+            if ("true".equalsIgnoreCase(disableSslValue) || "TRUE".equalsIgnoreCase(disableSslValue)) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,8 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            boolean disableSsl = Boolean.parseBoolean(disableSslValue); // Parse the value as a boolean
-            if (disableSsl) {
+            if ("true".equalsIgnoreCase(disableSslValue)) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;
@@ -115,7 +114,7 @@ public class SslConfiguration {
         }
 
         strategy = new NoSslStrategy();
-        logger.info("++-Selecteeeeeeeeeed NoSSL strategy");
+        logger.info("Selected NoSSL strategy");
     }
 
     // Test-only constructor

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -64,9 +64,9 @@ public class SslConfiguration {
         this.logger = logger;
 
         if ("true".equals(env.getEnv(Variables.DISABLE_SSL))) {
-                strategy = new NoSslStrategy();
-                logger.info("Selected NoSSL strategy");
-                return; 
+            strategy = new NoSslStrategy();
+            logger.info("Selected NoSSL strategy");
+            return;
         }
 
         {

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue )) {
+            if ("true".equals(disableSslValue) || "TRUE".equals(disableSslValue)) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -65,7 +65,7 @@ public class SslConfiguration {
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
             String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equalsIgnoreCase(disableSslValue) || "TRUE".equalsIgnoreCase(disableSslValue)) {
+            if ("true".equalsIgnoreCase(disableSslValue.toLowerCase())) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
                 return;

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -63,13 +63,10 @@ public class SslConfiguration {
         this.fs = fs;
         this.logger = logger;
 
-        if (env.hasEnv(Variables.DISABLE_SSL)) {
-            String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
-            if ("true".equals(disableSslValue)) {
+        if ("true".equals(env.getEnv(Variables.DISABLE_SSL))) {
                 strategy = new NoSslStrategy();
                 logger.info("Selected NoSSL strategy");
-                return;
-            }
+                return; 
         }
 
         {

--- a/src/main/java/io/cryostat/net/SslConfiguration.java
+++ b/src/main/java/io/cryostat/net/SslConfiguration.java
@@ -64,9 +64,14 @@ public class SslConfiguration {
         this.logger = logger;
 
         if (env.hasEnv(Variables.DISABLE_SSL)) {
-            strategy = new NoSslStrategy();
-            logger.info("Selected NoSSL strategy");
-            return;
+            String disableSslValue = env.getEnv(Variables.DISABLE_SSL);
+            logger.info("++-" + disableSslValue);
+            boolean disableSsl = Boolean.parseBoolean(disableSslValue); // Parse the value as a boolean
+            if (disableSsl) {
+                strategy = new NoSslStrategy();
+                logger.info("Selected NoSSL strategy");
+                return;
+            }
         }
 
         {
@@ -111,7 +116,7 @@ public class SslConfiguration {
         }
 
         strategy = new NoSslStrategy();
-        logger.info("Selected NoSSL strategy");
+        logger.info("++-Selecteeeeeeeeeed NoSSL strategy");
     }
 
     // Test-only constructor


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1507

## Description of the change:
This change allows enabling of SSL when CRYOSTAT_DISABLE_SSL is set to "false"

## Motivation for the change:
This change is helpful because users may want to sue a Secure Sockect Layer(SSL) where as he can just pass the environment variable to false i.e < CRYOSTAT_DISABLE_SSL=false>

## How to manually test:
1. Run `CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Run `CRYOSTAT_DISABLE_SSL=false sh smoketest.sh and test it by < http --verify=no https://localhost:8181/health`
