### PR TITLE
feat(matchExpression): POST matchExpression resource as json

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
@@ -149,7 +149,7 @@ public class MatchExpressionsPostHandler extends AbstractV2RequestHandler<Matche
             if (StringUtils.isBlank(matchExpression)) {
                 throw new ApiException(400, "'matchExpression' is required.");
             }
-            expressionEvaluator.evaluates(matchExpression);
+            expressionEvaluator.validate(matchExpression);
             if (targets != null) {
                 Set<ServiceRef> matched =
                         expressionManager.resolveMatchingTargets(

--- a/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
@@ -38,7 +38,6 @@
 package io.cryostat.rules;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -83,7 +82,7 @@ public class MatchExpressionEvaluator {
                 e -> {
                     switch (e.getEventType()) {
                         case REMOVED:
-                            invalidate(e.getPayload());
+                            invalidateCache(e.getPayload());
                             break;
                         default:
                             // ignore
@@ -94,7 +93,7 @@ public class MatchExpressionEvaluator {
                 e -> {
                     switch (e.getEventType()) {
                         case REMOVED:
-                            invalidate(e.getPayload().getMatchExpression());
+                            invalidateCache(e.getPayload().getMatchExpression());
                             break;
                         default:
                             // ignore
@@ -120,7 +119,7 @@ public class MatchExpressionEvaluator {
         }
     }
 
-    private void invalidate(String matchExpression) {
+    private void invalidateCache(String matchExpression) {
         var it = cache.asMap().keySet().iterator();
         while (it.hasNext()) {
             Pair<String, ServiceRef> entry = it.next();
@@ -130,13 +129,9 @@ public class MatchExpressionEvaluator {
         }
     }
 
-    public void evaluates(String matchExpression) throws ScriptException {
-        try {
-            ServiceRef dummyRef = new ServiceRef("jvmId", new URI("file:///foo/bar"), "alias");
-            compute(matchExpression, dummyRef);
-        } catch (URISyntaxException e) {
-            logger.error(e);
-        }
+    public void validate(String matchExpression) throws ScriptException {
+        ServiceRef dummyRef = new ServiceRef("jvmId", URI.create("file:///foo/bar"), "alias");
+        compute(matchExpression, dummyRef);
     }
 
     public boolean applies(String matchExpression, ServiceRef serviceRef) throws ScriptException {

--- a/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/rules/MatchExpressionEvaluator.java
@@ -37,6 +37,8 @@
  */
 package io.cryostat.rules;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -125,6 +127,15 @@ public class MatchExpressionEvaluator {
             if (Objects.equals(matchExpression, entry.getKey())) {
                 cache.invalidate(entry);
             }
+        }
+    }
+
+    public void evaluates(String matchExpression) throws ScriptException {
+        try {
+            ServiceRef dummyRef = new ServiceRef("jvmId", new URI("file:///foo/bar"), "alias");
+            compute(matchExpression, dummyRef);
+        } catch (URISyntaxException e) {
+            logger.error(e);
         }
     }
 

--- a/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
+++ b/src/test/java/io/cryostat/rules/MatchExpressionEvaluatorTest.java
@@ -95,12 +95,16 @@ class MatchExpressionEvaluatorTest {
         this.platformAnnotations = Map.of("annotation1", "someAnnotation");
         this.cryostatAnnotations = Map.of(AnnotationKey.JAVA_MAIN, "io.cryostat.Cryostat");
 
-        Mockito.when(serviceRef.getServiceUri()).thenReturn(this.serviceUri);
-        Mockito.when(serviceRef.getJvmId()).thenReturn(this.jvmId);
-        Mockito.when(serviceRef.getAlias()).thenReturn(Optional.of(this.alias));
-        Mockito.when(serviceRef.getLabels()).thenReturn(this.labels);
-        Mockito.when(serviceRef.getPlatformAnnotations()).thenReturn(this.platformAnnotations);
-        Mockito.when(serviceRef.getCryostatAnnotations()).thenReturn(this.cryostatAnnotations);
+        Mockito.lenient().when(serviceRef.getServiceUri()).thenReturn(this.serviceUri);
+        Mockito.lenient().when(serviceRef.getJvmId()).thenReturn(this.jvmId);
+        Mockito.lenient().when(serviceRef.getAlias()).thenReturn(Optional.of(this.alias));
+        Mockito.lenient().when(serviceRef.getLabels()).thenReturn(this.labels);
+        Mockito.lenient()
+                .when(serviceRef.getPlatformAnnotations())
+                .thenReturn(this.platformAnnotations);
+        Mockito.lenient()
+                .when(serviceRef.getCryostatAnnotations())
+                .thenReturn(this.cryostatAnnotations);
     }
 
     @Nested
@@ -276,6 +280,12 @@ class MatchExpressionEvaluatorTest {
         void shouldThrowExceptionOnNonBooleanExpressionEval(String expr) throws Exception {
             Assertions.assertThrows(
                     ScriptException.class, () -> ruleMatcher.applies(expr, serviceRef));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1", "null", "target.alias", "\"a string\""})
+        void shouldThrowExceptionOnInvalidExpressionValidate(String expr) throws Exception {
+            Assertions.assertThrows(ScriptException.class, () -> ruleMatcher.validate(expr));
         }
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1601

## Description of the change:
This PR changes the content acception from formdata and url-encoded data to only accept a JSON body. For example: 
```json
{
  "matchExpression": "asdf"
  ,"targets": 
    [
      {
        "alias": "org.codehaus.plexus.classworlds.launcher.Launcher",
        "annotations": {
            "cryostat": {
                "HOST": "macao",
                "JAVA_MAIN": "org.codehaus.plexus.classworlds.launcher.Launcher",
                "PORT": "9091",
                "REALM": "JDP"
            },
            "platform": {}
        },
        "connectUrl": "service:jmx:rmi:///jndi/rmi://macao:9091/jmxrmi",
        "jvmId": "6I8-ZE3qOC5TThRktZi7Y0V6FNNYdwbC2tYHgQVILeM=",
        "labels": {}
      }
    ]
}
```

## Motivation for the change:
See #1601 

## How to manually test:
1. Run cryostat with smoketest.sh
2. Try a query like:
```
http --auth=user:pass -v POST :8181/api/beta/matchExpressions @matchExpression.json
```
with the file contents being:
```json
{
  "matchExpression": "asdf"
  ,"targets": 
    [
      {
       ...some target details...
      }
    ]
}
```

use `api/v2.1/discovery` for a list of discovered targets to try.