### PR TITLE
fix(startup): platform detection progresses with limited parallelism

### DIFF
--- a/src/main/java/io/cryostat/discovery/DiscoveryModule.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryModule.java
@@ -17,6 +17,7 @@ package io.cryostat.discovery;
 
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -79,6 +80,7 @@ public abstract class DiscoveryModule {
             Logger logger) {
         return new DiscoveryStorage(
                 deployer,
+                Executors.newCachedThreadPool(),
                 pingPeriod,
                 builtin,
                 dao,

--- a/src/main/java/io/cryostat/net/AgentClient.java
+++ b/src/main/java/io/cryostat/net/AgentClient.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ExecutorService;
 
 import javax.management.ObjectName;
 import javax.script.ScriptException;
@@ -49,7 +49,6 @@ import io.cryostat.util.HttpStatusCodeIdentifier;
 
 import com.google.gson.Gson;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -64,7 +63,7 @@ import org.apache.http.auth.InvalidCredentialsException;
 public class AgentClient {
     public static final String NULL_CREDENTIALS = "No credentials found for agent";
 
-    private final Vertx vertx;
+    private final ExecutorService executor;
     private final Gson gson;
     private final long httpTimeout;
     private final WebClient webClient;
@@ -73,14 +72,14 @@ public class AgentClient {
     private final Logger logger;
 
     AgentClient(
-            Vertx vertx,
+            ExecutorService executor,
             Gson gson,
             long httpTimeout,
             WebClient webClient,
             CredentialsManager credentialsManager,
             URI agentUri,
             Logger logger) {
-        this.vertx = vertx;
+        this.executor = executor;
         this.gson = gson;
         this.httpTimeout = httpTimeout;
         this.webClient = webClient;
@@ -237,7 +236,7 @@ public class AgentClient {
                                         throw new RuntimeException(e);
                                     }
                                 },
-                                ForkJoinPool.commonPool())
+                                executor)
                         .exceptionally(
                                 t -> {
                                     throw new RuntimeException(t);
@@ -246,7 +245,7 @@ public class AgentClient {
 
     static class Factory {
 
-        private final Vertx vertx;
+        private final ExecutorService executor;
         private final Gson gson;
         private final long httpTimeout;
         private final WebClient webClient;
@@ -254,13 +253,13 @@ public class AgentClient {
         private final Logger logger;
 
         Factory(
-                Vertx vertx,
+                ExecutorService executor,
                 Gson gson,
                 long httpTimeout,
                 WebClient webClient,
                 CredentialsManager credentialsManager,
                 Logger logger) {
-            this.vertx = vertx;
+            this.executor = executor;
             this.gson = gson;
             this.httpTimeout = httpTimeout;
             this.webClient = webClient;
@@ -270,7 +269,7 @@ public class AgentClient {
 
         AgentClient create(URI agentUri) {
             return new AgentClient(
-                    vertx, gson, httpTimeout, webClient, credentialsManager, agentUri, logger);
+                    executor, gson, httpTimeout, webClient, credentialsManager, agentUri, logger);
         }
     }
 

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -19,7 +19,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -104,14 +104,18 @@ public abstract class NetworkModule {
     @Provides
     @Singleton
     static AgentClient.Factory provideAgentClientFactory(
-            Vertx vertx,
             Gson gson,
             @Named(HttpModule.HTTP_REQUEST_TIMEOUT_SECONDS) long httpTimeout,
             WebClient webClient,
             CredentialsManager credentialsManager,
             Logger logger) {
         return new AgentClient.Factory(
-                vertx, gson, httpTimeout, webClient, credentialsManager, logger);
+                Executors.newCachedThreadPool(),
+                gson,
+                httpTimeout,
+                webClient,
+                credentialsManager,
+                logger);
     }
 
     @Provides
@@ -127,7 +131,7 @@ public abstract class NetworkModule {
                 connectionToolkit,
                 agentConnectionFactory,
                 storage,
-                ForkJoinPool.commonPool(),
+                Executors.newCachedThreadPool(),
                 Scheduler.systemScheduler(),
                 maxTargetTtl,
                 maxTargetConnections,

--- a/src/main/java/io/cryostat/net/NetworkModule.java
+++ b/src/main/java/io/cryostat/net/NetworkModule.java
@@ -148,7 +148,11 @@ public abstract class NetworkModule {
     @Provides
     @Singleton
     static Vertx provideVertx() {
-        return Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+        VertxOptions defaults = new VertxOptions();
+        return Vertx.vertx(
+                new VertxOptions()
+                        .setPreferNativeTransport(true)
+                        .setEventLoopPoolSize(defaults.getEventLoopPoolSize() + 4));
     }
 
     @Provides

--- a/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
@@ -18,7 +18,6 @@ package io.cryostat.platform.internal;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -94,8 +93,7 @@ class DockerPlatformStrategy implements PlatformDetectionStrategy<DockerPlatform
     private boolean testDockerApi() {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         URI requestPath = URI.create("http://d/v1.41/info");
-        ForkJoinPool.commonPool()
-                .submit(
+        new Thread(
                         () -> {
                             webClient
                                     .get()
@@ -117,7 +115,8 @@ class DockerPlatformStrategy implements PlatformDetectionStrategy<DockerPlatform
                                                 }
                                                 result.complete(true);
                                             });
-                        });
+                        })
+                .start();
         try {
             return result.get(2, TimeUnit.SECONDS);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {

--- a/src/main/java/io/cryostat/recordings/RecordingsModule.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsModule.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executors;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -177,7 +177,7 @@ public abstract class RecordingsModule {
                                         PosixFilePermission.OWNER_EXECUTE)));
             }
             return new RecordingMetadataManager(
-                    ForkJoinPool.commonPool(),
+                    Executors.newSingleThreadExecutor(),
                     metadataDir,
                     archivedRecordingsPath,
                     connectionTimeoutSeconds,
@@ -210,7 +210,7 @@ public abstract class RecordingsModule {
                 credentialsManager,
                 storage,
                 connectionTimeoutSeconds,
-                ForkJoinPool.commonPool(),
+                Executors.newCachedThreadPool(),
                 Scheduler.systemScheduler(),
                 base32,
                 logger);

--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Singleton;
 
+import io.cryostat.DirectExecutorService;
 import io.cryostat.MainModule;
 import io.cryostat.MockVertx;
 import io.cryostat.VerticleDeployer;
@@ -106,6 +107,7 @@ class DiscoveryStorageTest {
         this.storage =
                 new DiscoveryStorage(
                         deployer,
+                        new DirectExecutorService(),
                         Duration.ofMinutes(5),
                         () -> builtin,
                         dao,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1649
Related to #1629 #1636

## Description of the change:
This:
- updates calls to `ForkJoinPool.commonPool()` to use specific Executor instances where sensible. This may increase some overhead by allowing more threads to be created than there are CPUs to run them, but also helps to isolate various components from each other so that they do not share worker pools and threading bugs in one component do not starve every other component.
- forces the minimum Vert.x event loop pool size to be the same as the default, plus 4 additional at minimum. This worker pool owns the threads that perform the application startup and initialization of all the various Verticles, including the DiscoveryStorage verticle which triggers the platform detection checks. Ideally all verticles should have non-blocking startup procedures but that is not always possible for us, and this same thread pool is also the one that owns threads that handle the Vert.x web-client async responses. If this pool is too small - for example if there are not many CPUs assigned to the container - then the pool can starve itself because startup workers are trying to initialize Verticles, and those Verticles require more workers to perform async HTTP requests to check startup conditions.

## How to manually test:
1. `run.sh` with `--cpus 0.5` or other smaller values
2. Check Topology view or read logs or otherwise validate that all expected platform discoveries succeeded
3. `smoketest.sh`, click around the UI and ensure everything still works as expected
