### PR TITLE
chore(dependabot): increase PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       - "dependencies"
       - "chore"
       - "safe-to-test"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     registries:
       - "maven-github"
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1695

## Description of the change:
Increases the Dependabot open PR limit from 10 to 20

## Motivation for the change:
This project has quite a few dependencies, and we often get stuck waiting for downstream versions of dependencies to be available before merging Dependabot PRs. Meanwhile, other dependencies get updated but we miss the notifications because we already have 10 pending PRs open and waiting. I think it's worth testing increasing the limit so we don't let other things, which may not necessarily require a downstream equivalent (ex. Maven plugins), get too out of date.
