### PR TITLE
feat(agent): implement Agent HTTP dynamic JFR stop/delete

### DIFF
--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -123,7 +123,7 @@ public class AgentClient {
 
     Future<MBeanMetrics> mbeanMetrics() {
         Future<HttpResponse<String>> f =
-                invoke(HttpMethod.GET, "/mbean-metrics", BodyCodec.string());
+                invoke(HttpMethod.GET, "/mbean-metrics/", BodyCodec.string());
         return f.map(HttpResponse::body)
                 // uses Gson rather than Vertx's Jackson because Gson is able to handle MBeanMetrics
                 // with no additional fuss. Jackson complains about private final fields.
@@ -134,7 +134,7 @@ public class AgentClient {
         Future<HttpResponse<String>> f =
                 invoke(
                         HttpMethod.POST,
-                        "/recordings",
+                        "/recordings/",
                         Buffer.buffer(gson.toJson(req)),
                         BodyCodec.string());
         return f.map(
@@ -152,8 +152,48 @@ public class AgentClient {
                 });
     }
 
+    Future<Void> stopRecording(long id) {
+        Future<HttpResponse<Void>> f =
+                invoke(
+                        HttpMethod.PATCH,
+                        String.format("/recordings/%d", id),
+                        Buffer.buffer(),
+                        BodyCodec.none());
+        return f.map(
+                resp -> {
+                    int statusCode = resp.statusCode();
+                    if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                        return null;
+                    } else if (statusCode == 403) {
+                        throw new UnsupportedOperationException();
+                    } else {
+                        throw new RuntimeException("Unknown failure");
+                    }
+                });
+    }
+
+    Future<Void> deleteRecording(long id) {
+        Future<HttpResponse<Void>> f =
+                invoke(
+                        HttpMethod.DELETE,
+                        String.format("/recordings/%d", id),
+                        Buffer.buffer(),
+                        BodyCodec.none());
+        return f.map(
+                resp -> {
+                    int statusCode = resp.statusCode();
+                    if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                        return null;
+                    } else if (statusCode == 403) {
+                        throw new UnsupportedOperationException();
+                    } else {
+                        throw new RuntimeException("Unknown failure");
+                    }
+                });
+    }
+
     Future<List<IRecordingDescriptor>> activeRecordings() {
-        Future<HttpResponse<String>> f = invoke(HttpMethod.GET, "/recordings", BodyCodec.string());
+        Future<HttpResponse<String>> f = invoke(HttpMethod.GET, "/recordings/", BodyCodec.string());
         return f.map(HttpResponse::body)
                 .map(
                         s ->
@@ -168,14 +208,14 @@ public class AgentClient {
 
     Future<Collection<? extends IEventTypeInfo>> eventTypes() {
         Future<HttpResponse<JsonArray>> f =
-                invoke(HttpMethod.GET, "/event-types", BodyCodec.jsonArray());
+                invoke(HttpMethod.GET, "/event-types/", BodyCodec.jsonArray());
         return f.map(HttpResponse::body)
                 .map(arr -> arr.stream().map(o -> new AgentEventTypeInfo((JsonObject) o)).toList());
     }
 
     Future<IConstrainedMap<EventOptionID>> eventSettings() {
         Future<HttpResponse<JsonArray>> f =
-                invoke(HttpMethod.GET, "/event-settings", BodyCodec.jsonArray());
+                invoke(HttpMethod.GET, "/event-settings/", BodyCodec.jsonArray());
         return f.map(HttpResponse::body)
                 .map(
                         arr -> {
@@ -229,7 +269,7 @@ public class AgentClient {
 
     Future<List<String>> eventTemplates() {
         Future<HttpResponse<JsonArray>> f =
-                invoke(HttpMethod.GET, "/event-templates", BodyCodec.jsonArray());
+                invoke(HttpMethod.GET, "/event-templates/", BodyCodec.jsonArray());
         return f.map(HttpResponse::body).map(arr -> arr.stream().map(Object::toString).toList());
     }
 

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -104,7 +104,14 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public void close(IRecordingDescriptor descriptor) throws FlightRecorderException {
-        throw new UnimplementedException();
+        try {
+            client.deleteRecording(descriptor.getId())
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new FlightRecorderException("Failed to stop recording", e);
+        }
     }
 
     @Override
@@ -227,8 +234,15 @@ class AgentJFRService implements CryostatFlightRecorderService {
     }
 
     @Override
-    public void stop(IRecordingDescriptor arg0) throws FlightRecorderException {
-        throw new UnimplementedException();
+    public void stop(IRecordingDescriptor descriptor) throws FlightRecorderException {
+        try {
+            client.stopRecording(descriptor.getId())
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new FlightRecorderException("Failed to stop recording", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes #1581
Based on #1566
Depends on https://github.com/cryostatio/cryostat-agent/pull/176

## Description of the change:
Adds implementation to talk to the Cryostat Agent over HTTP for stopping and deleting flight recordings.

## Motivation for the change:
This continues the effort to bring Cryostat application feature parity between JMX and HTTP connection methods.

## How to manually test:
1. Same setup as in #1566
2. Use with https://github.com/cryostatio/cryostat-agent/pull/176
3. Test against the `smoketest.sh` `http://localhost:9988/` agent target. Go to the Cryostat Web UI, Recordings, Create, and check that a custom recording can be started, stopped, and deleted. Stop and delete requests should work on running active recordings, and delete requests should also work on stopped active recordings. (In theory it should also be possible to delete a scheduled recording, but we don't have any easy way to create these via Cryostat)
