### PR TITLE
ci(submodule): don't use remote branch HEAD

### DIFF
--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         step: restore
     - run: git submodule init
-    - run: git submodule update --remote
+    - run: git submodule update
     - run: mvn -B -U -Dbuild.arch=${{ inputs.build-arch }} clean package
       env:
         GITHUB_TOKEN_REF: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI should use the ref stored in this repo.