### PR TITLE
docs(http): update health endpoint to include cryostatVersion

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -161,6 +161,7 @@
     `200` - The body is
     ```
         {
+          "cryostatVersion": "$CRYOSTAT_VERSION",
           "datasourceConfigured": $DATASOURCE_CONFIGURED,
           "datasourceAvailable": $DATASOURCE_AVAILABLE,
           "dashboardConfigured": $DASHBOARD_CONFIGURED,
@@ -169,6 +170,7 @@
           "reportsAvailable": $REPORTS_AVAILABLE
         }
     ```
+    `$CRYOSTAT_VERSION` is the version of the current Cryostat instance.
 
     `$DATASOURCE_CONFIGURED` is `true` if the relevant environment variable has
     been set to a non-empty value.


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #852 

## Description of the change:

Update HTTP doc to include `cryostatVersion` in the response for the `/health` endpoint.

## Motivation for the change:


See: https://github.com/cryostatio/cryostat-web/blob/ee99ad168f707e4342444589a466f9abb0ca6599/src/app/Shared/Services/Api.service.tsx#L1626