### PR TITLE
feat(agent): implement HTTP JFR snapshot creation

### DIFF
--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -130,6 +130,30 @@ public class AgentClient {
                 });
     }
 
+    Future<IRecordingDescriptor> startSnapshot(StartRecordingRequest req) {
+
+        Future<HttpResponse<String>> f =
+                invoke(
+                        HttpMethod.POST,
+                        "/recordings/",
+                        Buffer.buffer(gson.toJson(req)),
+                        BodyCodec.string());
+
+        return f.map(
+                resp -> {
+                    int statusCode = resp.statusCode();
+                    if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                        String body = resp.body();
+                        return gson.fromJson(body, SerializableRecordingDescriptor.class)
+                                .toJmcForm();
+                    } else if (statusCode == 403) {
+                        throw new UnsupportedOperationException();
+                    } else {
+                        throw new RuntimeException("Unknown failure");
+                    }
+                });
+    }
+
     Future<Buffer> openStream(long id) {
         Future<HttpResponse<Buffer>> f =
                 invoke(HttpMethod.GET, "/recordings/" + id, BodyCodec.buffer());

--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -155,6 +155,32 @@ public class AgentClient {
                 });
     }
 
+    Future<Void> updateRecordingOptions(long id, IConstrainedMap<String> newSettings) {
+
+        JsonObject jsonSettings = new JsonObject();
+        for (String key : newSettings.keySet()) {
+            jsonSettings.put(key, newSettings.get(key));
+        }
+        Future<HttpResponse<Void>> f =
+                invoke(
+                        HttpMethod.PATCH,
+                        String.format("/recordings/%d", id),
+                        jsonSettings.toBuffer(),
+                        BodyCodec.none());
+
+        return f.map(
+                resp -> {
+                    int statusCode = resp.statusCode();
+                    if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                        return null;
+                    } else if (statusCode == 403) {
+                        throw new UnsupportedOperationException();
+                    } else {
+                        throw new RuntimeException("Unknown failure");
+                    }
+                });
+    }
+
     Future<Buffer> openStream(long id) {
         Future<HttpResponse<Buffer>> f =
                 invoke(HttpMethod.GET, "/recordings/" + id, BodyCodec.buffer());

--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -130,13 +130,14 @@ public class AgentClient {
                 });
     }
 
-    Future<IRecordingDescriptor> startSnapshot(StartRecordingRequest req) {
+    Future<IRecordingDescriptor> startSnapshot() {
+        StartRecordingRequest snapshotReq = new StartRecordingRequest("snapshot", "", "", 0, 0, 0);
 
         Future<HttpResponse<String>> f =
                 invoke(
                         HttpMethod.POST,
                         "/recordings/",
-                        Buffer.buffer(gson.toJson(req)),
+                        Buffer.buffer(gson.toJson(snapshotReq)),
                         BodyCodec.string());
 
         return f.map(

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
@@ -251,23 +250,14 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public void updateRecordingOptions(
-        IRecordingDescriptor recordingDescriptor, IConstrainedMap<String> newSettings)
-        throws FlightRecorderException {
+            IRecordingDescriptor recordingDescriptor, IConstrainedMap<String> newSettings)
+            throws FlightRecorderException {
         try {
             long recordingId = recordingDescriptor.getId();
-                
-            Set<String> keys = newSettings.keySet();
-            boolean nameKeyExists = keys.contains("name");
-        
-        if (nameKeyExists) {
-            // Get the new name from newSettings
-            String newName = (String) newSettings.get("name");
-                // Update the recording name using the AgentClient's method
-                client.updateRecordingOptions(recordingId, newName)
+            client.updateRecordingOptions(recordingId, newSettings)
                     .toCompletionStage()
                     .toCompletableFuture()
                     .get();
-            }
         } catch (ExecutionException | InterruptedException e) {
             throw new FlightRecorderException("Failed to update recording options", e);
         }

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
@@ -250,14 +251,23 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public void updateRecordingOptions(
-            IRecordingDescriptor recordingDescriptor, IConstrainedMap<String> newSettings)
-            throws FlightRecorderException {
+        IRecordingDescriptor recordingDescriptor, IConstrainedMap<String> newSettings)
+        throws FlightRecorderException {
         try {
             long recordingId = recordingDescriptor.getId();
-            client.updateRecordingOptions(recordingId, newSettings)
+                
+            Set<String> keys = newSettings.keySet();
+            boolean nameKeyExists = keys.contains("name");
+        
+        if (nameKeyExists) {
+            // Get the new name from newSettings
+            String newName = (String) newSettings.get("name");
+                // Update the recording name using the AgentClient's method
+                client.updateRecordingOptions(recordingId, newName)
                     .toCompletionStage()
                     .toCompletableFuture()
                     .get();
+            }
         } catch (ExecutionException | InterruptedException e) {
             throw new FlightRecorderException("Failed to update recording options", e);
         }

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -177,7 +177,7 @@ class AgentJFRService implements CryostatFlightRecorderService {
         try {
             return client.startSnapshot().toCompletionStage().toCompletableFuture().get();
         } catch (ExecutionException | InterruptedException e) {
-            throw new FlightRecorderException("Failed to creat snapshot recording");
+            throw new FlightRecorderException("Failed to create snapshot recording", e);
         }
     }
 
@@ -249,9 +249,18 @@ class AgentJFRService implements CryostatFlightRecorderService {
     }
 
     @Override
-    public void updateRecordingOptions(IRecordingDescriptor arg0, IConstrainedMap<String> arg1)
+    public void updateRecordingOptions(
+            IRecordingDescriptor recordingDescriptor, IConstrainedMap<String> newSettings)
             throws FlightRecorderException {
-        throw new UnimplementedException();
+        try {
+            long recordingId = recordingDescriptor.getId();
+            client.updateRecordingOptions(recordingId, newSettings)
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new FlightRecorderException("Failed to update recording options", e);
+        }
     }
 
     @Override

--- a/src/main/java/io/cryostat/net/AgentJFRService.java
+++ b/src/main/java/io/cryostat/net/AgentJFRService.java
@@ -174,7 +174,11 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public IRecordingDescriptor getSnapshotRecording() throws FlightRecorderException {
-        throw new UnimplementedException();
+        try {
+            return client.startSnapshot().toCompletionStage().toCompletableFuture().get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new FlightRecorderException("Failed to creat snapshot recording");
+        }
     }
 
     @Override


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1613 

## Description of the change:
This change allows users to start snapshot via HTTP

## Motivation for the change:
This continues the effort to bring Cryostat application feature parity between JMX and HTTP connection methods.

## How to manually test:
1. Same setup as in [https://github.com/cryostatio/cryostat/pull/1566](https://github.com/cryostatio/cryostat/pull/1566)
2. Test against the smoketest.sh http://localhost:9988/ agent target. Go to the Cryostat Web UI, Recordings, Create, and check that a recording can be started and a snapshot can be started.
