### PR TITLE
test(smoketest): apply resource constraints matching operator deployment defaults

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -116,6 +116,9 @@ fi
 # run as root (uid 0) within the container - with rootless podman this means
 # that the process will actually run with your own uid on the host machine,
 # rather than the uid being remapped to something else
+#
+# limits set to match operator defaults:
+# https://github.com/cryostatio/cryostat-operator/blob/2d386930dc96f0dcaf937987ec35874006c53b61/internal/controllers/common/resource_definitions/resource_definitions.go#L66
 podman run \
     --pod cryostat-pod \
     --name cryostat \
@@ -125,7 +128,8 @@ podman run \
     --label io.cryostat.jmxHost="localhost" \
     --label io.cryostat.jmxPort="0" \
     --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi" \
-    --memory 768M \
+    --cpus 0.1 \
+    --memory 384M \
     --mount type=bind,source="$(dirname "$0")/archive",destination=/opt/cryostat.d/recordings.d,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/certs",destination=/certs,relabel=shared \
     --mount type=bind,source="$(dirname "$0")/clientlib",destination=/clientlib,relabel=shared \


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/1329

## Description of the change:
This sets `--cpu` and `--memory` flags on Cryostat component containers that match the defaults the `-operator` sets if the user does not provide overriding configurations.

## Motivation for the change:
With this configuration, we can get a better sense of what the resource requirements are for the various containers within one of the shorter development loops.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Test general functionality and ensure things still work. They will probably be much slower with this configuration - perhaps we need to raise some defaults.
