### PR TITLE
fix(discovery): plugin registration bugfixes

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -125,7 +125,7 @@ runDemoApps() {
         --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="localhost" \
         --label io.cryostat.jmxPort="9089" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 
     podman run \
         --name vertx-fib-demo-1 \
@@ -142,9 +142,9 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
         --label io.cryostat.discovery="true" \
-        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxHost="vertx-fib-demo-1" \
         --label io.cryostat.jmxPort="9093" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 
     podman run \
         --name vertx-fib-demo-2 \
@@ -162,10 +162,10 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
         --label io.cryostat.discovery="true" \
-        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxHost="vertx-fib-demo-2" \
         --label io.cryostat.jmxPort="9094" \
         --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9094/jmxrmi" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.0
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 
     podman run \
         --name vertx-fib-demo-3 \
@@ -184,8 +184,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --pod cryostat-pod \
         --label io.cryostat.discovery="true" \
-        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9095/jmxrmi" \
-        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.0
+        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://vertx-fib-demo-3:9095/jmxrmi" \
+        --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 
     # this config is broken on purpose (missing required env vars) to test the agent's behaviour
     # when not properly set up
@@ -234,7 +234,7 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
-        --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="true" \
+        --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="false" \
         --rm -d quay.io/andrewazores/quarkus-test:latest
 
     # copy a jboss-client.jar into /clientlib first

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -123,7 +123,7 @@ runDemoApps() {
         --env START_DELAY=60 \
         --pod cryostat-pod \
         --label io.cryostat.discovery="true" \
-        --label io.cryostat.jmxHost="localhost" \
+        --label io.cryostat.jmxHost="vertx-fib-demo-0" \
         --label io.cryostat.jmxPort="9089" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -164,7 +164,7 @@ runDemoApps() {
         --label io.cryostat.discovery="true" \
         --label io.cryostat.jmxHost="vertx-fib-demo-2" \
         --label io.cryostat.jmxPort="9094" \
-        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://localhost:9094/jmxrmi" \
+        --label io.cryostat.jmxUrl="service:jmx:rmi:///jndi/rmi://vertx-fib-demo-2:9094/jmxrmi" \
         --rm -d quay.io/andrewazores/vertx-fib-demo:0.13.1
 
     podman run \

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -205,7 +205,7 @@ runDemoApps() {
         --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
         --env QUARKUS_HTTP_PORT=10010 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
-        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent-1" \
         --env CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME="false" \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \
@@ -225,7 +225,7 @@ runDemoApps() {
         --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar" \
         --env QUARKUS_HTTP_PORT=10011 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
-        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent" \
+        --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent-2" \
         --env CRYOSTAT_AGENT_WEBCLIENT_SSL_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME="false" \
         --env CRYOSTAT_AGENT_WEBSERVER_HOST="localhost" \

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -277,6 +277,9 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
     }
 
     private Optional<StoredCredentials> getStoredCredentials(URI uri) {
+        if (uri == NO_CALLBACK) {
+            return Optional.empty();
+        }
         String userInfo = uri.getUserInfo();
         if (StringUtils.isNotBlank(userInfo) && userInfo.contains(":")) {
             String[] parts = userInfo.split(":");

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -401,6 +401,8 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
 
     public PluginInfo deregister(UUID id) {
         PluginInfo plugin = dao.get(id).orElseThrow(() -> new NotFoundException(id));
+        getStoredCredentials(plugin.getCallback())
+                .ifPresent(sc -> credentialsManager.get().delete(sc.getId()));
         dao.delete(id);
         findLeavesFrom(gson.fromJson(plugin.getSubtree(), EnvironmentNode.class)).stream()
                 .map(TargetNode::getTarget)

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -152,7 +152,7 @@ public abstract class NetworkModule {
         return Vertx.vertx(
                 new VertxOptions()
                         .setPreferNativeTransport(true)
-                        .setEventLoopPoolSize(defaults.getEventLoopPoolSize() + 4));
+                        .setEventLoopPoolSize(defaults.getEventLoopPoolSize() + 6));
     }
 
     @Provides

--- a/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/beta/MatchExpressionsPostHandler.java
@@ -159,7 +159,7 @@ public class MatchExpressionsPostHandler extends AbstractV2RequestHandler<Matche
             throw new ApiException(400, "Unable to parse JSON", e);
         } catch (RollbackException e) {
             if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
-                throw new ApiException(400, "Duplicate matchExpression", e);
+                throw new ApiException(409, "Duplicate matchExpression", e);
             }
             throw new ApiException(500, e);
         } catch (MatchExpressionValidationException e) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/CredentialsPostHandler.java
@@ -144,7 +144,7 @@ class CredentialsPostHandler extends AbstractV2RequestHandler<Void> {
                     .body(null);
         } catch (RollbackException e) {
             if (ExceptionUtils.indexOfType(e, ConstraintViolationException.class) >= 0) {
-                throw new ApiException(400, "Duplicate matchExpression", e);
+                throw new ApiException(409, "Duplicate matchExpression", e);
             }
             throw new ApiException(500, e);
         } catch (MatchExpressionValidationException e) {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat/issues/1633
See also https://github.com/cryostatio/cryostat-agent/pull/193
Based on #1636

## Description of the change:
Improves error handling and cleanup when plugin registrations fail and are associated with stored credentials.

## Motivation for the change:
This along with https://github.com/cryostatio/cryostat-agent/pull/193 increases the resiliency of the server/agent registration system so that temporary networking failures or registration conflicts or other bugs are less likely to leave the server and agent both in a state where neither recognizes the other and yet neither is able to clean up and reset the registration status.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Check that agent instances properly register & publish, and are visible in the Topology view
3. `podman kill` some agent instances to prevent clean shutdown
4. `podman run` (reference `smoketest.sh` for exact invocation) to restart some of the killed agent instances to spin them back up
5. stop the smoketest, then restart it without clearing databases, and ensure that the agent instances are able to re-register. This may take a couple of minutes for the server to recognize that the old state is stale, clear it, and allow agents to register again.
