### PR TITLE
fix(discovery): do not fail startup if plugin ping fails

### DIFF
--- a/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryStorageTest.java
@@ -213,6 +213,8 @@ class DiscoveryStorageTest {
 
         @Test
         void removesPluginsIfCallbackFails() throws Exception {
+            Mockito.when(deployer.deploy(Mockito.any(), Mockito.anyBoolean()))
+                    .thenReturn(Future.succeededFuture());
             EnvironmentNode realm =
                     new EnvironmentNode("realm", BaseNodeType.REALM, Map.of(), Set.of());
             PluginInfo plugin =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1698

## Description of the change:
Modifies the `DiscoveryStorage` plugin ping logic to be tolerant of request failures or network exceptions by remapping the ping task future to one that logs exceptions but does not propagate the `Future` failure to the aggregate `Future` representing the entire task.

## Motivation for the change:
When this plugin ping prune task is done periodically failures are already ignored. However, when this task is done initially at startup to check plugin registrations already present in the database from the last run, ping failures would fail the whole task, cascading into failing the server startup. This should not happen - the server is not dependent upon the discovery plugins and can handle their absence fine, so it should not be startup-blocking if an exception occurs when probing them.

## How to manually test:
1. Tough to nail down because it requires a narrow condition where the discovery plugin is present but a network error occurs during the registration ping request, ex. the network stack says that the plugin hostname can be resolved but the connection is refused because the plugin JVM is not yet ready to accept connections.
