### PR TITLE
feat(agent): implement Agent HTTP recording retrieval

### DIFF
--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
+import java.io.InputStream;
 
 import javax.script.ScriptException;
 
@@ -144,6 +145,25 @@ public class AgentClient {
                         String body = resp.body();
                         return gson.fromJson(body, SerializableRecordingDescriptor.class)
                                 .toJmcForm();
+                    } else if (statusCode == 403) {
+                        throw new UnsupportedOperationException();
+                    } else {
+                        throw new RuntimeException("Unknown failure");
+                    }
+                });
+    }
+
+    Future<Buffer> openStream(long id) {
+        Future<HttpResponse<Buffer>> f =
+                invoke(
+                        HttpMethod.GET,
+                        "/recordings/" + id,
+                        BodyCodec.buffer());
+        return f.map(
+                resp -> {
+                    int statusCode = resp.statusCode();
+                    if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                        return resp.body();
                     } else if (statusCode == 403) {
                         throw new UnsupportedOperationException();
                     } else {

--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -72,6 +72,7 @@ import io.cryostat.net.web.http.api.ApiResponse;
 import io.cryostat.net.web.http.api.ApiVersion;
 import io.cryostat.net.web.http.api.v2.ApiException;
 import io.cryostat.util.HttpStatusCodeIdentifier;
+import io.cryostat.util.URIUtil;
 
 import com.google.gson.Gson;
 import io.vertx.core.AbstractVerticle;
@@ -318,13 +319,7 @@ public class WebServer extends AbstractVerticle {
     }
 
     private String getTargetId(JFRConnection conn) throws IOException {
-        // TODO this is a hack, the JFRConnection interface should be refactored to expose a more
-        // general connection URL / targetId method since the JMX implementation is now only one
-        // possible implementation
-        if (conn instanceof AgentConnection) {
-            return ((AgentConnection) conn).getUri().toString();
-        }
-        return conn.getJMXURL().toString();
+        return URIUtil.getConnectionUri(conn).toString();
     }
 
     public FileUpload getTempFileUpload(

--- a/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingArchiveHelper.java
@@ -938,7 +938,7 @@ public class RecordingArchiveHelper {
 
     Path writeRecordingToDestination(JFRConnection connection, IRecordingDescriptor descriptor)
             throws IOException, URISyntaxException, FlightRecorderException, Exception {
-        URI serviceUri = URIUtil.convert(connection.getJMXURL());
+        URI serviceUri = URIUtil.getConnectionUri(connection);
         String jvmId = jvmIdHelper.getJvmId(serviceUri.toString());
         Path specificRecordingsPath = getRecordingSubdirectoryPath(jvmId);
         if (!fs.exists(specificRecordingsPath)) {

--- a/src/main/java/io/cryostat/util/URIUtil.java
+++ b/src/main/java/io/cryostat/util/URIUtil.java
@@ -37,10 +37,14 @@
  */
 package io.cryostat.util;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.management.remote.JMXServiceURL;
+
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.net.AgentConnection;
 
 public class URIUtil {
     private URIUtil() {}
@@ -69,5 +73,15 @@ public class URIUtil {
             throw new IllegalArgumentException(serviceUrl.getURLPath());
         }
         return new URI(pathPart.substring("/jndi/".length(), pathPart.length()));
+    }
+
+    public static URI getConnectionUri(JFRConnection connection) throws IOException {
+        // TODO this is a hack, the JFRConnection interface should be refactored to expose a more
+        // general connection URL / targetId method since the JMX implementation is now only one
+        // possible implementation
+        if (connection instanceof AgentConnection) {
+            return ((AgentConnection) connection).getUri();
+        }
+        return URI.create(connection.getJMXURL().toString());
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on #1604
Depends on https://github.com/cryostatio/cryostat-agent/pull/179
Fixes #1582

## Description of the change:
This replaces stubs with real implementations for pulling JFR files from Cryostat Agent instances over HTTP.

## Motivation for the change:
Users can deploy their workload applications with the Cryostat Agent and dynamically start/analyze/retrieve/stop/delete recordings all over the Agent HTTP API rather than over JMX.

## How to manually test:
1. See #1604 and https://github.com/cryostatio/cryostat-agent/pull/179