### PR TITLE
fix(logging): exclude slf4j from vertx bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,16 @@
       <version>${io.vertx.version}</version>
       <type>pom</type>
       <scope>import</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-jdk14</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </dependencyManagement>
@@ -234,8 +244,15 @@
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+    <version>${org.slf4j.version}</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
     <artifactId>slf4j-jdk14</artifactId>
     <version>${org.slf4j.version}</version>
+    <scope>runtime</scope>
   </dependency>
   <dependency>
     <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1742

## Description of the change:
Excludes slf4j artifacts from the vertx-dependencies bom. We define our own version and scopes.

## Motivation for the change:
This restores missing log messages since #1720.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Check server logs for messages like:

```
INFO: Observing new target: io.cryostat.platform.ServiceRef@1eea678c[alias=io.cryostat.Cryostat,annotations=io.cryostat.platform.ServiceRef$Annotations@55e20de0[cryostat={HOST=cryostat, PORT=9091, JAVA_MAIN=io.cryostat.Cryostat, REALM=JDP},platform={}],jvmId=<null>,labels={},serviceUri=service:jmx:rmi:///jndi/rmi://cryostat:9091/jmxrmi]
...
INFO: Outgoing WS message: {"meta":{"category":"WsClientActivity","type":{"type":"application","subType":"json"}},"message":{"10.0.2.100:35544":"connected"}}
...
INFO: Outgoing WS message: {"meta":{"category":"WsClientActivity","type":{"type":"application","subType":"json"}},"message":{"10.0.2.100:35544":"accepted"}}
```
