### PR TITLE
test(smoketest): set jfr-datasource for JDP and Podman discovery

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -254,7 +254,7 @@ runJfrDatasource() {
     fi
     # limits set to match operator defaults:
     # https://github.com/cryostatio/cryostat-operator/blob/2d386930dc96f0dcaf937987ec35874006c53b61/internal/controllers/common/resource_definitions/resource_definitions.go#L66
-    local RJMX_PORT=11223
+    local RJMX_PORT=10111
     podman run \
         --name jfr-datasource \
         --pull "${PULL_IMAGES}" \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -261,6 +261,11 @@ runJfrDatasource() {
         --pod cryostat-pod \
         --cpus 0.1 \
         --memory 512m \
+        --label io.cryostat.discovery="true" \
+        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxPort="${RJMX_PORT}" \
+        --restart on-failure \
+        --env JAVA_OPTS="-Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.rmi.port=${RJMX_PORT} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false" \
         --rm -d "${DATASOURCE_IMAGE}"
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/jfr-datasource/pull/204
Depends on https://github.com/cryostatio/jfr-datasource/pull/204

## Description of the change:
After the above PR is merged, `jfr-datasource` images will be published in JVM mode and supporting JMX connections. This adds configuration matching how `cryostat-reports` is deployed in `smoketest.sh` since both containers are built similarly.

## Motivation for the change:
This allows `jfr-datasource` to be a JMX target in the smoketest environment.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Select the target with JMX port `11223`, which is the `jfr-datasource`. Test that general Cryostat functionality works on this target.
