### PR TITLE
fix(build): allow Cryostat to be buildable with docker-ce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,11 +453,9 @@
             <executable>${imageBuilder}</executable>
             <arguments>
               <argument>save</argument>
-              <argument>--format</argument>
-              <argument>docker-archive</argument>
-              <argument>${baseImage}:${baseImageTag}</argument>
               <argument>--output</argument>
               <argument>${project.build.directory}/${baseImageTarball}</argument>
+              <argument>${baseImage}:${baseImageTag}</argument>
             </arguments>
             <skip>${skipBaseImage}</skip>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -760,7 +760,7 @@
         </from>
         <to>
           <image>${cryostat.imageStream}</image>
-          <tags>${cryostat.imageVersionLower}-${build.os}-${build.arch}</tags>
+          <tags>${cryostat.imageVersionLower},${cryostat.imageVersionLower}-${build.os}-${build.arch}</tags>
         </to>
         <container>
           <format>OCI</format>

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [ -z "$CRYOSTAT_IMAGE" ]; then
-    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:$(${MVN} validate help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.imageVersionLower)-$(getPomProperty build.os)-$(getPomProperty build.arch)"
+    CRYOSTAT_IMAGE="quay.io/cryostat/cryostat:$(${MVN} validate help:evaluate -o -B -q -DforceStdout -Dexpression=cryostat.imageVersionLower)"
 fi
 
 printf "\n\nRunning %s ...\n\n", "$CRYOSTAT_IMAGE"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1512 

## Description of the change:
The current setup has the specified image builder run the save command, but only podman has the `--format` option [[0]](https://docs.podman.io/en/v4.4/markdown/podman-save.1.html) whereas docker does not [[1]](https://docs.docker.com/engine/reference/commandline/save/). It looks like `--format` was used to specify the `docker-archive` format, but this is the default behaviour [[0]](https://docs.podman.io/en/v4.4/markdown/podman-save.1.html) so it can be removed.

[0] https://docs.podman.io/en/v4.4/markdown/podman-save.1.html
[1] https://docs.docker.com/engine/reference/commandline/save/

## Motivation for the change:
Lets docker-ce create a local Cryostat image.

## How to manually test:
1. Have docker installed, and run: `mvn clean package -DimageBuilder=/usr/bin/docker`

## Screenshots:
Docker: ![docker-after-1512](https://github.com/cryostatio/cryostat/assets/10425301/55a8c77e-d66b-4f03-a298-14310bd51f47)
Making sure it still works with podman too: 
![podman-after-1512](https://github.com/cryostatio/cryostat/assets/10425301/2db97b00-1671-4658-8007-0053b21f42d9)
