### PR TITLE
ci(permissions): set explicit write permission requests with restrictive GITHUB_TOKEN

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,46 +1,23 @@
 categories:
-    - title: 'Features'
-      label: 'feat'
-    - title: 'Fixes'
-      label: 'fix'
-    - title: 'Documentation'
-      label: 'docs'
-    - title: 'Maintenance'
-      labels:
-          - 'chore'
-          - 'ci'
-          - 'cleanup'
-          - 'perf'
-          - 'refactor'
-          - 'style'
-          - 'test'
-
-autolabeler:
-    - label: 'feat'
-      title: '/^feat:/'
-    - label: 'fix'
-      title: '/^fix:/'
-    - label: 'docs'
-      title: '/^docs:/'
-
-    - label: 'chore'
-      title: '/^chore:/'
-    - label: 'ci'
-      title: '/^ci:/'
-    - label: 'cleanup'
-      title: '/^cleanup:/'
-    - label: 'perf'
-      title: '/^perf:/'
-    - label: 'refactor'
-      title: '/^refactor:/'
-    - label: 'style'
-      title: '/^style:/'
-    - label: 'test'
-      title: '/^test:/'
+  - title: 'Features'
+    label: 'feat'
+  - title: 'Fixes'
+    label: 'fix'
+  - title: 'Documentation'
+    label: 'docs'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'ci'
+      - 'cleanup'
+      - 'perf'
+      - 'refactor'
+      - 'style'
+      - 'test'
 
 template: |
-    ## Contributors
-    $CONTRIBUTORS
-    ## What's Changed
-    $CHANGES
+  ## Contributors
+  $CONTRIBUTORS
+  ## What's Changed
+  $CHANGES
 

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -19,6 +19,10 @@ on:
         description: the Cryostat application version that will be built
         value: ${{ jobs.get-pom-properties.outputs.image-version }}
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   get-pom-properties:
     runs-on: ubuntu-latest
@@ -32,7 +36,8 @@ jobs:
       # Query POM for image version and save as output parameter
       run: |
         IMAGE_VERSION="$(mvn validate help:evaluate -Dexpression=cryostat.imageVersionLower -q -DforceStdout)"
-        echo "::set-output name=image-version::$IMAGE_VERSION"
+        echo "image-version=$IMAGE_VERSION" >> "$GITHUB_OUTPUT"
+        echo "::set-output name=image-version::"
     outputs:
       image-version: ${{ steps.query-pom.outputs.image-version }}
 

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -37,7 +37,6 @@ jobs:
       run: |
         IMAGE_VERSION="$(mvn validate help:evaluate -Dexpression=cryostat.imageVersionLower -q -DforceStdout)"
         echo "image-version=$IMAGE_VERSION" >> "$GITHUB_OUTPUT"
-        echo "::set-output name=image-version::"
     outputs:
       image-version: ${{ steps.query-pom.outputs.image-version }}
 

--- a/.github/workflows/ci-code-analysis.yml
+++ b/.github/workflows/ci-code-analysis.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   spotless:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -20,6 +20,10 @@ on:
 
 jobs:
   check:
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -9,6 +9,8 @@ jobs:
   delete-images:
     name: Delete PR-scoped test images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: r26d/ghcr-delete-image-action@v1.2.2
         with:

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           name: cryostat
-          token: ${{ secrets.GHCR_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ignore-missing-package: true
           tag-regex: pr-${{ github.event.number }}-.*
           tagged-keep-latest: 0

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,7 +1,7 @@
 name: Verify Linked Issue
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -11,6 +11,8 @@ on:
 jobs:
   verify-linked-issue:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: Verify Pull Request references Issue
     steps:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,6 +13,8 @@ jobs:
   check-before-build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'cryostatio' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/build_test')
+    permissions:
+      pull-requests: write
     steps:
     - name: Fail if needs-triage label applied 
       if: ${{ contains(github.event.issue.labels.*.name, 'needs-triage') }}
@@ -46,15 +48,13 @@ jobs:
   checkout-branch: 
     runs-on: ubuntu-latest
     needs: [check-before-build]
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
     outputs: 
       PR_head_ref: ${{ fromJSON(steps.comment-branch.outputs.result).ref }}
       PR_head_sha: ${{ fromJSON(steps.comment-branch.outputs.result).sha }}
       PR_num: ${{ fromJSON(steps.comment-branch.outputs.result).num }}
       PR_repo: ${{ fromJSON(steps.comment-branch.outputs.result).repo }}
+    permissions:
+      pull-requests: read
     steps:
     - uses: actions/github-script@v4
       id: comment-branch
@@ -88,16 +88,18 @@ jobs:
 
   push-to-ghcr:
     runs-on: ubuntu-latest
+    needs: [build-and-test, checkout-branch]
     strategy:
       matrix:
         arch: [amd64, arm64]
     outputs: 
       amd64_image: ${{ steps.amd64_image.outputs.image }}
       arm64_image: ${{ steps.arm64_image.outputs.image }}
-    needs: [build-and-test, checkout-branch]
     env:
       head_sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
       PR_num: ${{ needs.checkout-branch.outputs.PR_num }}
+    permissions:
+      packages: write
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -130,6 +132,8 @@ jobs:
     env:
       amd64_image: ${{ needs.push-to-ghcr.outputs.amd64_image }}
       arm64_image: ${{ needs.push-to-ghcr.outputs.arm64_image }}
+    permissions:
+      pull-requests: write
     steps:
     - name: Create markdown table
       id: md-table

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   check-pr-label-and-comment:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: yashhy/pr-label-check-and-comment-action@v1.0.1
         with:

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -1,7 +1,7 @@
 name: Require semantic labels
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -2,6 +2,7 @@ name: CI build and push
 
 concurrency:
   group: pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -72,9 +72,9 @@ jobs:
           podman tag \
           ${{ env.CRYOSTAT_IMG }}:$IMAGE_VERSION \
           ${{ env.CRYOSTAT_IMG }}:latest
-          echo "::set-output name=tags::$IMAGE_VERSION latest"
+          echo "tags=$IMAGE_VERSION latest" >> "$GITHUB_OUTPUT""
         else
-          echo "::set-output name=tags::$IMAGE_VERSION"
+          echo "tags=$IMAGE_VERSION" >> "$GITHUB_OUTPUT""
         fi
       if: github.repository_owner == 'cryostatio'
     - name: Push to quay.io

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,20 +5,12 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.0
         env:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1599 

## Description of the change:

Explicitly specify `package:write` (for push) permission. This would also mean other permissions that are listed for this job are denied.

We should implement strict permission requests in #1634 after taking in consideration of third-party actions. Also, some scope might enclose other scopes.
