### PR TITLE
ci(build-image): remove ghcr user login

### DIFF
--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -64,15 +64,6 @@ jobs:
       uses: s4u/maven-settings-action@v2
       with:
         githubServer: false
-<<<<<<< HEAD
-    - name: ghcr login
-      uses: redhat-actions/podman-login@v1
-      with:
-        registry: ghcr.io/${{ github.repository_owner }}
-        username: ${{ github.event.comment.user.login }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-=======
->>>>>>> 0a3f003f (removed login part)
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -64,12 +64,15 @@ jobs:
       uses: s4u/maven-settings-action@v2
       with:
         githubServer: false
+<<<<<<< HEAD
     - name: ghcr login
       uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.event.comment.user.login }}
         password: ${{ secrets.GITHUB_TOKEN }}
+=======
+>>>>>>> 0a3f003f (removed login part)
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -77,6 +77,7 @@ jobs:
         fi
       if: github.repository_owner == 'cryostatio'
     - name: Push to quay.io
+      id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1755 

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
