### PR TITLE
test(itest): ensure correct latest built image is tested

### DIFF
--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -115,7 +115,7 @@ jobs:
       with:
         step: restore
     - name: Run integration tests
-      run: POD_NAME=cryostat-itests CONTAINER_NAME=cryostat-itest ITEST_IMG_VERSION=latest bash repeated-integration-tests.bash
+      run: POD_NAME=cryostat-itests CONTAINER_NAME=cryostat-itest bash repeated-integration-tests.bash
     - name: Print itest logs
       if: failure()
       run: ls -1dt target/cryostat-itest-*.log | head -n1 | xargs cat

--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
               <argument>GRAFANA_DASHBOARD_URL=http://${cryostat.itest.webHost}:${cryostat.itest.grafana.port}</argument>
               <argument>--detach</argument>
               <argument>--rm</argument>
-              <argument>${cryostat.imageStream}:${cryostat.imageVersionLower}</argument>
+              <argument>${cryostat.imageStream}:${cryostat.imageVersionLower}-${build.os}-${build.arch}</argument>
             </arguments>
             <skip>${skipITs}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -550,6 +550,7 @@
             <executable>${imageBuilder}</executable>
             <arguments>
               <argument>run</argument>
+              <argument>--pull=never</argument>
               <argument>--pod=${cryostat.itest.podName}</argument>
               <argument>--name=${cryostat.itest.containerName}</argument>
               <argument>--health-cmd</argument>

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [ -z "$CRYOSTAT_IMAGE" ]; then
-    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:$(${MVN} validate help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.imageVersionLower)"
+    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:$(${MVN} validate help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.imageVersionLower)-$(getPomProperty build.os)-$(getPomProperty build.arch)"
 fi
 
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1571

## Description of the change:
- test(itest): never pull Cryostat container from registry, require one present locally
- test(itest): use os/arch-specific image tag for testing
- test(run.sh): include image os/arch in default image to run

## How to manually test:
1. Check out this PR
2. `run.sh` then `podman ps` and ensure that the image run is like `quay.io/cryostat/cryostat:2.4.0-snapshot-linux-amd64`
3. `bash repeated-integration-tests.bash` and ensure that the image run is the same
4. `mvn clean verify` and ensure that the image run is the same, ie the one that is just built by the same run
