### PR TITLE
fix(recording): backwards compatibility for restart parameter

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -861,6 +861,10 @@
 
     **The request may include the following fields:**
 
+    `restart`: Whether to restart the recording if one already exists with the same name. **DEPRECATED**: See `replace` below.
+
+    `replace`: The replacement policy if a recording already exists with the same name. Policies can be `ALWAYS` (i.e. `restart=true`), `NEVER` (i.e.`restart=false`), and `STOPPED` (restart only when the existing one is stopped).
+
     `duration` - The duration of the recording, in seconds.
     If this field is not set, or if it is set to zero,
     the recording will be continuous,

--- a/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v1/TargetRecordingsPostHandler.java
@@ -153,9 +153,18 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 .create(connection.getService())
                                                 .name(recordingName);
 
-                                String replace = attrs.get("replace");
-                                ReplacementPolicy replacementPolicy =
-                                        ReplacementPolicy.fromString(replace);
+                                ReplacementPolicy replace = ReplacementPolicy.NEVER;
+
+                                if (attrs.contains("restart")) {
+                                    replace =
+                                            Boolean.parseBoolean(attrs.get("restart"))
+                                                    ? ReplacementPolicy.ALWAYS
+                                                    : ReplacementPolicy.NEVER;
+                                }
+
+                                if (attrs.contains("replace")) {
+                                    replace = ReplacementPolicy.fromString(attrs.get("replace"));
+                                }
 
                                 if (attrs.contains("duration")) {
                                     builder =
@@ -201,7 +210,7 @@ public class TargetRecordingsPostHandler extends AbstractAuthenticatedRequestHan
                                                 eventSpecifier);
                                 IRecordingDescriptor descriptor =
                                         recordingTargetHelper.startRecording(
-                                                replacementPolicy,
+                                                replace,
                                                 connectionDescriptor,
                                                 builder.build(),
                                                 template.getLeft(),

--- a/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/graph/StartRecordingOnTargetMutator.java
@@ -111,15 +111,20 @@ class StartRecordingOnTargetMutator
         return targetConnectionManager.executeConnectedTask(
                 cd,
                 conn -> {
-                    ReplacementPolicy replace = ReplacementPolicy.NEVER;
                     RecordingOptionsBuilder builder =
                             recordingOptionsBuilderFactory
                                     .create(conn.getService())
                                     .name((String) settings.get("name"));
 
+                    ReplacementPolicy replace = ReplacementPolicy.NEVER;
+                    if (settings.containsKey("restart")) {
+                        replace =
+                                Boolean.TRUE.equals(settings.get("restart"))
+                                        ? ReplacementPolicy.ALWAYS
+                                        : ReplacementPolicy.NEVER;
+                    }
                     if (settings.containsKey("replace")) {
-                        String replaceValue = (String) settings.get("replace");
-                        replace = ReplacementPolicy.fromString(replaceValue);
+                        replace = ReplacementPolicy.fromString((String) settings.get("replace"));
                     }
                     if (settings.containsKey("duration")) {
                         builder =

--- a/src/main/resources/types.graphqls
+++ b/src/main/resources/types.graphqls
@@ -172,16 +172,17 @@ type RecordingMetadata {
 }
 
 input RecordingSettings {
-    replace: ReplacementPolicy
     name: String!
     template: String!
     templateType: String!
-    duration: Long
+    replace: ReplacementPolicy
+    restart: Boolean
     continuous: Boolean
+    archiveOnStop: Boolean
     toDisk: Boolean
+    duration: Long
     maxSize: Long
     maxAge: Long
-    archiveOnStop: Boolean
     metadata: Object
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1670 

## Description of the change:

Added back the `restart` parameter for backwards compatibility. Future major releases can remove it if needed but should highlight this.

## Motivation for the change:

See #1670 

> I recall we had some discussion around this change before but I can't remember exactly what we landed on. Since this is changing in a minor release version the API "shouldn't" change in incompatible ways, but I'm okay with changing a query parameter like this. Or we could have the endpoint handler handle both forms and prefer the newer one if both are supplied.

## How to manually test:

The old legacy graphQL query with `restart` parameter should work fine:

```graphql
query {
    environmentNodes(filter: { name: "JDP" }) {
        descendantTargets {
            doStartRecording(recording: {
                name: "foo",
                template: "Profiling",
                templateType: "TARGET",
                duration: 30,
                restart: true
                }) {
                    name
                    state
            }
        }
    }
}
```

Also, operations on web client also succeeds.
