### PR TITLE
fix(credentials): query for Agent HTTP credentials without specific userinfo

### DIFF
--- a/src/main/java/io/cryostat/util/URIUtil.java
+++ b/src/main/java/io/cryostat/util/URIUtil.java
@@ -16,6 +16,7 @@
 package io.cryostat.util;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -37,6 +38,19 @@ public class URIUtil {
 
     public static URI convert(JMXServiceURL serviceUrl) throws URISyntaxException {
         return new URI(serviceUrl.toString());
+    }
+
+    public static boolean isJmxUrl(URI uri) {
+        return isJmxUrl(uri.toString());
+    }
+
+    public static boolean isJmxUrl(String uri) {
+        try {
+            new JMXServiceURL(uri);
+            return true;
+        } catch (MalformedURLException mue) {
+            return false;
+        }
     }
 
     public static boolean isRmiUrl(JMXServiceURL serviceUrl) {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1673

## Description of the change:
When querying for stored credentials by `targetId`, check if the provided `targetId` is JMX. If not, assume it is Agent HTTP, and check if there is an exact match for the given `targetId` as well as if there is a match for that `targetId` without the `userinfo` part of the URI.

## Motivation for the change:
This way the credentials querying is lenient on clients not including stored credentials in the Agent HTTP URI, which should not normally be expected - the server has those credentials stored in the encrypted database table, provided to it by the Agent instance, so these credentials are not known to the client and the reference to them in the database should also not be required knowledge for the client to perform queries.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. `https -vv --auth=user:pass :8181/api/v2.3/targets/$(echo -n http://localhost:9988/ | jq -sRr @uri)/mbeanMetrics` and ensure that the response is a JSON object containing MBean information.
