### PR TITLE
feat(replace-param): Fine-grained replacement parameter for Start Recording Mutator

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -47,7 +47,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -154,22 +154,22 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 .name(recordingName);
 
                                 String replace = attrs.get("replace");
-                                replacementPolicy rPolicy;
+                                ReplacementPolicy replacementPolicy;
                                 if (StringUtils.isBlank(replace)) {
-                                    rPolicy =
-                                            replacementPolicy
+                                    replacementPolicy =
+                                            ReplacementPolicy
                                                     .NEVER; // Default to "never" if not provided
                                 } else {
                                     switch (replace.toLowerCase()) {
                                         case "always":
-                                            rPolicy = replacementPolicy.ALWAYS;
+                                            replacementPolicy = ReplacementPolicy.ALWAYS;
                                             break;
                                         case "stopped":
-                                            rPolicy = replacementPolicy.STOPPED;
+                                            replacementPolicy = ReplacementPolicy.STOPPED;
                                             break;
                                         case "never":
                                         default:
-                                            rPolicy = replacementPolicy.NEVER;
+                                            replacementPolicy = ReplacementPolicy.NEVER;
                                             break;
                                     }
                                 }
@@ -218,7 +218,7 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 eventSpecifier);
                                 IRecordingDescriptor descriptor =
                                         recordingTargetHelper.startRecording(
-                                                rPolicy,
+                                                replacementPolicy,
                                                 connectionDescriptor,
                                                 builder.build(),
                                                 template.getLeft(),

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -151,10 +151,10 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                         recordingOptionsBuilderFactory
                                                 .create(connection.getService())
                                                 .name(recordingName);
-                                String restart = "false";
+                                Boolean restart = false;
                                 String replace = "never";
                                 if (attrs.contains("restart")) {
-                                    restart = attrs.get("restart");
+                                    restart = Boolean.parseBoolean(attrs.get("restart"));
                                 }
                                 if (attrs.contains("replace")) {
                                     replace = attrs.get("replace");

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -26,15 +26,9 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
@@ -53,11 +47,17 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -151,9 +151,13 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                         recordingOptionsBuilderFactory
                                                 .create(connection.getService())
                                                 .name(recordingName);
-                                boolean restart = false;
+                                String restart = "false";
+                                String replace = "never";
                                 if (attrs.contains("restart")) {
-                                    restart = Boolean.parseBoolean(attrs.get("restart"));
+                                    restart = attrs.get("restart");
+                                }
+                                if (attrs.contains("replace")) {
+                                    replace = attrs.get("replace");
                                 }
                                 if (attrs.contains("duration")) {
                                     builder =
@@ -199,8 +203,8 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 eventSpecifier);
                                 IRecordingDescriptor descriptor =
                                         recordingTargetHelper.startRecording(
-                                                null,
-                                                "always",
+                                                restart,
+                                                replace,
                                                 connectionDescriptor,
                                                 builder.build(),
                                                 template.getLeft(),

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -26,9 +26,15 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
@@ -47,17 +53,11 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 
 public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHandler {
 
@@ -199,7 +199,8 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 eventSpecifier);
                                 IRecordingDescriptor descriptor =
                                         recordingTargetHelper.startRecording(
-                                                restart,
+                                                null,
+                                                "always",
                                                 connectionDescriptor,
                                                 builder.build(),
                                                 template.getLeft(),

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -154,25 +154,8 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 .name(recordingName);
 
                                 String replace = attrs.get("replace");
-                                ReplacementPolicy replacementPolicy;
-                                if (StringUtils.isBlank(replace)) {
-                                    replacementPolicy =
-                                            ReplacementPolicy
-                                                    .NEVER; // Default to "never" if not provided
-                                } else {
-                                    switch (replace.toLowerCase()) {
-                                        case "always":
-                                            replacementPolicy = ReplacementPolicy.ALWAYS;
-                                            break;
-                                        case "stopped":
-                                            replacementPolicy = ReplacementPolicy.STOPPED;
-                                            break;
-                                        case "never":
-                                        default:
-                                            replacementPolicy = ReplacementPolicy.NEVER;
-                                            break;
-                                    }
-                                }
+                                ReplacementPolicy replacementPolicy =
+                                        ReplacementPolicy.fromString(replace);
 
                                 if (attrs.contains("duration")) {
                                     builder =

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -151,8 +151,8 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                         recordingOptionsBuilderFactory
                                                 .create(connection.getService())
                                                 .name(recordingName);
-                                Boolean restart = false;
-                                String replace = "never";
+                                boolean restart = false;
+                                String replace = null;
                                 if (attrs.contains("restart")) {
                                     restart = Boolean.parseBoolean(attrs.get("restart"));
                                 }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -119,12 +119,7 @@ class StartRecordingOnTargetMutator
 
                     if (settings.containsKey("replace")) {
                         String replaceValue = (String) settings.get("replace");
-                        try {
-                            replace = ReplacementPolicy.valueOf(replaceValue.toUpperCase());
-                        } catch (IllegalArgumentException e) {
-                            // Handles invalid value for "replace"
-                            replace = ReplacementPolicy.NEVER;
-                        }
+                        replace = ReplacementPolicy.fromString(replaceValue);
                     }
                     if (settings.containsKey("duration")) {
                         builder =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -28,10 +28,6 @@ import javax.inject.Provider;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-
-import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -46,6 +42,10 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import graphql.schema.DataFetchingEnvironment;
 
 class StartRecordingOnTargetMutator
         extends AbstractPermissionedDataFetcher<HyperlinkedSerializableRecordingDescriptor> {
@@ -110,13 +110,17 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
-                    boolean restart = false;
+                    String restart = "false";
+                    String replace = "never";
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
                     if (settings.containsKey("restart")) {
-                        restart = Boolean.TRUE.equals(settings.get("restart"));
+                        restart = (String) settings.get("restart");
+                    }
+                    if (settings.containsKey("replace")) {
+                        restart = (String) settings.get("replace");
                     }
                     if (settings.containsKey("duration")) {
                         builder =
@@ -157,8 +161,8 @@ class StartRecordingOnTargetMutator
                     }
                     IRecordingDescriptor desc =
                             recordingTargetHelper.startRecording(
-                                    null,
-                                    "always",
+                                    restart,
+                                    replace,
                                     cd,
                                     builder.build(),
                                     (String) settings.get("template"),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -110,17 +110,17 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
-                    String restart = "false";
+                    Boolean restart = false;
                     String replace = "never";
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
                     if (settings.containsKey("restart")) {
-                        restart = (String) settings.get("restart");
+                        restart = Boolean.TRUE.equals(settings.get("restart"));
                     }
                     if (settings.containsKey("replace")) {
-                        restart = (String) settings.get("replace");
+                        replace = (String) settings.get("replace");
                     }
                     if (settings.containsKey("duration")) {
                         builder =

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -110,7 +110,7 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
-                    Boolean restart = false;
+                    boolean restart = false;
                     String replace = "never";
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -42,7 +42,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -111,7 +111,7 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
-                    replacementPolicy replace = replacementPolicy.NEVER;
+                    ReplacementPolicy replace = ReplacementPolicy.NEVER;
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())
@@ -120,10 +120,10 @@ class StartRecordingOnTargetMutator
                     if (settings.containsKey("replace")) {
                         String replaceValue = (String) settings.get("replace");
                         try {
-                            replace = replacementPolicy.valueOf(replaceValue.toUpperCase());
+                            replace = ReplacementPolicy.valueOf(replaceValue.toUpperCase());
                         } catch (IllegalArgumentException e) {
                             // Handles invalid value for "replace"
-                            replace = replacementPolicy.NEVER;
+                            replace = ReplacementPolicy.NEVER;
                         }
                     }
                     if (settings.containsKey("duration")) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -28,6 +28,10 @@ import javax.inject.Provider;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import graphql.schema.DataFetchingEnvironment;
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.jmc.serialization.HyperlinkedSerializableRecordingDescriptor;
@@ -42,10 +46,6 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import graphql.schema.DataFetchingEnvironment;
 
 class StartRecordingOnTargetMutator
         extends AbstractPermissionedDataFetcher<HyperlinkedSerializableRecordingDescriptor> {
@@ -157,7 +157,8 @@ class StartRecordingOnTargetMutator
                     }
                     IRecordingDescriptor desc =
                             recordingTargetHelper.startRecording(
-                                    restart,
+                                    null,
+                                    "always",
                                     cd,
                                     builder.build(),
                                     (String) settings.get("template"),

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -114,9 +114,15 @@ public class RecordingTargetHelper {
                 connection -> connection.getService().getAvailableRecordings());
     }
 
+    public enum replacementPolicy {
+        ALWAYS,
+        STOPPED,
+        NEVER
+    }
+
     public IRecordingDescriptor startRecording(
-            boolean restart, // Deprecated: Use replace parameter instead
-            String replace,
+            // boolean restart, // is now completely removed
+            replacementPolicy replace,
             ConnectionDescriptor connectionDescriptor,
             IConstrainedMap<String> recordingOptions,
             String templateName,
@@ -125,7 +131,7 @@ public class RecordingTargetHelper {
             boolean archiveOnStop)
             throws Exception {
         String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
-        boolean restartRecording = shouldRestartRecording(restart, replace);
+        boolean restartRecording = shouldRestartRecording(replace);
 
         return targetConnectionManager.executeConnectedTask(
                 connectionDescriptor,
@@ -143,8 +149,8 @@ public class RecordingTargetHelper {
                         } else if (isRecordingStopped(previous.get())) {
                             connection.getService().close(previous.get());
                         } else {
-                            // If recording exists and still running, stop and close it before
-                            // starting a new one
+                            // If recording exists and running, stop and close it before starting a
+                            // new one
                             connection.getService().stop(previous.get());
                             connection.getService().close(previous.get());
                         }
@@ -190,19 +196,19 @@ public class RecordingTargetHelper {
                 });
     }
 
-    private boolean shouldRestartRecording(boolean restart, String replace) {
+    private boolean shouldRestartRecording(replacementPolicy replace) {
         if (replace != null) {
             switch (replace) {
-                case "always":
+                case ALWAYS:
                     return true;
-                case "stopped":
+                case STOPPED:
                     return true;
-                case "never":
+                case NEVER:
                     return false;
             }
         }
         // If neither restart nor replace is specified, default to never
-        return restart;
+        return false;
     }
 
     private boolean isRecordingStopped(IRecordingDescriptor recording) {

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -143,8 +143,10 @@ public class RecordingTargetHelper {
                         } else if (isRecordingStopped(previous.get())) {
                             connection.getService().close(previous.get());
                         } else {
-                            // if recording exists and still running, do nothing.
-                            return previous.get();
+                            // If recording exists and still running, stop and close it before
+                            // starting a new one
+                            connection.getService().stop(previous.get());
+                            connection.getService().close(previous.get());
                         }
                     }
                     IRecordingDescriptor desc =

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -114,7 +114,7 @@ public class RecordingTargetHelper {
                 connection -> connection.getService().getAvailableRecordings());
     }
 
-    public enum replacementPolicy {
+    public enum ReplacementPolicy {
         ALWAYS,
         STOPPED,
         NEVER
@@ -122,7 +122,7 @@ public class RecordingTargetHelper {
 
     public IRecordingDescriptor startRecording(
             // boolean restart, // is now completely removed
-            replacementPolicy replace,
+            ReplacementPolicy replace,
             ConnectionDescriptor connectionDescriptor,
             IConstrainedMap<String> recordingOptions,
             String templateName,
@@ -196,7 +196,7 @@ public class RecordingTargetHelper {
                 });
     }
 
-    private boolean shouldRestartRecording(replacementPolicy replace) {
+    private boolean shouldRestartRecording(ReplacementPolicy replace) {
         if (replace != null) {
             switch (replace) {
                 case ALWAYS:

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -142,7 +142,7 @@ public class RecordingTargetHelper {
                                             recordingName));
                         } else if (isRecordingStopped(previous.get())) {
                             connection.getService().close(previous.get());
-                        }else{
+                        } else {
                             // if recording exists and still running, do nothing.
                             return previous.get();
                         }

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -29,8 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
@@ -38,7 +36,6 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor.RecordingState;
 
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.Template;
@@ -51,9 +48,13 @@ import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
+
+import dagger.Lazy;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class RecordingTargetHelper {
 
@@ -113,7 +114,7 @@ public class RecordingTargetHelper {
                 connection -> connection.getService().getAvailableRecordings());
     }
 
-    /* // original code 
+    /* // original code
     public IRecordingDescriptor startRecording(
             boolean restart,
             ConnectionDescriptor connectionDescriptor,
@@ -187,83 +188,92 @@ public class RecordingTargetHelper {
     // first save
     // my edited
     public IRecordingDescriptor startRecording(
-        String restart, // Deprecated: Use replace parameter instead
-        String replace,
-        ConnectionDescriptor connectionDescriptor,
-        IConstrainedMap<String> recordingOptions,
-        String templateName,
-        TemplateType templateType,
-        Metadata metadata,
-        boolean archiveOnStop)
-        throws Exception {
-    String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
-    boolean restartRecording = shouldRestartRecording(replace, restart);
+            String restart, // Deprecated: Use replace parameter instead
+            String replace,
+            ConnectionDescriptor connectionDescriptor,
+            IConstrainedMap<String> recordingOptions,
+            String templateName,
+            TemplateType templateType,
+            Metadata metadata,
+            boolean archiveOnStop)
+            throws Exception {
+        String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
+        boolean restartRecording = shouldRestartRecording(replace, restart);
 
-    return targetConnectionManager.executeConnectedTask(
-            connectionDescriptor,
-            connection -> {
-                TemplateType preferredTemplateType =
-                        getPreferredTemplateType(connection, templateName, templateType);
-                Optional<IRecordingDescriptor> previous = getDescriptorByName(connection, recordingName);
-                if (previous.isPresent()) {
-                    if (!restartRecording) {
-                        throw new IllegalArgumentException(
-                                String.format(
-                                        "Recording with name \"%s\" already exists",
-                                        recordingName));
-                    } else {
-                        connection.getService().close(previous.get());
+        return targetConnectionManager.executeConnectedTask(
+                connectionDescriptor,
+                connection -> {
+                    TemplateType preferredTemplateType =
+                            getPreferredTemplateType(connection, templateName, templateType);
+                    Optional<IRecordingDescriptor> previous =
+                            getDescriptorByName(connection, recordingName);
+                    if (previous.isPresent()) {
+                        if (!restartRecording) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "Recording with name \"%s\" already exists",
+                                            recordingName));
+                        } else {
+                            connection.getService().close(previous.get());
+                        }
                     }
-                }
-                IRecordingDescriptor desc =
-                        connection.getService().start(
-                                recordingOptions,
-                                enableEvents(connection, templateName, preferredTemplateType));
-                String targetId = connectionDescriptor.getTargetId();
+                    IRecordingDescriptor desc =
+                            connection
+                                    .getService()
+                                    .start(
+                                            recordingOptions,
+                                            enableEvents(
+                                                    connection,
+                                                    templateName,
+                                                    preferredTemplateType));
+                    String targetId = connectionDescriptor.getTargetId();
 
-                Map<String, String> labels = metadata.getLabels();
-                labels.put("template.name", templateName);
-                labels.put("template.type", preferredTemplateType.name());
-                Metadata updatedMetadata = new Metadata(labels);
-                updatedMetadata =
-                        recordingMetadataManager
-                                .setRecordingMetadata(connectionDescriptor, recordingName, updatedMetadata)
-                                .get();
-                HyperlinkedSerializableRecordingDescriptor linkedDesc =
-                        new HyperlinkedSerializableRecordingDescriptor(
-                                desc,
-                                webServer.get().getDownloadURL(connection, desc.getName()),
-                                webServer.get().getReportURL(connection, desc.getName()),
-                                updatedMetadata,
-                                archiveOnStop);
-                this.issueNotification(targetId, linkedDesc, CREATION_NOTIFICATION_CATEGORY);
+                    Map<String, String> labels = metadata.getLabels();
+                    labels.put("template.name", templateName);
+                    labels.put("template.type", preferredTemplateType.name());
+                    Metadata updatedMetadata = new Metadata(labels);
+                    updatedMetadata =
+                            recordingMetadataManager
+                                    .setRecordingMetadata(
+                                            connectionDescriptor, recordingName, updatedMetadata)
+                                    .get();
+                    HyperlinkedSerializableRecordingDescriptor linkedDesc =
+                            new HyperlinkedSerializableRecordingDescriptor(
+                                    desc,
+                                    webServer.get().getDownloadURL(connection, desc.getName()),
+                                    webServer.get().getReportURL(connection, desc.getName()),
+                                    updatedMetadata,
+                                    archiveOnStop);
+                    this.issueNotification(targetId, linkedDesc, CREATION_NOTIFICATION_CATEGORY);
 
-                Object fixedDuration = recordingOptions.get(RecordingOptionsBuilder.KEY_DURATION);
-                if (fixedDuration != null) {
-                    Long delay = Long.valueOf(fixedDuration.toString().replaceAll("[^0-9]", ""));
-                    scheduleRecordingTasks(recordingName, delay, connectionDescriptor, archiveOnStop);
-                }
+                    Object fixedDuration =
+                            recordingOptions.get(RecordingOptionsBuilder.KEY_DURATION);
+                    if (fixedDuration != null) {
+                        Long delay =
+                                Long.valueOf(fixedDuration.toString().replaceAll("[^0-9]", ""));
+                        scheduleRecordingTasks(
+                                recordingName, delay, connectionDescriptor, archiveOnStop);
+                    }
 
-                return desc;
-            });
-}
-
-private boolean shouldRestartRecording(String replace, String restart) {
-    if (replace != null) {
-        switch (replace) {
-            case "always":
-                return true;
-            case "stopped":
-                return restart == null || restart.equals("true");
-            case "never":
-            default:
-                return false;
-        }
+                    return desc;
+                });
     }
-    // Default behavior if 'replace' is not specified
-    return restart != null && restart.equals("true");
-}
 
+    private boolean shouldRestartRecording(String replace, String restart) {
+        if (replace != null) {
+            switch (replace) {
+                case "always":
+                    return true;
+                case "stopped":
+                    return restart == null || restart.equals("true");
+                case "never":
+                default:
+                    return false;
+            }
+        }
+        // Default behavior if 'replace' is not specified
+        return restart != null && restart.equals("true");
+    }
 
     // end of edited //
 

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -141,7 +141,6 @@ public class RecordingTargetHelper {
             boolean archiveOnStop)
             throws Exception {
         String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
-        // boolean restartRecording = shouldRestartRecording(replace);
 
         return targetConnectionManager.executeConnectedTask(
                 connectionDescriptor,

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -154,10 +154,7 @@ public class RecordingTargetHelper {
                             if (isRecordingStopped(previous.get())) {
                                 connection.getService().close(previous.get());
                             } else {
-                                // If recording exists and running, stop and close it before
-                                // starting a
-                                // new one
-                                connection.getService().stop(previous.get());
+                                // If recording exists & running, close it before starting new one
                                 connection.getService().close(previous.get());
                             }
                         } else {

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -142,6 +142,9 @@ public class RecordingTargetHelper {
                                             recordingName));
                         } else if (isRecordingStopped(previous.get())) {
                             connection.getService().close(previous.get());
+                        }else{
+                            // if recording exists and still running, do nothing.
+                            return previous.get();
                         }
                     }
                     IRecordingDescriptor desc =

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -29,8 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
@@ -38,7 +36,6 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor.RecordingState;
 
-import dagger.Lazy;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.Template;
@@ -51,9 +48,13 @@ import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
+
+import dagger.Lazy;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class RecordingTargetHelper {
 
@@ -113,79 +114,6 @@ public class RecordingTargetHelper {
                 connection -> connection.getService().getAvailableRecordings());
     }
 
-    /* // original code
-    public IRecordingDescriptor startRecording(
-            boolean restart,
-            ConnectionDescriptor connectionDescriptor,
-            IConstrainedMap<String> recordingOptions,
-            String templateName,
-            TemplateType templateType,
-            Metadata metadata,
-            boolean archiveOnStop)
-            throws Exception {
-        String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
-        return targetConnectionManager.executeConnectedTask(
-                connectionDescriptor,
-                connection -> {
-                    TemplateType preferredTemplateType =
-                            getPreferredTemplateType(connection, templateName, templateType);
-                    Optional<IRecordingDescriptor> previous =
-                            getDescriptorByName(connection, recordingName);
-                    if (previous.isPresent()) {
-                        if (!restart) {
-                            throw new IllegalArgumentException(
-                                    String.format(
-                                            "Recording with name \"%s\" already exists",
-                                            recordingName));
-                        } else {
-                            connection.getService().close(previous.get());
-                        }
-                    }
-                    IRecordingDescriptor desc =
-                            connection
-                                    .getService()
-                                    .start(
-                                            recordingOptions,
-                                            enableEvents(
-                                                    connection,
-                                                    templateName,
-                                                    preferredTemplateType));
-                    String targetId = connectionDescriptor.getTargetId();
-
-                    Map<String, String> labels = metadata.getLabels();
-                    labels.put("template.name", templateName);
-                    labels.put("template.type", preferredTemplateType.name());
-                    Metadata updatedMetadata = new Metadata(labels);
-                    updatedMetadata =
-                            recordingMetadataManager
-                                    .setRecordingMetadata(
-                                            connectionDescriptor, recordingName, updatedMetadata)
-                                    .get();
-                    HyperlinkedSerializableRecordingDescriptor linkedDesc =
-                            new HyperlinkedSerializableRecordingDescriptor(
-                                    desc,
-                                    webServer.get().getDownloadURL(connection, desc.getName()),
-                                    webServer.get().getReportURL(connection, desc.getName()),
-                                    updatedMetadata,
-                                    archiveOnStop);
-                    this.issueNotification(targetId, linkedDesc, CREATION_NOTIFICATION_CATEGORY);
-
-                    Object fixedDuration =
-                            recordingOptions.get(RecordingOptionsBuilder.KEY_DURATION);
-                    if (fixedDuration != null) {
-                        Long delay =
-                                Long.valueOf(fixedDuration.toString().replaceAll("[^0-9]", ""));
-
-                        scheduleRecordingTasks(
-                                recordingName, delay, connectionDescriptor, archiveOnStop);
-                    }
-
-                    return desc;
-                });
-    } */
-
-    // first save
-    // my edited
     public IRecordingDescriptor startRecording(
             String restart, // Deprecated: Use replace parameter instead
             String replace,
@@ -198,8 +126,6 @@ public class RecordingTargetHelper {
             throws Exception {
         String recordingName = (String) recordingOptions.get(RecordingOptionsBuilder.KEY_NAME);
         boolean restartRecording = shouldRestartRecording(replace, restart);
-         System.out.println("++==Restart value: " + restart); // Log the value of restart 
-          System.out.println("++==Replace value: " + replace);
 
         return targetConnectionManager.executeConnectedTask(
                 connectionDescriptor,
@@ -255,50 +181,36 @@ public class RecordingTargetHelper {
                         scheduleRecordingTasks(
                                 recordingName, delay, connectionDescriptor, archiveOnStop);
                     }
-
                     return desc;
                 });
     }
 
     private boolean shouldRestartRecording(String replace, String restart) {
-        System.out.println("++replace: " + replace);
-        System.out.println("++restart: " + restart);
-    
-        if (replace != null && !replace.isEmpty()) {
+        if (replace != null) {
             switch (replace) {
                 case "always":
-                    System.out.println("++replace is 'always'");
                     return true;
                 case "stopped":
-                    System.out.println("replace is 'stopped'");
                     // Check if the recording is stopped
                     boolean isStopped = isRecordingStopped(replace);
-                    System.out.println("++isStopped: " + isStopped);
                     return isStopped;
                 case "never":
-                    System.out.println("++replace is 'never'");
                     return false;
             }
         }
-    
         // Handle restart parameter (deprecated)
-        if (restart != null && !restart.isEmpty()) {  // Check 'restart' parameter here
-        System.out.println("++Handling restart parameter");
-        boolean isStopped = isRecordingStopped(restart);
-        System.out.println("++isStopped: " + isStopped);
-        return isStopped;
-    }
-    // if neither restart nor replace is specified, default to never
-    System.out.println("++Defaulting to 'never'");
+        if (restart != null) {
+            boolean isStopped = isRecordingStopped(restart);
+            return isStopped;
+        }
+        // if neither restart nor replace is specified, default to never
         return false;
     }
-    
+
     private boolean isRecordingStopped(String restart) {
         // If restart is null or "true", consider the recording as stopped
         return restart != null && restart.equals("true");
     }
-
-    // end of edited //
 
     /**
      * The returned {@link InputStream}, if any, is only readable while the remote connection

--- a/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingTargetHelper.java
@@ -115,7 +115,7 @@ public class RecordingTargetHelper {
     }
 
     public IRecordingDescriptor startRecording(
-            Boolean restart, // Deprecated: Use replace parameter instead
+            boolean restart, // Deprecated: Use replace parameter instead
             String replace,
             ConnectionDescriptor connectionDescriptor,
             IConstrainedMap<String> recordingOptions,
@@ -185,23 +185,19 @@ public class RecordingTargetHelper {
                 });
     }
 
-    private boolean shouldRestartRecording(Boolean restart, String replace) {
+    private boolean shouldRestartRecording(boolean restart, String replace) {
         if (replace != null) {
             switch (replace) {
                 case "always":
                     return true;
                 case "stopped":
-                    return restart != null && restart.equals(true);
+                    return true;
                 case "never":
                     return false;
             }
         }
-        // Handle restart parameter (deprecated)
-        if (restart != null) {
-            return restart.equals(true);
-        }
-        // if neither restart nor replace is specified, default to never
-        return false;
+        // If neither restart nor replace is specified, default to never
+        return restart;
     }
 
     private boolean isRecordingStopped(IRecordingDescriptor recording) {

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -383,7 +383,7 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                                     RecordingTargetHelper.parseEventSpecifierToTemplate(
                                             rule.getEventSpecifier());
                             return recordingTargetHelper.startRecording(
-                                    "true",
+                                    true,
                                     "always",
                                     connectionDescriptor,
                                     builder.build(),

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -48,6 +48,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
+import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
 import io.cryostat.rules.RuleRegistry.RuleEvent;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
@@ -383,8 +384,7 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                                     RecordingTargetHelper.parseEventSpecifierToTemplate(
                                             rule.getEventSpecifier());
                             return recordingTargetHelper.startRecording(
-                                    true,
-                                    "always",
+                                    replacementPolicy.ALWAYS,
                                     connectionDescriptor,
                                     builder.build(),
                                     template.getLeft(),

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -30,7 +30,6 @@ import java.util.function.Consumer;
 
 import javax.script.ScriptException;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -52,8 +51,10 @@ import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.rules.RuleRegistry.RuleEvent;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDiscoveryEvent> {
 

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -48,7 +48,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 import io.cryostat.rules.RuleRegistry.RuleEvent;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
@@ -384,7 +384,7 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                                     RecordingTargetHelper.parseEventSpecifierToTemplate(
                                             rule.getEventSpecifier());
                             return recordingTargetHelper.startRecording(
-                                    replacementPolicy.ALWAYS,
+                                    ReplacementPolicy.ALWAYS,
                                     connectionDescriptor,
                                     builder.build(),
                                     template.getLeft(),

--- a/src/main/java/io/cryostat/rules/RuleProcessor.java
+++ b/src/main/java/io/cryostat/rules/RuleProcessor.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 
 import javax.script.ScriptException;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
@@ -51,10 +52,8 @@ import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.rules.RuleRegistry.RuleEvent;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
-
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
-import org.apache.commons.lang3.tuple.Pair;
 
 public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDiscoveryEvent> {
 
@@ -383,7 +382,8 @@ public class RuleProcessor extends AbstractVerticle implements Consumer<TargetDi
                                     RecordingTargetHelper.parseEventSpecifierToTemplate(
                                             rule.getEventSpecifier());
                             return recordingTargetHelper.startRecording(
-                                    true,
+                                    "true",
+                                    "always",
                                     connectionDescriptor,
                                     builder.build(),
                                     template.getLeft(),

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -8,7 +8,7 @@ scalar Int
 scalar Float
 
 enum ReplacementPolicy {
-    AlWAYS
+    ALWAYS
     STOPPED
     NEVER
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -167,6 +167,7 @@ type RecordingMetadata {
 
 input RecordingSettings {
     restart: Boolean
+    replace: String
     name: String!
     template: String!
     templateType: String!

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -8,7 +8,7 @@ scalar Int
 scalar Float
 
 enum ReplacementPolicy {
-    ALWAYS
+    AlWAYS
     STOPPED
     NEVER
 }

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -7,6 +7,12 @@ scalar Long
 scalar Int
 scalar Float
 
+enum ReplacementPolicy{
+    AlWAYS
+    STOPPED
+    NEVER
+}
+
 input EnvironmentNodeFilterInput {
     id: Int
     name: String
@@ -166,8 +172,7 @@ type RecordingMetadata {
 }
 
 input RecordingSettings {
-    restart: Boolean
-    replace: String
+    replace: ReplacementPolicy
     name: String!
     template: String!
     templateType: String!

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -7,7 +7,7 @@ scalar Long
 scalar Int
 scalar Float
 
-enum ReplacementPolicy{
+enum ReplacementPolicy {
     AlWAYS
     STOPPED
     NEVER

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -182,7 +182,7 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.any(),
+                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -203,7 +203,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -233,7 +233,7 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo("false"));
+        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
 
         MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("never"));
 
@@ -292,7 +292,7 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.any(),
+                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -324,7 +324,7 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingOptionsBuilder).name("someRecording");
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -354,7 +354,7 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo("true"));
+        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(true));
 
         MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("always"));
 
@@ -403,7 +403,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(recordingOptionsBuilder.build()).thenReturn(recordingOptions);
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.any(),
+                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -567,7 +567,7 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.any(),
+                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -588,7 +588,7 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -618,7 +618,7 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo("false"));
+        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
 
         MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("never"));
 

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -558,7 +558,6 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                // Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -235,7 +235,7 @@ class TargetRecordingsPostHandlerTest {
 
         MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
 
-        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("never"));
+        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo(null));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -620,7 +620,7 @@ class TargetRecordingsPostHandlerTest {
 
         MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
 
-        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("never"));
+        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo(null));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -43,6 +43,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
+import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
 
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
@@ -182,7 +183,6 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -203,9 +203,8 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -224,7 +223,6 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
@@ -233,9 +231,8 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
-
-        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo(null));
+        MatcherAssert.assertThat(
+                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.NEVER));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -292,7 +289,6 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -315,7 +311,6 @@ class TargetRecordingsPostHandlerTest {
                         resp.putHeader(
                                 Mockito.any(CharSequence.class), Mockito.any(CharSequence.class)))
                 .thenReturn(resp);
-        attrs.add("restart", "true"); // deprecated use replace
         attrs.add("replace", "always");
         attrs.add("recordingName", "someRecording");
         attrs.add("events", "template=Foo");
@@ -324,9 +319,8 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingOptionsBuilder).name("someRecording");
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -345,7 +339,6 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
@@ -354,9 +347,8 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(true));
-
-        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo("always"));
+        MatcherAssert.assertThat(
+                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -403,7 +395,6 @@ class TargetRecordingsPostHandlerTest {
         Mockito.when(recordingOptionsBuilder.build()).thenReturn(recordingOptions);
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -567,7 +558,7 @@ class TargetRecordingsPostHandlerTest {
         IRecordingDescriptor descriptor = createDescriptor("someRecording");
         Mockito.when(
                         recordingTargetHelper.startRecording(
-                                Mockito.anyBoolean(),
+                                // Mockito.anyBoolean(),
                                 Mockito.any(),
                                 Mockito.any(),
                                 Mockito.any(),
@@ -588,9 +579,8 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -609,7 +599,6 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
@@ -618,9 +607,8 @@ class TargetRecordingsPostHandlerTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        MatcherAssert.assertThat(restartCaptor.getValue(), Matchers.equalTo(false));
-
-        MatcherAssert.assertThat(replaceCaptor.getValue(), Matchers.equalTo(null));
+        MatcherAssert.assertThat(
+                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.NEVER));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
+++ b/src/test/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandlerTest.java
@@ -43,7 +43,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 
 import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
@@ -203,8 +203,8 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -232,7 +232,7 @@ class TargetRecordingsPostHandlerTest {
                         archiveOnStopCaptor.capture());
 
         MatcherAssert.assertThat(
-                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.NEVER));
+                replaceCaptor.getValue(), Matchers.equalTo(ReplacementPolicy.NEVER));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -319,8 +319,8 @@ class TargetRecordingsPostHandlerTest {
 
         Mockito.verify(recordingOptionsBuilder).name("someRecording");
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -348,7 +348,7 @@ class TargetRecordingsPostHandlerTest {
                         archiveOnStopCaptor.capture());
 
         MatcherAssert.assertThat(
-                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
+                replaceCaptor.getValue(), Matchers.equalTo(ReplacementPolicy.ALWAYS));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -579,8 +579,8 @@ class TargetRecordingsPostHandlerTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(50L);
         Mockito.verify(recordingOptionsBuilder).maxSize(64L);
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -608,7 +608,7 @@ class TargetRecordingsPostHandlerTest {
                         archiveOnStopCaptor.capture());
 
         MatcherAssert.assertThat(
-                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.NEVER));
+                replaceCaptor.getValue(), Matchers.equalTo(ReplacementPolicy.NEVER));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -54,6 +54,7 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
+import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
 
 import io.vertx.core.Vertx;
 import org.hamcrest.MatcherAssert;
@@ -730,8 +731,7 @@ public class RecordingTargetHelperTest {
                         });
 
         recordingTargetHelper.startRecording(
-                false,
-                "never",
+                replacementPolicy.NEVER,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -831,8 +831,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                false,
-                "always",
+                replacementPolicy.ALWAYS,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -894,8 +893,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                false,
-                "always",
+                replacementPolicy.ALWAYS,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -955,8 +953,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                false,
-                "stopped",
+                replacementPolicy.STOPPED,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -730,7 +730,7 @@ public class RecordingTargetHelperTest {
                         });
 
         recordingTargetHelper.startRecording(
-                "false",
+                false,
                 "never",
                 connectionDescriptor,
                 recordingOptions,

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -53,8 +53,8 @@ import io.cryostat.net.reports.ReportService;
 import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
 
 import io.vertx.core.Vertx;
 import org.hamcrest.MatcherAssert;
@@ -731,7 +731,7 @@ public class RecordingTargetHelperTest {
                         });
 
         recordingTargetHelper.startRecording(
-                replacementPolicy.NEVER,
+                ReplacementPolicy.NEVER,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -831,7 +831,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                replacementPolicy.ALWAYS,
+                ReplacementPolicy.ALWAYS,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -893,7 +893,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                replacementPolicy.ALWAYS,
+                ReplacementPolicy.ALWAYS,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,
@@ -953,7 +953,7 @@ public class RecordingTargetHelperTest {
         Mockito.doNothing().when(notification).send();
 
         recordingTargetHelper.startRecording(
-                replacementPolicy.STOPPED,
+                ReplacementPolicy.STOPPED,
                 connectionDescriptor,
                 recordingOptions,
                 templateName,

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -30,20 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
@@ -68,7 +54,22 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
+
 import io.vertx.core.Vertx;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingTargetHelperTest {

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -30,6 +30,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
@@ -54,22 +68,7 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
-
 import io.vertx.core.Vertx;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingTargetHelperTest {

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -847,7 +847,7 @@ public class RecordingTargetHelperTest {
     }
 
     @Test
-    void shouldStopAndRecreateIfRecordingExistsAndIsRunning() throws Exception {
+    void shouldCloseAndRecreateIfRecordingExistsAndIsRunning() throws Exception {
         String recordingName = "existingRecording";
         String targetId = "fooTarget";
         String duration = "5000ms";
@@ -901,7 +901,6 @@ public class RecordingTargetHelperTest {
                 metadata,
                 false);
 
-        Mockito.verify(service).stop(existingRecording);
         Mockito.verify(service).close(existingRecording);
         Mockito.verify(service).start(Mockito.any(), Mockito.any());
     }

--- a/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingTargetHelperTest.java
@@ -15,7 +15,7 @@
  */
 package io.cryostat.recordings;
 
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,6 +30,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
@@ -54,22 +68,7 @@ import io.cryostat.net.web.WebServer;
 import io.cryostat.net.web.http.HttpMimeType;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingTargetHelper.SnapshotCreationException;
-
 import io.vertx.core.Vertx;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordingTargetHelperTest {
@@ -730,7 +729,8 @@ public class RecordingTargetHelperTest {
                         });
 
         recordingTargetHelper.startRecording(
-                false,
+                "false",
+                "never",
                 connectionDescriptor,
                 recordingOptions,
                 templateName,

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -474,7 +474,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-         Assertions.assertTrue(restartCaptor.getValue());
+        Assertions.assertTrue(restartCaptor.getValue());
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
 

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -54,6 +54,7 @@ import io.vertx.core.Vertx;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -187,7 +188,7 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -217,7 +218,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        assertEquals("true", restartCaptor.getValue());
+        Assertions.assertTrue(restartCaptor.getValue());
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -443,7 +444,7 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -473,8 +474,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        assertEquals("true", restartCaptor.getValue());
-
+         Assertions.assertTrue(restartCaptor.getValue());
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
 
@@ -514,7 +514,7 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingOptionsBuilder, never()).name("auto_Test_Rule");
 
-        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
 
         ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -46,7 +46,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
-import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
+import io.cryostat.recordings.RecordingTargetHelper.ReplacementPolicy;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
 
@@ -188,8 +188,8 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -217,7 +217,7 @@ class RuleProcessorTest {
                         archiveOnStopCaptor.capture());
 
         MatcherAssert.assertThat(
-                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
+                replaceCaptor.getValue(), Matchers.equalTo(ReplacementPolicy.ALWAYS));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -443,8 +443,8 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -472,7 +472,7 @@ class RuleProcessorTest {
                         archiveOnStopCaptor.capture());
 
         MatcherAssert.assertThat(
-                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
+                replaceCaptor.getValue(), Matchers.equalTo(ReplacementPolicy.ALWAYS));
 
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
@@ -513,8 +513,8 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingOptionsBuilder, never()).name("auto_Test_Rule");
 
-        ArgumentCaptor<replacementPolicy> replaceCaptor =
-                ArgumentCaptor.forClass(replacementPolicy.class);
+        ArgumentCaptor<ReplacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(ReplacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -23,19 +23,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
@@ -61,8 +48,22 @@ import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
+
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class RuleProcessorTest {
@@ -188,8 +189,7 @@ class RuleProcessorTest {
 
         ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
 
-                        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
-
+        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -217,7 +217,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-assertEquals("true", restartCaptor.getValue());
+        assertEquals("true", restartCaptor.getValue());
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -445,8 +445,7 @@ assertEquals("true", restartCaptor.getValue());
 
         ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
 
-                ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
-
+        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -474,7 +473,7 @@ assertEquals("true", restartCaptor.getValue());
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-                        assertEquals("true", restartCaptor.getValue());
+        assertEquals("true", restartCaptor.getValue());
 
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
@@ -517,8 +516,7 @@ assertEquals("true", restartCaptor.getValue());
 
         ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
 
-                ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
-
+        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -547,4 +545,3 @@ assertEquals("true", restartCaptor.getValue());
                         archiveOnStopCaptor.capture());
     }
 }
-// first save

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -15,13 +15,27 @@
  */
 package io.cryostat.rules;
 
-import static org.mockito.Mockito.never;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.net.URI;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBuilder;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
@@ -47,23 +61,8 @@ import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
-
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import org.apache.commons.lang3.tuple.Pair;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class RuleProcessorTest {
@@ -187,7 +186,10 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+
+                        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -207,6 +209,7 @@ class RuleProcessorTest {
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
                         restartCaptor.capture(),
+                        replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
                         templateNameCaptor.capture(),
@@ -214,7 +217,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        Assertions.assertTrue(restartCaptor.getValue());
+assertEquals("true", restartCaptor.getValue());
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -440,7 +443,10 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+
+                ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -460,6 +466,7 @@ class RuleProcessorTest {
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
                         restartCaptor.capture(),
+                        replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
                         templateNameCaptor.capture(),
@@ -467,7 +474,7 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        Assertions.assertTrue(restartCaptor.getValue());
+                        assertEquals("true", restartCaptor.getValue());
 
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
@@ -508,7 +515,10 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingOptionsBuilder, never()).name("auto_Test_Rule");
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> restartCaptor = ArgumentCaptor.forClass(String.class);
+
+                ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -528,6 +538,7 @@ class RuleProcessorTest {
         Mockito.verify(recordingTargetHelper, never())
                 .startRecording(
                         restartCaptor.capture(),
+                        replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
                         templateNameCaptor.capture(),
@@ -536,3 +547,4 @@ class RuleProcessorTest {
                         archiveOnStopCaptor.capture());
     }
 }
+// first save

--- a/src/test/java/io/cryostat/rules/RuleProcessorTest.java
+++ b/src/test/java/io/cryostat/rules/RuleProcessorTest.java
@@ -46,6 +46,7 @@ import io.cryostat.recordings.RecordingMetadataManager;
 import io.cryostat.recordings.RecordingMetadataManager.Metadata;
 import io.cryostat.recordings.RecordingOptionsBuilderFactory;
 import io.cryostat.recordings.RecordingTargetHelper;
+import io.cryostat.recordings.RecordingTargetHelper.replacementPolicy;
 import io.cryostat.util.events.Event;
 import io.cryostat.util.events.EventListener;
 
@@ -54,7 +55,6 @@ import io.vertx.core.Vertx;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -188,9 +188,8 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -209,7 +208,6 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
@@ -218,7 +216,8 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        Assertions.assertTrue(restartCaptor.getValue());
+        MatcherAssert.assertThat(
+                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
 
         ConnectionDescriptor connectionDescriptor = connectionDescriptorCaptor.getValue();
         MatcherAssert.assertThat(
@@ -444,9 +443,8 @@ class RuleProcessorTest {
         Mockito.verify(recordingOptionsBuilder).maxAge(30);
         Mockito.verify(recordingOptionsBuilder).maxSize(1234);
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -465,7 +463,6 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingTargetHelper)
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),
@@ -474,7 +471,9 @@ class RuleProcessorTest {
                         metadataCaptor.capture(),
                         archiveOnStopCaptor.capture());
 
-        Assertions.assertTrue(restartCaptor.getValue());
+        MatcherAssert.assertThat(
+                replaceCaptor.getValue(), Matchers.equalTo(replacementPolicy.ALWAYS));
+
         IConstrainedMap<String> actualRecordingOptions = recordingOptionsCaptor.getValue();
         MatcherAssert.assertThat(actualRecordingOptions, Matchers.sameInstance(recordingOptions));
 
@@ -514,9 +513,8 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingOptionsBuilder, never()).name("auto_Test_Rule");
 
-        ArgumentCaptor<Boolean> restartCaptor = ArgumentCaptor.forClass(Boolean.class);
-
-        ArgumentCaptor<String> replaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<replacementPolicy> replaceCaptor =
+                ArgumentCaptor.forClass(replacementPolicy.class);
 
         ArgumentCaptor<ConnectionDescriptor> connectionDescriptorCaptor =
                 ArgumentCaptor.forClass(ConnectionDescriptor.class);
@@ -535,7 +533,6 @@ class RuleProcessorTest {
 
         Mockito.verify(recordingTargetHelper, never())
                 .startRecording(
-                        restartCaptor.capture(),
                         replaceCaptor.capture(),
                         connectionDescriptorCaptor.capture(),
                         recordingOptionsCaptor.capture(),

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -82,10 +82,10 @@ class GraphQLIT extends ExternalTargetsTest {
             CONTAINERS.add(Podman.run(spec));
         }
         CompletableFuture.allOf(
-                CONTAINERS.stream()
-                        .map(id -> Podman.waitForContainerState(id, "running"))
-                        .collect(Collectors.toList())
-                        .toArray(new CompletableFuture[0]))
+                        CONTAINERS.stream()
+                                .map(id -> Podman.waitForContainerState(id, "running"))
+                                .collect(Collectors.toList())
+                                .toArray(new CompletableFuture[0]))
                 .join();
         waitForDiscovery(NUM_EXT_CONTAINERS);
     }
@@ -177,20 +177,22 @@ class GraphQLIT extends ExternalTargetsTest {
         TargetNode cryostat = new TargetNode();
         Target cryostatTarget = new Target();
         cryostatTarget.alias = "io.cryostat.Cryostat";
-        cryostatTarget.serviceUri = String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
+        cryostatTarget.serviceUri =
+                String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
         cryostat.name = cryostatTarget.serviceUri;
         cryostat.target = cryostatTarget;
         cryostat.nodeType = "JVM";
         Annotations cryostatAnnotations = new Annotations();
-        cryostatAnnotations.cryostat = Map.of(
-                "REALM",
-                "JDP",
-                "JAVA_MAIN",
-                "io.cryostat.Cryostat",
-                "HOST",
-                Podman.POD_NAME,
-                "PORT",
-                "9091");
+        cryostatAnnotations.cryostat =
+                Map.of(
+                        "REALM",
+                        "JDP",
+                        "JAVA_MAIN",
+                        "io.cryostat.Cryostat",
+                        "HOST",
+                        Podman.POD_NAME,
+                        "PORT",
+                        "9091");
         cryostatAnnotations.platform = Map.of();
         cryostatTarget.annotations = cryostatAnnotations;
         cryostat.labels = Map.of();
@@ -198,8 +200,9 @@ class GraphQLIT extends ExternalTargetsTest {
 
         for (int i = 0; i < NUM_EXT_CONTAINERS; i++) {
             int port = 9093 + i;
-            String uri = String.format(
-                    "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, port);
+            String uri =
+                    String.format(
+                            "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, port);
             String mainClass = "es.andrewazor.demo.Main";
             TargetNode ext = new TargetNode();
             Target target = new Target();
@@ -209,15 +212,16 @@ class GraphQLIT extends ExternalTargetsTest {
             ext.target = target;
             ext.nodeType = "JVM";
             Annotations annotations = new Annotations();
-            annotations.cryostat = Map.of(
-                    "REALM",
-                    "JDP",
-                    "JAVA_MAIN",
-                    mainClass,
-                    "HOST",
-                    Podman.POD_NAME,
-                    "PORT",
-                    Integer.toString(port));
+            annotations.cryostat =
+                    Map.of(
+                            "REALM",
+                            "JDP",
+                            "JAVA_MAIN",
+                            mainClass,
+                            "HOST",
+                            Podman.POD_NAME,
+                            "PORT",
+                            Integer.toString(port));
             annotations.platform = Map.of();
             target.annotations = annotations;
             ext.labels = Map.of();
@@ -249,7 +253,8 @@ class GraphQLIT extends ExternalTargetsTest {
         TargetNodesQueryResponse actual = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
 
-        String uri = String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, 9093);
+        String uri =
+                String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, 9093);
         TargetNode ext = new TargetNode();
         ext.name = uri;
         ext.nodeType = "JVM";
@@ -265,29 +270,31 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
-                        + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
-                        + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
-                        + " name state duration archiveOnStop }} }");
-        Map<String, String> expectedLabels = Map.of(
-                "template.name",
-                "Profiling",
-                "template.type",
-                "TARGET",
-                "newLabel",
-                "someValue");
-        Future<JsonObject> f = worker.submit(
-                () -> {
-                    try {
-                        return expectNotification(
-                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                .get();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
+                    + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
+                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
+                    + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
+                    + " name state duration archiveOnStop }} }");
+        Map<String, String> expectedLabels =
+                Map.of(
+                        "template.name",
+                        "Profiling",
+                        "template.type",
+                        "TARGET",
+                        "newLabel",
+                        "someValue");
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
 
         Thread.sleep(5000); // Sleep to setup notification listening before query resolves
 
@@ -310,7 +317,8 @@ class GraphQLIT extends ExternalTargetsTest {
         // Ensure ActiveRecordingCreated notification emitted matches expected values
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
 
-        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording =
+                notification.getJsonObject("message").getJsonObject("recording");
         MatcherAssert.assertThat(
                 notificationRecording.getString("name"), Matchers.equalTo("graphql-itest"));
         MatcherAssert.assertThat(
@@ -321,8 +329,8 @@ class GraphQLIT extends ExternalTargetsTest {
                         String.format(
                                 "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
                                 Podman.POD_NAME, 9093)));
-        Map<String, Object> notificationLabels = notificationRecording.getJsonObject("metadata").getJsonObject("labels")
-                .getMap();
+        Map<String, Object> notificationLabels =
+                notificationRecording.getJsonObject("metadata").getJsonObject("labels").getMap();
         for (var entry : expectedLabels.entrySet()) {
             MatcherAssert.assertThat(
                     notificationLabels, Matchers.hasEntry(entry.getKey(), entry.getValue()));
@@ -578,11 +586,12 @@ class GraphQLIT extends ExternalTargetsTest {
     void testQueryForSpecificTargetsByNames() throws Exception {
         CompletableFuture<TargetNodesQueryResponse> resp = new CompletableFuture<>();
 
-        String query = String.format(
-                "query { targetNodes(filter: { names:"
-                        + " [\"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\","
-                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9093/jmxrmi\"] }) {"
-                        + " name nodeType } }");
+        String query =
+                String.format(
+                        "query { targetNodes(filter: { names:"
+                            + " [\"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\","
+                            + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9093/jmxrmi\"] }) {"
+                            + " name nodeType } }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -664,10 +673,11 @@ class GraphQLIT extends ExternalTargetsTest {
 
         // GraphQL Query to filter Active recordings by names
         CompletableFuture<TargetNodesQueryResponse> resp2 = new CompletableFuture<>();
-        String query = "query { targetNodes (filter: {name:"
-                + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\"}){ recordings"
-                + " {active(filter: { names: [\"Recording1\", \"Recording2\",\"Recording3\"] })"
-                + " {data {name}}}}}";
+        String query =
+                "query { targetNodes (filter: {name:"
+                    + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\"}){ recordings"
+                    + " {active(filter: { names: [\"Recording1\", \"Recording2\",\"Recording3\"] })"
+                    + " {data {name}}}}}";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -685,10 +695,11 @@ class GraphQLIT extends ExternalTargetsTest {
 
         List<String> filterNames = Arrays.asList("Recording1", "Recording2");
 
-        List<ActiveRecording> filteredRecordings = graphqlResp.data.targetNodes.stream()
-                .flatMap(targetNode -> targetNode.recordings.active.data.stream())
-                .filter(recording -> filterNames.contains(recording.name))
-                .collect(Collectors.toList());
+        List<ActiveRecording> filteredRecordings =
+                graphqlResp.data.targetNodes.stream()
+                        .flatMap(targetNode -> targetNode.recordings.active.data.stream())
+                        .filter(recording -> filterNames.contains(recording.name))
+                        .collect(Collectors.toList());
 
         MatcherAssert.assertThat(filteredRecordings.size(), Matchers.equalTo(2));
         ActiveRecording r1 = new ActiveRecording();
@@ -799,25 +810,27 @@ class GraphQLIT extends ExternalTargetsTest {
                                 archivedRecordingsFuture2.complete(ar.result().bodyAsJsonArray());
                             }
                         });
-        JsonArray retrivedArchivedRecordings = archivedRecordingsFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray retrivedArchivedRecordings =
+                archivedRecordingsFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         JsonObject retrievedArchivedrecordings = retrivedArchivedRecordings.getJsonObject(0);
         String retrievedArchivedRecordingsName = retrievedArchivedrecordings.getString("name");
 
         // GraphQL Query to filter Archived recordings by names
         CompletableFuture<TargetNodesQueryResponse> resp2 = new CompletableFuture<>();
 
-        String query = "query { targetNodes {"
-                + "recordings {"
-                + "archived(filter: { names: [\""
-                + retrievedArchivedRecordingsName
-                + "\",\"someOtherName\"] }) {"
-                + "data {"
-                + "name"
-                + "}"
-                + "}"
-                + "}"
-                + "}"
-                + "}";
+        String query =
+                "query { targetNodes {"
+                        + "recordings {"
+                        + "archived(filter: { names: [\""
+                        + retrievedArchivedRecordingsName
+                        + "\",\"someOtherName\"] }) {"
+                        + "data {"
+                        + "name"
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -832,9 +845,10 @@ class GraphQLIT extends ExternalTargetsTest {
                         });
 
         TargetNodesQueryResponse graphqlResp = resp2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        List<ArchivedRecording> archivedRecordings2 = graphqlResp.data.targetNodes.stream()
-                .flatMap(targetNode -> targetNode.recordings.archived.data.stream())
-                .collect(Collectors.toList());
+        List<ArchivedRecording> archivedRecordings2 =
+                graphqlResp.data.targetNodes.stream()
+                        .flatMap(targetNode -> targetNode.recordings.archived.data.stream())
+                        .collect(Collectors.toList());
 
         int filteredRecordingsCount = archivedRecordings2.size();
         Assertions.assertEquals(
@@ -884,16 +898,17 @@ class GraphQLIT extends ExternalTargetsTest {
                             }
                         });
 
-        JsonArray updatedArchivedRecordings = updatedArchivedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS,
-                TimeUnit.SECONDS);
+        JsonArray updatedArchivedRecordings =
+                updatedArchivedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Assert that the targeted recordings have been deleted
-        boolean recordingsDeleted = updatedArchivedRecordings.stream()
-                .noneMatch(
-                        json -> {
-                            JsonObject recording = (JsonObject) json;
-                            return recording.getString("name").equals(TEST_RECORDING_NAME);
-                        });
+        boolean recordingsDeleted =
+                updatedArchivedRecordings.stream()
+                        .noneMatch(
+                                json -> {
+                                    JsonObject recording = (JsonObject) json;
+                                    return recording.getString("name").equals(TEST_RECORDING_NAME);
+                                });
 
         Assertions.assertTrue(
                 recordingsDeleted, "The targeted archived recordings should be deleted");
@@ -924,7 +939,8 @@ class GraphQLIT extends ExternalTargetsTest {
                             }
                         });
 
-        JsonArray savedRecordings = savedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray savedRecordings =
+                savedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         for (Object savedRecording : savedRecordings) {
             String recordingName = ((JsonObject) savedRecording).getString("name");
@@ -952,8 +968,9 @@ class GraphQLIT extends ExternalTargetsTest {
     public void testQueryforFilteredEnvironmentNodesByNames() throws Exception {
         CompletableFuture<EnvironmentNodesResponse> resp = new CompletableFuture<>();
 
-        String query = "query { environmentNodes(filter: { names: [\"anotherName1\","
-                + " \"JDP\",\"anotherName2\"] }) { name nodeType } }";
+        String query =
+                "query { environmentNodes(filter: { names: [\"anotherName1\","
+                        + " \"JDP\",\"anotherName2\"] }) { name nodeType } }";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -1010,22 +1027,23 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                        + " state}} }");
 
-            Future<JsonObject> f3 = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+            Future<JsonObject> f3 =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
             webClient
@@ -1046,7 +1064,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 =
+                    notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1086,9 +1105,9 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                        + " state}} }");
 
             Thread.sleep(5000);
             webClient
@@ -1149,22 +1168,23 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                        + " state}} }");
 
-            Future<JsonObject> f3 = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+            Future<JsonObject> f3 =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
             webClient
@@ -1185,7 +1205,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 =
+                    notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1217,22 +1238,23 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                        + " state}} }");
 
-            Future<JsonObject> f3 = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+            Future<JsonObject> f3 =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
             webClient
@@ -1253,7 +1275,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 =
+                    notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1285,9 +1308,9 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                        + " state}} }");
 
             Thread.sleep(5000);
             webClient
@@ -1341,22 +1364,23 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                            + " state}} }");
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                        + " state}} }");
 
-            Future<JsonObject> f3 = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+            Future<JsonObject> f3 =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
             webClient
@@ -1377,7 +1401,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 =
+                    notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1400,21 +1425,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                            + " state}} }");
-            Future<JsonObject> f = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                        + " state}} }");
+            Future<JsonObject> f =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
 
@@ -1436,7 +1462,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording =
+                    notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1459,21 +1486,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                            + " state}} }");
-            Future<JsonObject> f = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                        + " state}} }");
+            Future<JsonObject> f =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
 
@@ -1495,7 +1523,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording =
+                    notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1518,21 +1547,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                            + " state}} }");
-            Future<JsonObject> f = worker.submit(
-                    () -> {
-                        try {
-                            return expectNotification(
-                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                    .get();
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            latch.countDown();
-                        }
-                    });
+                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                        + " state}} }");
+            Future<JsonObject> f =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
 
             Thread.sleep(5000);
             webClient
@@ -1553,7 +1583,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording =
+                    notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1690,17 +1721,12 @@ class GraphQLIT extends ExternalTargetsTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
             AggregateInfo other = (AggregateInfo) obj;
-            if (count != other.count)
-                return false;
-            if (size != other.size)
-                return false;
+            if (count != other.count) return false;
+            if (size != other.size) return false;
             return true;
         }
     }
@@ -2317,18 +2343,19 @@ class GraphQLIT extends ExternalTargetsTest {
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
                         + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
                         + " \"Profiling\", templateType: \"TARGET\"}) { name state}} }");
-        Future<JsonObject> f = worker.submit(
-                () -> {
-                    try {
-                        return expectNotification(
-                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                .get();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
 
         Thread.sleep(5000);
 
@@ -2349,7 +2376,8 @@ class GraphQLIT extends ExternalTargetsTest {
         latch.await(30, TimeUnit.SECONDS);
 
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
-        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording =
+                notification.getJsonObject("message").getJsonObject("recording");
 
         notificationRecordingHolder[0] = notificationRecording;
     }
@@ -2366,18 +2394,19 @@ class GraphQLIT extends ExternalTargetsTest {
                         + " doStop(recording: { name: \"test\", duration: 30, template:"
                         + " \"Profiling\", templateType: \"TARGET\"}) { name state }} }");
 
-        Future<JsonObject> f = worker.submit(
-                () -> {
-                    try {
-                        return expectNotification(
-                                "ActiveRecordingStopped", 15, TimeUnit.SECONDS)
-                                .get();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
+        Future<JsonObject> f =
+                worker.submit(
+                        () -> {
+                            try {
+                                return expectNotification(
+                                                "ActiveRecordingStopped", 15, TimeUnit.SECONDS)
+                                        .get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
 
         Thread.sleep(5000);
 
@@ -2398,7 +2427,8 @@ class GraphQLIT extends ExternalTargetsTest {
         latch.await(30, TimeUnit.SECONDS);
 
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
-        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording =
+                notification.getJsonObject("message").getJsonObject("recording");
 
         notificationRecordingHolder[0] = notificationRecording;
     }

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -19,6 +19,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
+import com.google.gson.Gson;
+import io.cryostat.MainModule;
+import io.cryostat.core.log.Logger;
+import io.cryostat.net.web.http.HttpMimeType;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.bases.ExternalTargetsTest;
+import itest.util.ITestCleanupFailedException;
+import itest.util.Podman;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -33,20 +45,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import io.cryostat.MainModule;
-import io.cryostat.core.log.Logger;
-import io.cryostat.net.web.http.HttpMimeType;
-
-import com.google.gson.Gson;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import itest.bases.ExternalTargetsTest;
-import itest.util.ITestCleanupFailedException;
-import itest.util.Podman;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -56,6 +54,8 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+
 
 @TestMethodOrder(OrderAnnotation.class)
 class GraphQLIT extends ExternalTargetsTest {
@@ -995,6 +995,30 @@ class GraphQLIT extends ExternalTargetsTest {
         }
         Assertions.assertTrue(nameExists, "Name not found");
     }
+
+    // new added test
+
+    /* @Order(13) // Add a new order for this test
+    void testReplaceAlwaysOnStoppedRecording() throws Exception {
+                System.out.println("++This is a test");
+
+        // check if any recordings exist
+        CompletableFuture<JsonArray> listRespFuture1 = new CompletableFuture<>();
+        webClient
+                .get(String.format("/api/v1/targets/%s/recordings", SELF_REFERENCE_TARGET_ID))
+                .send(
+                        ar -> {
+                            if (assertRequestStatus(ar, listRespFuture1)) {
+                                listRespFuture1.complete(ar.result().bodyAsJsonArray());
+                            }
+                        });
+        JsonArray listResp = listRespFuture1.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertFalse(listResp.isEmpty());
+        System.out.println("++Recording status before Step 4: " + listResp.encodePrettily());
+        System.out.println("++This is a test");
+
+     } */
+
 
     static class Target {
         String alias;

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -2051,7 +2051,7 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: {"
-                        + " name:\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\" }) { name"
+                        + " name:\"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" }) {"
                         + " doStartRecording(recording: { name: \"test\", template:\"Profiling\","
                         + " templateType: \"TARGET\"}) { name state}} }");
         Future<JsonObject> f =
@@ -2102,9 +2102,9 @@ class GraphQLIT extends ExternalTargetsTest {
         CompletableFuture<StartRecordingMutationResponse> resp = new CompletableFuture<>();
         query.put(
                 "query",
-                "query { targetNodes(filter: {"
-                    + " name:\\\\\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\\\\\" }) "
-                    + " {name recordings { active { data { doStop { name state } } } } } }");
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" })  {"
+                        + " recordings { active { data { doStop { name state } } } } } }");
 
         Future<JsonObject> f2 =
                 worker.submit(
@@ -2154,8 +2154,8 @@ class GraphQLIT extends ExternalTargetsTest {
         CompletableFuture<JsonObject> resp = new CompletableFuture<>();
         query.put(
                 "query",
-                "query { targetNodes(filter: {"
-                        + " name:\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\" }) { name"
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" }) {"
                         + " recordings { active { data { doDelete { name state } } } } } }");
 
         Thread.sleep(5000);
@@ -2175,7 +2175,6 @@ class GraphQLIT extends ExternalTargetsTest {
 
         latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         deletedObj = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        System.out.println("++ deleteing");
         System.out.println("++deleteing" + deletedObj.encodePrettily());
     }
 
@@ -2188,8 +2187,8 @@ class GraphQLIT extends ExternalTargetsTest {
         CompletableFuture<StartRecordingMutationResponse> resp = new CompletableFuture<>();
         query.put(
                 "query",
-                "query { targetNodes(filter: {"
-                        + " name:\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\" }) { name"
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" }) {"
                         + " doStartRecording(recording: { name: \"test\", template:\"Profiling\","
                         + " templateType: \"TARGET\", replace:ALWAYS}) { name state}} }");
         Future<JsonObject> f =
@@ -2242,8 +2241,8 @@ class GraphQLIT extends ExternalTargetsTest {
         CompletableFuture<StartRecordingMutationResponse> resp = new CompletableFuture<>();
         query.put(
                 "query",
-                "query { targetNodes(filter: {"
-                    + " name:\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\" }) { name"
+                "query { targetNodes(filter: { name:"
+                    + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" }) {"
                     + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
                     + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name state}}"
                     + " }");
@@ -2296,8 +2295,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
         query.put(
                 "query",
-                "query { targetNodes(filter: {"
-                        + " name:\\\"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\\\" }) {name "
+                "query { targetNodes(filter: { name:"
+                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\" }) {"
                         + " doStartRecording(recording: { name: \"test\", template:\"Profiling\","
                         + " templateType: \"TARGET\", replace:NEVER }) { name state}} }");
 

--- a/src/test/java/itest/GraphQLIT.java
+++ b/src/test/java/itest/GraphQLIT.java
@@ -82,10 +82,10 @@ class GraphQLIT extends ExternalTargetsTest {
             CONTAINERS.add(Podman.run(spec));
         }
         CompletableFuture.allOf(
-                        CONTAINERS.stream()
-                                .map(id -> Podman.waitForContainerState(id, "running"))
-                                .collect(Collectors.toList())
-                                .toArray(new CompletableFuture[0]))
+                CONTAINERS.stream()
+                        .map(id -> Podman.waitForContainerState(id, "running"))
+                        .collect(Collectors.toList())
+                        .toArray(new CompletableFuture[0]))
                 .join();
         waitForDiscovery(NUM_EXT_CONTAINERS);
     }
@@ -177,22 +177,20 @@ class GraphQLIT extends ExternalTargetsTest {
         TargetNode cryostat = new TargetNode();
         Target cryostatTarget = new Target();
         cryostatTarget.alias = "io.cryostat.Cryostat";
-        cryostatTarget.serviceUri =
-                String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
+        cryostatTarget.serviceUri = String.format("service:jmx:rmi:///jndi/rmi://%s:9091/jmxrmi", Podman.POD_NAME);
         cryostat.name = cryostatTarget.serviceUri;
         cryostat.target = cryostatTarget;
         cryostat.nodeType = "JVM";
         Annotations cryostatAnnotations = new Annotations();
-        cryostatAnnotations.cryostat =
-                Map.of(
-                        "REALM",
-                        "JDP",
-                        "JAVA_MAIN",
-                        "io.cryostat.Cryostat",
-                        "HOST",
-                        Podman.POD_NAME,
-                        "PORT",
-                        "9091");
+        cryostatAnnotations.cryostat = Map.of(
+                "REALM",
+                "JDP",
+                "JAVA_MAIN",
+                "io.cryostat.Cryostat",
+                "HOST",
+                Podman.POD_NAME,
+                "PORT",
+                "9091");
         cryostatAnnotations.platform = Map.of();
         cryostatTarget.annotations = cryostatAnnotations;
         cryostat.labels = Map.of();
@@ -200,9 +198,8 @@ class GraphQLIT extends ExternalTargetsTest {
 
         for (int i = 0; i < NUM_EXT_CONTAINERS; i++) {
             int port = 9093 + i;
-            String uri =
-                    String.format(
-                            "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, port);
+            String uri = String.format(
+                    "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, port);
             String mainClass = "es.andrewazor.demo.Main";
             TargetNode ext = new TargetNode();
             Target target = new Target();
@@ -212,16 +209,15 @@ class GraphQLIT extends ExternalTargetsTest {
             ext.target = target;
             ext.nodeType = "JVM";
             Annotations annotations = new Annotations();
-            annotations.cryostat =
-                    Map.of(
-                            "REALM",
-                            "JDP",
-                            "JAVA_MAIN",
-                            mainClass,
-                            "HOST",
-                            Podman.POD_NAME,
-                            "PORT",
-                            Integer.toString(port));
+            annotations.cryostat = Map.of(
+                    "REALM",
+                    "JDP",
+                    "JAVA_MAIN",
+                    mainClass,
+                    "HOST",
+                    Podman.POD_NAME,
+                    "PORT",
+                    Integer.toString(port));
             annotations.platform = Map.of();
             target.annotations = annotations;
             ext.labels = Map.of();
@@ -253,8 +249,7 @@ class GraphQLIT extends ExternalTargetsTest {
         TargetNodesQueryResponse actual = resp.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         MatcherAssert.assertThat(actual.data.targetNodes, Matchers.hasSize(1));
 
-        String uri =
-                String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, 9093);
+        String uri = String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", Podman.POD_NAME, 9093);
         TargetNode ext = new TargetNode();
         ext.name = uri;
         ext.nodeType = "JVM";
@@ -270,31 +265,29 @@ class GraphQLIT extends ExternalTargetsTest {
         query.put(
                 "query",
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                    + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
-                    + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
-                    + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
-                    + " name state duration archiveOnStop }} }");
-        Map<String, String> expectedLabels =
-                Map.of(
-                        "template.name",
-                        "Profiling",
-                        "template.type",
-                        "TARGET",
-                        "newLabel",
-                        "someValue");
-        Future<JsonObject> f =
-                worker.submit(
-                        () -> {
-                            try {
-                                return expectNotification(
-                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                        .get();
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                latch.countDown();
-                            }
-                        });
+                        + " doStartRecording(recording: { name: \"graphql-itest\", duration: 30,"
+                        + " template: \"Profiling\", templateType: \"TARGET\", archiveOnStop: true,"
+                        + " metadata: { labels: [ { key: \"newLabel\", value: \"someValue\"} ] }  }) {"
+                        + " name state duration archiveOnStop }} }");
+        Map<String, String> expectedLabels = Map.of(
+                "template.name",
+                "Profiling",
+                "template.type",
+                "TARGET",
+                "newLabel",
+                "someValue");
+        Future<JsonObject> f = worker.submit(
+                () -> {
+                    try {
+                        return expectNotification(
+                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                .get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
 
         Thread.sleep(5000); // Sleep to setup notification listening before query resolves
 
@@ -317,8 +310,7 @@ class GraphQLIT extends ExternalTargetsTest {
         // Ensure ActiveRecordingCreated notification emitted matches expected values
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
 
-        JsonObject notificationRecording =
-                notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
         MatcherAssert.assertThat(
                 notificationRecording.getString("name"), Matchers.equalTo("graphql-itest"));
         MatcherAssert.assertThat(
@@ -329,8 +321,8 @@ class GraphQLIT extends ExternalTargetsTest {
                         String.format(
                                 "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
                                 Podman.POD_NAME, 9093)));
-        Map<String, Object> notificationLabels =
-                notificationRecording.getJsonObject("metadata").getJsonObject("labels").getMap();
+        Map<String, Object> notificationLabels = notificationRecording.getJsonObject("metadata").getJsonObject("labels")
+                .getMap();
         for (var entry : expectedLabels.entrySet()) {
             MatcherAssert.assertThat(
                     notificationLabels, Matchers.hasEntry(entry.getKey(), entry.getValue()));
@@ -586,12 +578,11 @@ class GraphQLIT extends ExternalTargetsTest {
     void testQueryForSpecificTargetsByNames() throws Exception {
         CompletableFuture<TargetNodesQueryResponse> resp = new CompletableFuture<>();
 
-        String query =
-                String.format(
-                        "query { targetNodes(filter: { names:"
-                            + " [\"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\","
-                            + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9093/jmxrmi\"] }) {"
-                            + " name nodeType } }");
+        String query = String.format(
+                "query { targetNodes(filter: { names:"
+                        + " [\"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\","
+                        + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9093/jmxrmi\"] }) {"
+                        + " name nodeType } }");
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -673,11 +664,10 @@ class GraphQLIT extends ExternalTargetsTest {
 
         // GraphQL Query to filter Active recordings by names
         CompletableFuture<TargetNodesQueryResponse> resp2 = new CompletableFuture<>();
-        String query =
-                "query { targetNodes (filter: {name:"
-                    + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\"}){ recordings"
-                    + " {active(filter: { names: [\"Recording1\", \"Recording2\",\"Recording3\"] })"
-                    + " {data {name}}}}}";
+        String query = "query { targetNodes (filter: {name:"
+                + " \"service:jmx:rmi:///jndi/rmi://cryostat-itests:9091/jmxrmi\"}){ recordings"
+                + " {active(filter: { names: [\"Recording1\", \"Recording2\",\"Recording3\"] })"
+                + " {data {name}}}}}";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -695,11 +685,10 @@ class GraphQLIT extends ExternalTargetsTest {
 
         List<String> filterNames = Arrays.asList("Recording1", "Recording2");
 
-        List<ActiveRecording> filteredRecordings =
-                graphqlResp.data.targetNodes.stream()
-                        .flatMap(targetNode -> targetNode.recordings.active.data.stream())
-                        .filter(recording -> filterNames.contains(recording.name))
-                        .collect(Collectors.toList());
+        List<ActiveRecording> filteredRecordings = graphqlResp.data.targetNodes.stream()
+                .flatMap(targetNode -> targetNode.recordings.active.data.stream())
+                .filter(recording -> filterNames.contains(recording.name))
+                .collect(Collectors.toList());
 
         MatcherAssert.assertThat(filteredRecordings.size(), Matchers.equalTo(2));
         ActiveRecording r1 = new ActiveRecording();
@@ -810,27 +799,25 @@ class GraphQLIT extends ExternalTargetsTest {
                                 archivedRecordingsFuture2.complete(ar.result().bodyAsJsonArray());
                             }
                         });
-        JsonArray retrivedArchivedRecordings =
-                archivedRecordingsFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray retrivedArchivedRecordings = archivedRecordingsFuture2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         JsonObject retrievedArchivedrecordings = retrivedArchivedRecordings.getJsonObject(0);
         String retrievedArchivedRecordingsName = retrievedArchivedrecordings.getString("name");
 
         // GraphQL Query to filter Archived recordings by names
         CompletableFuture<TargetNodesQueryResponse> resp2 = new CompletableFuture<>();
 
-        String query =
-                "query { targetNodes {"
-                        + "recordings {"
-                        + "archived(filter: { names: [\""
-                        + retrievedArchivedRecordingsName
-                        + "\",\"someOtherName\"] }) {"
-                        + "data {"
-                        + "name"
-                        + "}"
-                        + "}"
-                        + "}"
-                        + "}"
-                        + "}";
+        String query = "query { targetNodes {"
+                + "recordings {"
+                + "archived(filter: { names: [\""
+                + retrievedArchivedRecordingsName
+                + "\",\"someOtherName\"] }) {"
+                + "data {"
+                + "name"
+                + "}"
+                + "}"
+                + "}"
+                + "}"
+                + "}";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -845,10 +832,9 @@ class GraphQLIT extends ExternalTargetsTest {
                         });
 
         TargetNodesQueryResponse graphqlResp = resp2.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        List<ArchivedRecording> archivedRecordings2 =
-                graphqlResp.data.targetNodes.stream()
-                        .flatMap(targetNode -> targetNode.recordings.archived.data.stream())
-                        .collect(Collectors.toList());
+        List<ArchivedRecording> archivedRecordings2 = graphqlResp.data.targetNodes.stream()
+                .flatMap(targetNode -> targetNode.recordings.archived.data.stream())
+                .collect(Collectors.toList());
 
         int filteredRecordingsCount = archivedRecordings2.size();
         Assertions.assertEquals(
@@ -898,17 +884,16 @@ class GraphQLIT extends ExternalTargetsTest {
                             }
                         });
 
-        JsonArray updatedArchivedRecordings =
-                updatedArchivedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray updatedArchivedRecordings = updatedArchivedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
 
         // Assert that the targeted recordings have been deleted
-        boolean recordingsDeleted =
-                updatedArchivedRecordings.stream()
-                        .noneMatch(
-                                json -> {
-                                    JsonObject recording = (JsonObject) json;
-                                    return recording.getString("name").equals(TEST_RECORDING_NAME);
-                                });
+        boolean recordingsDeleted = updatedArchivedRecordings.stream()
+                .noneMatch(
+                        json -> {
+                            JsonObject recording = (JsonObject) json;
+                            return recording.getString("name").equals(TEST_RECORDING_NAME);
+                        });
 
         Assertions.assertTrue(
                 recordingsDeleted, "The targeted archived recordings should be deleted");
@@ -939,8 +924,7 @@ class GraphQLIT extends ExternalTargetsTest {
                             }
                         });
 
-        JsonArray savedRecordings =
-                savedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        JsonArray savedRecordings = savedRecordingsFuture.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         for (Object savedRecording : savedRecordings) {
             String recordingName = ((JsonObject) savedRecording).getString("name");
@@ -968,9 +952,8 @@ class GraphQLIT extends ExternalTargetsTest {
     public void testQueryforFilteredEnvironmentNodesByNames() throws Exception {
         CompletableFuture<EnvironmentNodesResponse> resp = new CompletableFuture<>();
 
-        String query =
-                "query { environmentNodes(filter: { names: [\"anotherName1\","
-                        + " \"JDP\",\"anotherName2\"] }) { name nodeType } }";
+        String query = "query { environmentNodes(filter: { names: [\"anotherName1\","
+                + " \"JDP\",\"anotherName2\"] }) { name nodeType } }";
         webClient
                 .post("/api/v2.2/graphql")
                 .sendJson(
@@ -1027,23 +1010,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                            + " state}} }");
 
-            Future<JsonObject> f3 =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+            Future<JsonObject> f3 = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
             webClient
@@ -1064,8 +1046,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 =
-                    notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1105,9 +1086,9 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                            + " state}} }");
 
             Thread.sleep(5000);
             webClient
@@ -1168,23 +1149,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                            + " state}} }");
 
-            Future<JsonObject> f3 =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+            Future<JsonObject> f3 = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
             webClient
@@ -1205,8 +1185,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 =
-                    notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1238,23 +1217,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                            + " state}} }");
 
-            Future<JsonObject> f3 =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+            Future<JsonObject> f3 = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
             webClient
@@ -1275,8 +1253,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 =
-                    notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1308,9 +1285,9 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                            + " state}} }");
 
             Thread.sleep(5000);
             webClient
@@ -1364,23 +1341,22 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                        + " state}} }");
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                            + " state}} }");
 
-            Future<JsonObject> f3 =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+            Future<JsonObject> f3 = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
             webClient
@@ -1401,8 +1377,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Recreated
             JsonObject notification3 = f3.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording3 =
-                    notification3.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording3 = notification3.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording3.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording3.getString("state"));
@@ -1425,22 +1400,21 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
-                        + " state}} }");
-            Future<JsonObject> f =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:NEVER }) { name"
+                            + " state}} }");
+            Future<JsonObject> f = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
 
@@ -1462,8 +1436,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording =
-                    notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1486,22 +1459,21 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
-                        + " state}} }");
-            Future<JsonObject> f =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:ALWAYS }) { name"
+                            + " state}} }");
+            Future<JsonObject> f = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
 
@@ -1523,8 +1495,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording =
-                    notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1547,22 +1518,21 @@ class GraphQLIT extends ExternalTargetsTest {
             query.put(
                     "query",
                     "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
-                        + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
-                        + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
-                        + " state}} }");
-            Future<JsonObject> f =
-                    worker.submit(
-                            () -> {
-                                try {
-                                    return expectNotification(
-                                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                            .get();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
+                            + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
+                            + " \"Profiling\", templateType: \"TARGET\", replace:STOPPED }) { name"
+                            + " state}} }");
+            Future<JsonObject> f = worker.submit(
+                    () -> {
+                        try {
+                            return expectNotification(
+                                    "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                    .get();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
 
             Thread.sleep(5000);
             webClient
@@ -1583,8 +1553,7 @@ class GraphQLIT extends ExternalTargetsTest {
 
             // Ensure Active Recording is Created
             JsonObject notification = f.get(5, TimeUnit.SECONDS);
-            JsonObject notificationRecording =
-                    notification.getJsonObject("message").getJsonObject("recording");
+            JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
 
             Assertions.assertEquals("test", notificationRecording.getString("name"));
             Assertions.assertEquals("RUNNING", notificationRecording.getString("state"));
@@ -1721,12 +1690,17 @@ class GraphQLIT extends ExternalTargetsTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
             AggregateInfo other = (AggregateInfo) obj;
-            if (count != other.count) return false;
-            if (size != other.size) return false;
+            if (count != other.count)
+                return false;
+            if (size != other.size)
+                return false;
             return true;
         }
     }
@@ -2343,19 +2317,18 @@ class GraphQLIT extends ExternalTargetsTest {
                 "query { targetNodes(filter: { annotations: \"PORT == 9093\" }) {"
                         + " doStartRecording(recording: { name: \"test\", duration: 30, template:"
                         + " \"Profiling\", templateType: \"TARGET\"}) { name state}} }");
-        Future<JsonObject> f =
-                worker.submit(
-                        () -> {
-                            try {
-                                return expectNotification(
-                                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
-                                        .get();
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                latch.countDown();
-                            }
-                        });
+        Future<JsonObject> f = worker.submit(
+                () -> {
+                    try {
+                        return expectNotification(
+                                "ActiveRecordingCreated", 15, TimeUnit.SECONDS)
+                                .get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
 
         Thread.sleep(5000);
 
@@ -2376,8 +2349,7 @@ class GraphQLIT extends ExternalTargetsTest {
         latch.await(30, TimeUnit.SECONDS);
 
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
-        JsonObject notificationRecording =
-                notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
 
         notificationRecordingHolder[0] = notificationRecording;
     }
@@ -2394,19 +2366,18 @@ class GraphQLIT extends ExternalTargetsTest {
                         + " doStop(recording: { name: \"test\", duration: 30, template:"
                         + " \"Profiling\", templateType: \"TARGET\"}) { name state }} }");
 
-        Future<JsonObject> f =
-                worker.submit(
-                        () -> {
-                            try {
-                                return expectNotification(
-                                                "ActiveRecordingStopped", 15, TimeUnit.SECONDS)
-                                        .get();
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                latch.countDown();
-                            }
-                        });
+        Future<JsonObject> f = worker.submit(
+                () -> {
+                    try {
+                        return expectNotification(
+                                "ActiveRecordingStopped", 15, TimeUnit.SECONDS)
+                                .get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
 
         Thread.sleep(5000);
 
@@ -2427,8 +2398,7 @@ class GraphQLIT extends ExternalTargetsTest {
         latch.await(30, TimeUnit.SECONDS);
 
         JsonObject notification = f.get(5, TimeUnit.SECONDS);
-        JsonObject notificationRecording =
-                notification.getJsonObject("message").getJsonObject("recording");
+        JsonObject notificationRecording = notification.getJsonObject("message").getJsonObject("recording");
 
         notificationRecordingHolder[0] = notificationRecording;
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1492 

## Description of the change:
*This change changes the previous behavior: query parameter ?restart=[true|false] but is now deprecated, and a new replacement ?replace=[always,stopped,never] introduced. ?replace=always would behave the same as ?restart=true, ?replace=never would behave the same as ?restart=false, and ?replace=stopped would implement the quoted behavior. If replace is not specified then it should behave like ?replace=never, so that this also maintains consistency and compatibility with the existing ?restart=false default behavior.

## Motivation for the change:
This change is helpful because it enhances the behavior of restart recording while keeping the same request format

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. bash repeated-unit-tests.bash 1 RecordingTargetHelperTest (for unit testing)

