### PR TITLE
ci(release): consider lightweight tags, run workflow on tag

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -11,6 +11,8 @@ on:
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   code-analysis:

--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,7 @@
             <executable>git</executable>
             <arguments>
               <argument>describe</argument>
+              <argument>--tags</argument>
               <argument>--dirty</argument>
               <argument>--long</argument>
               <argument>--always</argument>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1818 

## Description of the change:
* Add `--tags` argument to `git describe` when computing the version at build time.
* Add `on.push.tags` event to `push-ci` workflow to re-run the build and push after a release tag is made. 

## Motivation for the change:
CI was failing to use the X.Y.Z version number in release builds.

## How to manually test:
1. Wait for next release?