### PR TITLE
build(pom): restore dagger compiler property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
   <org.owasp.dependency.check.version>8.3.1</org.owasp.dependency.check.version>
   <com.google.cloud.tools.jib.maven.plugin.version>3.3.2</com.google.cloud.tools.jib.maven.plugin.version>
 
-  <!-- Use a separate property for dependency alignment purposes, keep the two versions in sync. -->
+  <!-- Use a separate property for dependency alignment purposes. -->
   <com.google.dagger.version>2.47</com.google.dagger.version>
-  <com.google.dagger.compiler.version>2.47</com.google.dagger.compiler.version>
+  <com.google.dagger.compiler.version>${com.google.dagger.version}</com.google.dagger.compiler.version>
 
   <io.cryostat.core.version>2.21.1</io.cryostat.core.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,9 @@
   <org.owasp.dependency.check.version>8.3.1</org.owasp.dependency.check.version>
   <com.google.cloud.tools.jib.maven.plugin.version>3.3.2</com.google.cloud.tools.jib.maven.plugin.version>
 
+  <!-- Use a separate property for dependency alignment purposes, keep the two versions in sync. -->
   <com.google.dagger.version>2.47</com.google.dagger.version>
+  <com.google.dagger.compiler.version>2.47</com.google.dagger.compiler.version>
 
   <io.cryostat.core.version>2.21.1</io.cryostat.core.version>
 
@@ -353,7 +355,7 @@
           <path>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger-compiler</artifactId>
-            <version>${com.google.dagger.version}</version>
+            <version>${com.google.dagger.compiler.version}</version>
           </path>
         </annotationProcessorPaths>
       </configuration>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________
Unfortunately, we still need these properties to be separate for downstream builds.

Related to: #1589 
