### PR TITLE
fix(k8s): Endpoints discovery port names/numbers are configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ using the environment variables `CRYOSTAT_DISCOVERY_K8S_PORT_NAMES` and
 `CRYOSTAT_DISCOVERY_K8S_PORT_NUMBERS` respectively. Both of these accept
 comma-separated lists as values. Any observed `Endpoints` object with a name
 in the given list or a number in the given list will be taken as a connectable
-target application. To set either of the lists empty use the value `-`.
+target application. To set the names list to the empty list use `-`. To set the
+numbers list to the empty list use `0`.
 
 The second discovery mechanism is JDP (Java Discovery Protocol). This relies on
 target JVMs being configured with the JVM flags to enable JDP and requires the

--- a/README.md
+++ b/README.md
@@ -195,8 +195,7 @@ using the environment variables `CRYOSTAT_DISCOVERY_K8S_PORT_NAMES` and
 `CRYOSTAT_DISCOVERY_K8S_PORT_NUMBERS` respectively. Both of these accept
 comma-separated lists as values. Any observed `Endpoints` object with a name
 in the given list or a number in the given list will be taken as a connectable
-target application. To set the names list to the empty list use `-`. To set the
-numbers list to the empty list use `0`.
+target application. To set either of the lists empty use the value `-`.
 
 The second discovery mechanism is JDP (Java Discovery Protocol). This relies on
 target JVMs being configured with the JVM flags to enable JDP and requires the

--- a/README.md
+++ b/README.md
@@ -189,7 +189,14 @@ service endpoints and expose all discovered services as potential targets. This
 is runtime dynamic, allowing `cryostat` to discover new services which come
 online after `cryostat`, or to detect when known services disappear later.
 This requires the `cryostat` pod to have authorization to list services
-within its own namespace.
+within its own namespace. By default this will look for `Endpoints` objects
+with ports named `jfr-jmx` or numbered `9091`. This behaviour can be overridden
+using the environment variables `CRYOSTAT_DISCOVERY_K8S_PORT_NAMES` and
+`CRYOSTAT_DISCOVERY_K8S_PORT_NUMBERS` respectively. Both of these accept
+comma-separated lists as values. Any observed `Endpoints` object with a name
+in the given list or a number in the given list will be taken as a connectable
+target application. To set the names list to the empty list use `-`. To set the
+numbers list to the empty list use `0`.
 
 The second discovery mechanism is JDP (Java Discovery Protocol). This relies on
 target JVMs being configured with the JVM flags to enable JDP and requires the

--- a/src/main/java/io/cryostat/configuration/Variables.java
+++ b/src/main/java/io/cryostat/configuration/Variables.java
@@ -47,6 +47,8 @@ public final class Variables {
     public static final String DISABLE_BUILTIN_DISCOVERY = "CRYOSTAT_DISABLE_BUILTIN_DISCOVERY";
     public static final String DISCOVERY_PING_PERIOD_MS = "CRYOSTAT_DISCOVERY_PING_PERIOD";
     public static final String K8S_NAMESPACES = "CRYOSTAT_K8S_NAMESPACES";
+    public static final String K8S_PORT_NAMES = "CRYOSTAT_DISCOVERY_K8S_PORT_NAMES";
+    public static final String K8S_PORT_NUMBERS = "CRYOSTAT_DISCOVERY_K8S_PORT_NUMBERS";
     public static final String VERTX_POOL_SIZE = "CRYOSTAT_VERTX_POOL_SIZE";
 
     // webserver configuration

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -66,6 +66,8 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
 
     private final KubernetesClient k8sClient;
     private final Set<String> namespaces;
+    private final Set<String> portNames;
+    private final Set<Integer> portNumbers;
     private final LazyInitializer<HashMap<String, SharedIndexInformer<Endpoints>>> nsInformers =
             new LazyInitializer<HashMap<String, SharedIndexInformer<Endpoints>>>() {
                 @Override
@@ -105,10 +107,14 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
     KubeApiPlatformClient(
             Environment environment,
             Collection<String> namespaces,
+            Collection<String> portNames,
+            Collection<Integer> portNumbers,
             KubernetesClient k8sClient,
             Logger logger) {
         super(environment);
         this.namespaces = new HashSet<>(namespaces);
+        this.portNames = new HashSet<>(portNames);
+        this.portNumbers = new HashSet<>(portNumbers);
         this.k8sClient = k8sClient;
         this.logger = logger;
     }
@@ -284,7 +290,7 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
     }
 
     private boolean isCompatiblePort(EndpointPort port) {
-        return "jfr-jmx".equals(port.getName()) || 9091 == port.getPort();
+        return portNames.contains(port.getName()) || portNumbers.contains(port.getPort());
     }
 
     private List<ServiceRef> getAllServiceRefs() {

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.AbstractPlatformClient;
@@ -44,7 +43,6 @@ import io.cryostat.platform.discovery.EnvironmentNode;
 import io.cryostat.platform.discovery.NodeType;
 import io.cryostat.platform.discovery.TargetNode;
 
-import dagger.Lazy;
 import io.fabric8.kubernetes.api.model.EndpointAddress;
 import io.fabric8.kubernetes.api.model.EndpointPort;
 import io.fabric8.kubernetes.api.model.EndpointSubset;
@@ -98,7 +96,6 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
             };
     private Integer memoHash;
     private EnvironmentNode memoTree;
-    private final Lazy<JFRConnectionToolkit> connectionToolkit;
     private final Logger logger;
     private final Map<Triple<String, String, String>, Pair<HasMetadata, EnvironmentNode>>
             discoveryNodeCache = new ConcurrentHashMap<>();
@@ -109,12 +106,10 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
             Environment environment,
             Collection<String> namespaces,
             KubernetesClient k8sClient,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
             Logger logger) {
         super(environment);
         this.namespaces = new HashSet<>(namespaces);
         this.k8sClient = k8sClient;
-        this.connectionToolkit = connectionToolkit;
         this.logger = logger;
     }
 

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatformClient> {
 
     public static final String NO_PORT_NAME = "-";
-    public static final String NO_PORT_NUMBER = "0";
+    public static final Integer NO_PORT_NUMBER = 0;
 
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
@@ -74,8 +74,8 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
                         .toList();
         List<Integer> portNumbers =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
-                        .filter(n -> !NO_PORT_NAME.equals(n))
                         .map(Integer::parseInt)
+                        .filter(n -> !NO_PORT_NUMBER.equals(n))
                         .toList();
         return new KubeApiPlatformClient(
                 env, getNamespaces(), portNames, portNumbers, createClient(), logger);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ForkJoinPool;
 
 import io.cryostat.configuration.Variables;
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
@@ -42,18 +41,12 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
     protected final FileSystem fs;
-    protected final Lazy<JFRConnectionToolkit> connectionToolkit;
     protected final Logger logger;
 
     KubeApiPlatformStrategy(
-            Lazy<? extends AuthManager> authMgr,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
-            Environment env,
-            FileSystem fs,
-            Logger logger) {
+            Lazy<? extends AuthManager> authMgr, Environment env, FileSystem fs, Logger logger) {
         this.logger = logger;
         this.authMgr = authMgr;
-        this.connectionToolkit = connectionToolkit;
         this.env = env;
         this.fs = fs;
     }
@@ -72,8 +65,7 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     @Override
     public KubeApiPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
-        return new KubeApiPlatformClient(
-                env, getNamespaces(), createClient(), connectionToolkit, logger);
+        return new KubeApiPlatformClient(env, getNamespaces(), createClient(), logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -38,8 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 
 class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatformClient> {
 
-    public static final String NO_PORT_NAME = "-";
-    public static final Integer NO_PORT_NUMBER = 0;
+    public static final String PORT_NAME_NUMBER_NONE = "-";
 
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
@@ -71,13 +70,13 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
         List<String> portNames =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(",")).stream()
                         .map(String::strip)
-                        .filter(n -> !NO_PORT_NAME.equals(n))
+                        .filter(n -> !PORT_NAME_NUMBER_NONE.equals(n))
                         .toList();
         List<Integer> portNumbers =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
                         .map(String::strip)
+                        .filter(n -> !PORT_NAME_NUMBER_NONE.equals(n))
                         .map(Integer::parseInt)
-                        .filter(n -> !NO_PORT_NUMBER.equals(n))
                         .toList();
         return new KubeApiPlatformClient(
                 env, getNamespaces(), portNames, portNumbers, createClient(), logger);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -65,7 +65,14 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     @Override
     public KubeApiPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
-        return new KubeApiPlatformClient(env, getNamespaces(), createClient(), logger);
+        List<String> portNames =
+                Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(","));
+        List<Integer> portNumbers =
+                Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
+                        .map(Integer::parseInt)
+                        .toList();
+        return new KubeApiPlatformClient(
+                env, getNamespaces(), portNames, portNumbers, createClient(), logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -70,10 +70,12 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         List<String> portNames =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(",")).stream()
+                        .map(String::strip)
                         .filter(n -> !NO_PORT_NAME.equals(n))
                         .toList();
         List<Integer> portNumbers =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
+                        .map(String::strip)
                         .map(Integer::parseInt)
                         .filter(n -> !NO_PORT_NUMBER.equals(n))
                         .toList();

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -38,7 +38,8 @@ import org.apache.commons.lang3.StringUtils;
 
 class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatformClient> {
 
-    public static final String PORT_NAME_NUMBER_NONE = "-";
+    public static final String NO_PORT_NAME = "-";
+    public static final Integer NO_PORT_NUMBER = 0;
 
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
@@ -70,13 +71,13 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
         List<String> portNames =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(",")).stream()
                         .map(String::strip)
-                        .filter(n -> !PORT_NAME_NUMBER_NONE.equals(n))
+                        .filter(n -> !NO_PORT_NAME.equals(n))
                         .toList();
         List<Integer> portNumbers =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
                         .map(String::strip)
-                        .filter(n -> !PORT_NAME_NUMBER_NONE.equals(n))
                         .map(Integer::parseInt)
+                        .filter(n -> !NO_PORT_NUMBER.equals(n))
                         .toList();
         return new KubeApiPlatformClient(
                 env, getNamespaces(), portNames, portNumbers, createClient(), logger);

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -38,6 +38,9 @@ import org.apache.commons.lang3.StringUtils;
 
 class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatformClient> {
 
+    public static final String NO_PORT_NAME = "-";
+    public static final String NO_PORT_NUMBER = "0";
+
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
     protected final FileSystem fs;
@@ -66,9 +69,12 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     public KubeApiPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         List<String> portNames =
-                Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(","));
+                Arrays.asList(env.getEnv(Variables.K8S_PORT_NAMES, "jfr-jmx").split(",")).stream()
+                        .filter(n -> !NO_PORT_NAME.equals(n))
+                        .toList();
         List<Integer> portNumbers =
                 Arrays.asList(env.getEnv(Variables.K8S_PORT_NUMBERS, "9091").split(",")).stream()
+                        .filter(n -> !NO_PORT_NAME.equals(n))
                         .map(Integer::parseInt)
                         .toList();
         return new KubeApiPlatformClient(

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -16,7 +16,6 @@
 package io.cryostat.platform.internal;
 
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
@@ -28,12 +27,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
 
     OpenShiftPlatformStrategy(
-            Lazy<? extends AuthManager> authMgr,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
-            Environment env,
-            FileSystem fs,
-            Logger logger) {
-        super(authMgr, connectionToolkit, env, fs, logger);
+            Lazy<? extends AuthManager> authMgr, Environment env, FileSystem fs, Logger logger) {
+        super(authMgr, env, fs, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -68,23 +68,15 @@ public abstract class PlatformStrategyModule {
     @Provides
     @Singleton
     static OpenShiftPlatformStrategy provideOpenShiftPlatformStrategy(
-            Logger logger,
-            Lazy<OpenShiftAuthManager> authManager,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
-            Environment env,
-            FileSystem fs) {
-        return new OpenShiftPlatformStrategy(authManager, connectionToolkit, env, fs, logger);
+            Lazy<OpenShiftAuthManager> authManager, Environment env, FileSystem fs, Logger logger) {
+        return new OpenShiftPlatformStrategy(authManager, env, fs, logger);
     }
 
     @Provides
     @Singleton
     static KubeApiPlatformStrategy provideKubeApiPlatformStrategy(
-            Lazy<NoopAuthManager> noopAuthManager,
-            Lazy<JFRConnectionToolkit> connectionToolkit,
-            Environment env,
-            FileSystem fs,
-            Logger logger) {
-        return new KubeApiPlatformStrategy(noopAuthManager, connectionToolkit, env, fs, logger);
+            Lazy<NoopAuthManager> noopAuthManager, Environment env, FileSystem fs, Logger logger) {
+        return new KubeApiPlatformStrategy(noopAuthManager, env, fs, logger);
     }
 
     @Provides

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -846,6 +846,7 @@ class KubeApiPlatformClientTest {
         void setup() throws Exception {
             platformClient =
                     new KubeApiPlatformClient(
+                            env,
                             List.of(NAMESPACE),
                             Set.of("cryostat-jmx", "cryostat-jfr"),
                             Set.of(9999, 4545),
@@ -1118,7 +1119,7 @@ class KubeApiPlatformClientTest {
         void setup() throws Exception {
             platformClient =
                     new KubeApiPlatformClient(
-                            List.of(NAMESPACE), Set.of(), Set.of(), k8sClient, logger);
+                            env, List.of(NAMESPACE), Set.of(), Set.of(), k8sClient, logger);
         }
 
         @Test

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import io.cryostat.core.log.Logger;
-import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.ServiceRef;
@@ -65,15 +64,12 @@ class KubeApiPlatformClientTest {
     KubeApiPlatformClient platformClient;
     KubernetesClient k8sClient;
     KubernetesMockServer server;
-    @Mock JFRConnectionToolkit connectionToolkit;
     @Mock Environment env;
     @Mock Logger logger;
 
     @BeforeEach
     void setup() throws Exception {
-        this.platformClient =
-                new KubeApiPlatformClient(
-                        env, List.of(NAMESPACE), k8sClient, () -> connectionToolkit, logger);
+        this.platformClient = new KubeApiPlatformClient(env, List.of(NAMESPACE), k8sClient, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +70,14 @@ class KubeApiPlatformClientTest {
 
     @BeforeEach
     void setup() throws Exception {
-        this.platformClient = new KubeApiPlatformClient(env, List.of(NAMESPACE), k8sClient, logger);
+        this.platformClient =
+                new KubeApiPlatformClient(
+                        env,
+                        List.of(NAMESPACE),
+                        Set.of("jfr-jmx"),
+                        Set.of(9091),
+                        k8sClient,
+                        logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -51,768 +51,784 @@ import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@EnableKubernetesMockClient(https = false, crud = true)
 class KubeApiPlatformClientTest {
 
-    static final String NAMESPACE = "foo-namespace";
+    @Nested
+    @EnableKubernetesMockClient(https = false, crud = true)
+    class WithDefaultPortNameAndNumber {
 
-    KubeApiPlatformClient platformClient;
-    KubernetesClient k8sClient;
-    KubernetesMockServer server;
-    @Mock Environment env;
-    @Mock Logger logger;
+        static final String NAMESPACE = "foo-namespace";
 
-    @BeforeEach
-    void setup() throws Exception {
-        this.platformClient =
-                new KubeApiPlatformClient(
-                        env,
-                        List.of(NAMESPACE),
-                        Set.of("jfr-jmx"),
-                        Set.of(9091),
-                        k8sClient,
-                        logger);
-    }
+        KubeApiPlatformClient platformClient;
+        KubernetesClient k8sClient;
+        KubernetesMockServer server;
+        @Mock Environment env;
+        @Mock Logger logger;
 
-    @Test
-    void shouldReturnEmptyListIfNoEndpointsFound() throws Exception {
-        platformClient.start();
-        List<ServiceRef> result = platformClient.listDiscoverableServices();
-        MatcherAssert.assertThat(result, Matchers.equalTo(Collections.emptyList()));
-    }
+        @BeforeEach
+        void setup() throws Exception {
+            platformClient =
+                    new KubeApiPlatformClient(
+                            env,
+                            List.of(NAMESPACE),
+                            Set.of("jfr-jmx"),
+                            Set.of(9091),
+                            k8sClient,
+                            logger);
+        }
 
-    @Test
-    void shouldReturnListOfMatchingEndpointRefs() throws Exception {
-        Pod targetA =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetA")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        String ipA = "127.0.0.2";
-        String transformedIpA = ipA.replaceAll("\\.", "-");
-        int portA = 80;
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetA).create();
+        @Test
+        void shouldReturnEmptyListIfNoEndpointsFound() throws Exception {
+            platformClient.start();
+            List<ServiceRef> result = platformClient.listDiscoverableServices();
+            MatcherAssert.assertThat(result, Matchers.equalTo(Collections.emptyList()));
+        }
 
-        Pod targetB =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetB")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        String ipB = "127.0.0.3";
-        String transformedIpB = ipB.replaceAll("\\.", "-");
-        int portB = 1234;
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetB).create();
+        @Test
+        void shouldReturnListOfMatchingEndpointRefs() throws Exception {
+            Pod targetA =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetA")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            String ipA = "127.0.0.2";
+            String transformedIpA = ipA.replaceAll("\\.", "-");
+            int portA = 80;
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetA).create();
 
-        Pod targetC =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetC")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        String ipC = "127.0.0.4";
-        String transformedIpC = ipC.replaceAll("\\.", "-");
-        int portC = 9091;
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetC).create();
+            Pod targetB =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetB")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            String ipB = "127.0.0.3";
+            String transformedIpB = ipB.replaceAll("\\.", "-");
+            int portB = 1234;
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetB).create();
 
-        Pod targetD =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetD")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        String ipD = "127.0.0.5";
-        String transformedIpD = ipD.replaceAll("\\.", "-");
-        int portD = 9091;
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetD).create();
+            Pod targetC =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetC")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            String ipC = "127.0.0.4";
+            String transformedIpC = ipC.replaceAll("\\.", "-");
+            int portC = 9091;
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetC).create();
 
-        Pod targetE =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetE")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        String ipE = "127.0.0.6";
-        String transformedIpE = ipE.replaceAll("\\.", "-");
-        int portE = 5678;
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetE).create();
+            Pod targetD =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetD")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            String ipD = "127.0.0.5";
+            String transformedIpD = ipD.replaceAll("\\.", "-");
+            int portD = 9091;
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetD).create();
 
-        Endpoints endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipA)
-                                        .withHostname(targetA.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetA.getMetadata().getName())
-                                        .withKind(targetA.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("tcp-80")
-                                        .withPort(portA)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipB)
-                                        .withHostname(targetB.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetB.getMetadata().getName())
-                                        .withKind(targetB.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(portB)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipC)
-                                        .withHostname(targetC.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetC.getMetadata().getName())
-                                        .withKind(targetC.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("tcp-9091")
-                                        .withPort(portC)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipD)
-                                        .withHostname(targetD.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetD.getMetadata().getName())
-                                        .withKind(targetD.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("tcp-9091")
-                                        .withPort(portD)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipE)
-                                        .withHostname(targetE.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetE.getMetadata().getName())
-                                        .withKind(targetE.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(portE)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
+            Pod targetE =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetE")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            String ipE = "127.0.0.6";
+            String transformedIpE = ipE.replaceAll("\\.", "-");
+            int portE = 5678;
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetE).create();
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+            Endpoints endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipA)
+                                            .withHostname(targetA.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetA.getMetadata().getName())
+                                            .withKind(targetA.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("tcp-80")
+                                            .withPort(portA)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipB)
+                                            .withHostname(targetB.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetB.getMetadata().getName())
+                                            .withKind(targetB.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(portB)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipC)
+                                            .withHostname(targetC.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetC.getMetadata().getName())
+                                            .withKind(targetC.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("tcp-9091")
+                                            .withPort(portC)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipD)
+                                            .withHostname(targetD.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetD.getMetadata().getName())
+                                            .withKind(targetD.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("tcp-9091")
+                                            .withPort(portD)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipE)
+                                            .withHostname(targetE.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetE.getMetadata().getName())
+                                            .withKind(targetE.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(portE)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
 
-        platformClient.start();
-        List<ServiceRef> result = platformClient.listDiscoverableServices();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
-        // targetA is intentionally not a matching service
-        ServiceRef serv1 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpB, NAMESPACE, portB)),
-                        targetB.getMetadata().getName());
-        serv1.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipB,
-                        AnnotationKey.PORT,
-                        Integer.toString(portB),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetB.getMetadata().getName()));
-        ServiceRef serv2 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpC, NAMESPACE, portC)),
-                        targetC.getMetadata().getName());
-        serv2.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipC,
-                        AnnotationKey.PORT,
-                        Integer.toString(portC),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetC.getMetadata().getName()));
-        ServiceRef serv3 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpD, NAMESPACE, portD)),
-                        targetD.getMetadata().getName());
-        serv3.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipD,
-                        AnnotationKey.PORT,
-                        Integer.toString(portD),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetD.getMetadata().getName()));
-        ServiceRef serv4 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpE, NAMESPACE, portE)),
-                        targetE.getMetadata().getName());
-        serv4.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipE,
-                        AnnotationKey.PORT,
-                        Integer.toString(portE),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetE.getMetadata().getName()));
-        MatcherAssert.assertThat(
-                result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3, serv4)));
-    }
+            platformClient.start();
+            List<ServiceRef> result = platformClient.listDiscoverableServices();
 
-    @Test
-    void shouldReturnDiscoveryTree() throws Exception {
-        Pod targetA =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetA")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetA).create();
-        Pod targetB =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("targetB")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(targetB).create();
+            // targetA is intentionally not a matching service
+            ServiceRef serv1 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpB, NAMESPACE, portB)),
+                            targetB.getMetadata().getName());
+            serv1.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipB,
+                            AnnotationKey.PORT,
+                            Integer.toString(portB),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetB.getMetadata().getName()));
+            ServiceRef serv2 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpC, NAMESPACE, portC)),
+                            targetC.getMetadata().getName());
+            serv2.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipC,
+                            AnnotationKey.PORT,
+                            Integer.toString(portC),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetC.getMetadata().getName()));
+            ServiceRef serv3 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpD, NAMESPACE, portD)),
+                            targetD.getMetadata().getName());
+            serv3.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipD,
+                            AnnotationKey.PORT,
+                            Integer.toString(portD),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetD.getMetadata().getName()));
+            ServiceRef serv4 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpE, NAMESPACE, portE)),
+                            targetE.getMetadata().getName());
+            serv4.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipE,
+                            AnnotationKey.PORT,
+                            Integer.toString(portE),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetE.getMetadata().getName()));
+            MatcherAssert.assertThat(
+                    result, Matchers.equalTo(Arrays.asList(serv1, serv2, serv3, serv4)));
+        }
 
-        String ipA = "127.0.0.2";
-        String transformedIpA = ipA.replaceAll("\\.", "-");
-        int portA = 9091;
-        String ipB = "127.0.0.3";
-        String transformedIpB = ipB.replaceAll("\\.", "-");
-        int portB = 1234;
-        Endpoints endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipA)
-                                        .withHostname(targetA.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetA.getMetadata().getName())
-                                        .withKind(targetA.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("tcp-9091")
-                                        .withPort(portA)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ipB)
-                                        .withHostname(targetB.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(targetB.getMetadata().getName())
-                                        .withKind(targetB.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(portB)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+        @Test
+        void shouldReturnDiscoveryTree() throws Exception {
+            Pod targetA =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetA")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetA).create();
+            Pod targetB =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("targetB")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(targetB).create();
 
-        platformClient.start();
-        EnvironmentNode realmNode = platformClient.getDiscoveryTree();
-        ServiceRef serv1 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpA, NAMESPACE, portA)),
-                        targetA.getMetadata().getName());
-        serv1.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipA,
-                        AnnotationKey.PORT,
-                        Integer.toString(portA),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetA.getMetadata().getName()));
-        ServiceRef serv2 =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIpB, NAMESPACE, portB)),
-                        targetB.getMetadata().getName());
-        serv2.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ipB,
-                        AnnotationKey.PORT,
-                        Integer.toString(portB),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        targetB.getMetadata().getName()));
+            String ipA = "127.0.0.2";
+            String transformedIpA = ipA.replaceAll("\\.", "-");
+            int portA = 9091;
+            String ipB = "127.0.0.3";
+            String transformedIpB = ipB.replaceAll("\\.", "-");
+            int portB = 1234;
+            Endpoints endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipA)
+                                            .withHostname(targetA.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetA.getMetadata().getName())
+                                            .withKind(targetA.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("tcp-9091")
+                                            .withPort(portA)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ipB)
+                                            .withHostname(targetB.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(targetB.getMetadata().getName())
+                                            .withKind(targetB.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(portB)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
-        MatcherAssert.assertThat(realmNode.getName(), Matchers.equalTo("KubernetesApi"));
-        MatcherAssert.assertThat(realmNode.getNodeType(), Matchers.equalTo(BaseNodeType.REALM));
-        MatcherAssert.assertThat(realmNode.getLabels().size(), Matchers.equalTo(0));
-        MatcherAssert.assertThat(realmNode.getChildren(), Matchers.hasSize(1));
+            platformClient.start();
+            EnvironmentNode realmNode = platformClient.getDiscoveryTree();
+            ServiceRef serv1 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpA, NAMESPACE, portA)),
+                            targetA.getMetadata().getName());
+            serv1.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipA,
+                            AnnotationKey.PORT,
+                            Integer.toString(portA),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetA.getMetadata().getName()));
+            ServiceRef serv2 =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIpB, NAMESPACE, portB)),
+                            targetB.getMetadata().getName());
+            serv2.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ipB,
+                            AnnotationKey.PORT,
+                            Integer.toString(portB),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            targetB.getMetadata().getName()));
 
-        AbstractNode realmChild = realmNode.getChildren().get(0);
-        MatcherAssert.assertThat(realmChild, Matchers.instanceOf(EnvironmentNode.class));
-        EnvironmentNode namespaceNode = (EnvironmentNode) realmChild;
-        MatcherAssert.assertThat(namespaceNode.getName(), Matchers.equalTo(NAMESPACE));
-        MatcherAssert.assertThat(
-                namespaceNode.getNodeType(), Matchers.equalTo(KubernetesNodeType.NAMESPACE));
-        MatcherAssert.assertThat(namespaceNode.getLabels().size(), Matchers.equalTo(0));
-        MatcherAssert.assertThat(namespaceNode.getChildren(), Matchers.hasSize(2));
+            MatcherAssert.assertThat(realmNode.getName(), Matchers.equalTo("KubernetesApi"));
+            MatcherAssert.assertThat(realmNode.getNodeType(), Matchers.equalTo(BaseNodeType.REALM));
+            MatcherAssert.assertThat(realmNode.getLabels().size(), Matchers.equalTo(0));
+            MatcherAssert.assertThat(realmNode.getChildren(), Matchers.hasSize(1));
 
-        MatcherAssert.assertThat(
-                namespaceNode.getChildren(),
-                Matchers.everyItem(
-                        Matchers.hasProperty(
-                                "nodeType", Matchers.equalTo(KubernetesNodeType.POD))));
-        MatcherAssert.assertThat(
-                namespaceNode.getChildren(),
-                Matchers.allOf(
-                        Matchers.hasItem(
-                                Matchers.hasProperty(
-                                        "name", Matchers.equalTo(targetA.getMetadata().getName()))),
-                        Matchers.hasItem(
-                                Matchers.hasProperty(
-                                        "name",
-                                        Matchers.equalTo(targetB.getMetadata().getName())))));
+            AbstractNode realmChild = realmNode.getChildren().get(0);
+            MatcherAssert.assertThat(realmChild, Matchers.instanceOf(EnvironmentNode.class));
+            EnvironmentNode namespaceNode = (EnvironmentNode) realmChild;
+            MatcherAssert.assertThat(namespaceNode.getName(), Matchers.equalTo(NAMESPACE));
+            MatcherAssert.assertThat(
+                    namespaceNode.getNodeType(), Matchers.equalTo(KubernetesNodeType.NAMESPACE));
+            MatcherAssert.assertThat(namespaceNode.getLabels().size(), Matchers.equalTo(0));
+            MatcherAssert.assertThat(namespaceNode.getChildren(), Matchers.hasSize(2));
 
-        EnvironmentNode podA =
-                (EnvironmentNode)
-                        namespaceNode.getChildren().stream()
-                                .filter(c -> c.getName().equals(targetA.getMetadata().getName()))
-                                .findFirst()
-                                .get();
-        EnvironmentNode podB =
-                (EnvironmentNode)
-                        namespaceNode.getChildren().stream()
-                                .filter(c -> c.getName().equals(targetB.getMetadata().getName()))
-                                .findFirst()
-                                .get();
+            MatcherAssert.assertThat(
+                    namespaceNode.getChildren(),
+                    Matchers.everyItem(
+                            Matchers.hasProperty(
+                                    "nodeType", Matchers.equalTo(KubernetesNodeType.POD))));
+            MatcherAssert.assertThat(
+                    namespaceNode.getChildren(),
+                    Matchers.allOf(
+                            Matchers.hasItem(
+                                    Matchers.hasProperty(
+                                            "name",
+                                            Matchers.equalTo(targetA.getMetadata().getName()))),
+                            Matchers.hasItem(
+                                    Matchers.hasProperty(
+                                            "name",
+                                            Matchers.equalTo(targetB.getMetadata().getName())))));
 
-        // FIXME fill in more intermediate nodes, ie. ReplicationController, DeploymentConfig
-        Matcher<AbstractNode> sr1Matcher =
-                Matchers.allOf(
-                        Matchers.hasProperty(
-                                "name", Matchers.equalTo(serv1.getServiceUri().toString())),
-                        Matchers.hasProperty(
-                                "nodeType", Matchers.equalTo(KubernetesNodeType.ENDPOINT)),
-                        Matchers.hasProperty("target", Matchers.equalTo(serv1)));
-        MatcherAssert.assertThat(podA.getChildren(), Matchers.contains(sr1Matcher));
-        Matcher<AbstractNode> sr2Matcher =
-                Matchers.allOf(
-                        Matchers.hasProperty(
-                                "name", Matchers.equalTo(serv2.getServiceUri().toString())),
-                        Matchers.hasProperty(
-                                "nodeType", Matchers.equalTo(KubernetesNodeType.ENDPOINT)),
-                        Matchers.hasProperty("target", Matchers.equalTo(serv2)));
-        MatcherAssert.assertThat(podB.getChildren(), Matchers.contains(sr2Matcher));
-    }
+            EnvironmentNode podA =
+                    (EnvironmentNode)
+                            namespaceNode.getChildren().stream()
+                                    .filter(
+                                            c ->
+                                                    c.getName()
+                                                            .equals(
+                                                                    targetA.getMetadata()
+                                                                            .getName()))
+                                    .findFirst()
+                                    .get();
+            EnvironmentNode podB =
+                    (EnvironmentNode)
+                            namespaceNode.getChildren().stream()
+                                    .filter(
+                                            c ->
+                                                    c.getName()
+                                                            .equals(
+                                                                    targetB.getMetadata()
+                                                                            .getName()))
+                                    .findFirst()
+                                    .get();
 
-    @Test
-    public void shouldNotifyOnAsyncAdded() throws Exception {
-        CompletableFuture<TargetDiscoveryEvent> eventFuture = new CompletableFuture<>();
-        platformClient.addTargetDiscoveryListener(eventFuture::complete);
+            // FIXME fill in more intermediate nodes, ie. ReplicationController, DeploymentConfig
+            Matcher<AbstractNode> sr1Matcher =
+                    Matchers.allOf(
+                            Matchers.hasProperty(
+                                    "name", Matchers.equalTo(serv1.getServiceUri().toString())),
+                            Matchers.hasProperty(
+                                    "nodeType", Matchers.equalTo(KubernetesNodeType.ENDPOINT)),
+                            Matchers.hasProperty("target", Matchers.equalTo(serv1)));
+            MatcherAssert.assertThat(podA.getChildren(), Matchers.contains(sr1Matcher));
+            Matcher<AbstractNode> sr2Matcher =
+                    Matchers.allOf(
+                            Matchers.hasProperty(
+                                    "name", Matchers.equalTo(serv2.getServiceUri().toString())),
+                            Matchers.hasProperty(
+                                    "nodeType", Matchers.equalTo(KubernetesNodeType.ENDPOINT)),
+                            Matchers.hasProperty("target", Matchers.equalTo(serv2)));
+            MatcherAssert.assertThat(podB.getChildren(), Matchers.contains(sr2Matcher));
+        }
 
-        Pod watchedTarget =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("watchedTarget")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
+        @Test
+        public void shouldNotifyOnAsyncAdded() throws Exception {
+            CompletableFuture<TargetDiscoveryEvent> eventFuture = new CompletableFuture<>();
+            platformClient.addTargetDiscoveryListener(eventFuture::complete);
 
-        platformClient.start();
+            Pod watchedTarget =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("watchedTarget")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
 
-        String ip = "192.168.1.10";
-        String transformedIp = ip.replaceAll("\\.", "-");
-        int port = 9876;
-        Endpoints endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ip)
-                                        .withHostname(watchedTarget.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(watchedTarget.getMetadata().getName())
-                                        .withKind(watchedTarget.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(port)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+            platformClient.start();
 
-        TargetDiscoveryEvent evt = eventFuture.get(1, TimeUnit.SECONDS);
-        MatcherAssert.assertThat(evt.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        ServiceRef serv =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIp, NAMESPACE, port)),
-                        watchedTarget.getMetadata().getName());
-        serv.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ip,
-                        AnnotationKey.PORT,
-                        Integer.toString(port),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        watchedTarget.getMetadata().getName()));
-        MatcherAssert.assertThat(evt.getServiceRef(), Matchers.equalTo(serv));
-    }
+            String ip = "192.168.1.10";
+            String transformedIp = ip.replaceAll("\\.", "-");
+            int port = 9876;
+            Endpoints endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ip)
+                                            .withHostname(watchedTarget.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(watchedTarget.getMetadata().getName())
+                                            .withKind(watchedTarget.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(port)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
-    @Test
-    public void shouldNotifyOnAsyncDeleted() throws Exception {
-        Pod watchedTarget =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("watchedTarget")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
+            TargetDiscoveryEvent evt = eventFuture.get(1, TimeUnit.SECONDS);
+            MatcherAssert.assertThat(evt.getEventKind(), Matchers.equalTo(EventKind.FOUND));
+            ServiceRef serv =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIp, NAMESPACE, port)),
+                            watchedTarget.getMetadata().getName());
+            serv.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ip,
+                            AnnotationKey.PORT,
+                            Integer.toString(port),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            watchedTarget.getMetadata().getName()));
+            MatcherAssert.assertThat(evt.getServiceRef(), Matchers.equalTo(serv));
+        }
 
-        String ip = "192.168.1.10";
-        String transformedIp = ip.replaceAll("\\.", "-");
-        int port = 9876;
-        Endpoints endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ip)
-                                        .withHostname(watchedTarget.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(watchedTarget.getMetadata().getName())
-                                        .withKind(watchedTarget.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(port)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
+        @Test
+        public void shouldNotifyOnAsyncDeleted() throws Exception {
+            Pod watchedTarget =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("watchedTarget")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
 
-        CountDownLatch latch = new CountDownLatch(2);
-        Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(2);
-        platformClient.addTargetDiscoveryListener(
-                tde -> {
-                    events.add(tde);
-                    latch.countDown();
-                });
+            String ip = "192.168.1.10";
+            String transformedIp = ip.replaceAll("\\.", "-");
+            int port = 9876;
+            Endpoints endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ip)
+                                            .withHostname(watchedTarget.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(watchedTarget.getMetadata().getName())
+                                            .withKind(watchedTarget.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(port)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
 
-        platformClient.start();
+            CountDownLatch latch = new CountDownLatch(2);
+            Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(2);
+            platformClient.addTargetDiscoveryListener(
+                    tde -> {
+                        events.add(tde);
+                        latch.countDown();
+                    });
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).delete();
+            platformClient.start();
 
-        latch.await();
-        Thread.sleep(100); // to ensure no more events are coming
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).delete();
 
-        MatcherAssert.assertThat(events, Matchers.hasSize(2));
+            latch.await();
+            Thread.sleep(100); // to ensure no more events are coming
 
-        ServiceRef serv =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIp, NAMESPACE, port)),
-                        "watchedTarget");
-        serv.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ip,
-                        AnnotationKey.PORT,
-                        Integer.toString(port),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        watchedTarget.getMetadata().getName()));
+            MatcherAssert.assertThat(events, Matchers.hasSize(2));
 
-        TargetDiscoveryEvent found = events.remove();
-        MatcherAssert.assertThat(found.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        MatcherAssert.assertThat(found.getServiceRef(), Matchers.equalTo(serv));
+            ServiceRef serv =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIp, NAMESPACE, port)),
+                            "watchedTarget");
+            serv.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ip,
+                            AnnotationKey.PORT,
+                            Integer.toString(port),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            watchedTarget.getMetadata().getName()));
 
-        TargetDiscoveryEvent lost = events.remove();
-        MatcherAssert.assertThat(lost.getEventKind(), Matchers.equalTo(EventKind.LOST));
-        MatcherAssert.assertThat(lost.getServiceRef(), Matchers.equalTo(serv));
-    }
+            TargetDiscoveryEvent found = events.remove();
+            MatcherAssert.assertThat(found.getEventKind(), Matchers.equalTo(EventKind.FOUND));
+            MatcherAssert.assertThat(found.getServiceRef(), Matchers.equalTo(serv));
 
-    @Test
-    public void shouldNotifyOnAsyncModified() throws Exception {
-        Pod watchedTarget =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("watchedTarget")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
-        Pod modifiedTarget =
-                new PodBuilder()
-                        .withNewMetadata()
-                        .withName("modifiedTarget")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .build();
-        k8sClient.pods().inNamespace(NAMESPACE).resource(modifiedTarget).create();
+            TargetDiscoveryEvent lost = events.remove();
+            MatcherAssert.assertThat(lost.getEventKind(), Matchers.equalTo(EventKind.LOST));
+            MatcherAssert.assertThat(lost.getServiceRef(), Matchers.equalTo(serv));
+        }
 
-        String ip = "192.168.1.10";
-        String transformedIp = ip.replaceAll("\\.", "-");
-        int port = 9876;
+        @Test
+        public void shouldNotifyOnAsyncModified() throws Exception {
+            Pod watchedTarget =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("watchedTarget")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(watchedTarget).create();
+            Pod modifiedTarget =
+                    new PodBuilder()
+                            .withNewMetadata()
+                            .withName("modifiedTarget")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .build();
+            k8sClient.pods().inNamespace(NAMESPACE).resource(modifiedTarget).create();
 
-        Endpoints endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ip)
-                                        .withHostname(watchedTarget.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(watchedTarget.getMetadata().getName())
-                                        .withKind(watchedTarget.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(port)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
+            String ip = "192.168.1.10";
+            String transformedIp = ip.replaceAll("\\.", "-");
+            int port = 9876;
 
-        CountDownLatch latch = new CountDownLatch(2);
-        Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(2);
-        platformClient.addTargetDiscoveryListener(
-                tde -> {
-                    events.add(tde);
-                    latch.countDown();
-                });
+            Endpoints endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ip)
+                                            .withHostname(watchedTarget.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(watchedTarget.getMetadata().getName())
+                                            .withKind(watchedTarget.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(port)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
 
-        platformClient.start();
+            CountDownLatch latch = new CountDownLatch(2);
+            Queue<TargetDiscoveryEvent> events = new ArrayDeque<>(2);
+            platformClient.addTargetDiscoveryListener(
+                    tde -> {
+                        events.add(tde);
+                        latch.countDown();
+                    });
 
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
+            platformClient.start();
 
-        endpoints =
-                new EndpointsBuilder()
-                        .withNewMetadata()
-                        .withName("endpoints1")
-                        .withNamespace(NAMESPACE)
-                        .endMetadata()
-                        .addNewSubset()
-                        .withAddresses(
-                                new EndpointAddressBuilder()
-                                        .withIp(ip)
-                                        .withHostname(modifiedTarget.getMetadata().getName())
-                                        .withNewTargetRef()
-                                        .withName(modifiedTarget.getMetadata().getName())
-                                        .withKind(modifiedTarget.getKind())
-                                        .withNamespace(NAMESPACE)
-                                        .endTargetRef()
-                                        .build())
-                        .withPorts(
-                                new EndpointPortBuilder()
-                                        .withName("jfr-jmx")
-                                        .withPort(port)
-                                        .withProtocol("tcp")
-                                        .build())
-                        .endSubset()
-                        .build();
-        k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).replace();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).create();
 
-        latch.await();
-        Thread.sleep(100); // to ensure no more events are coming
+            endpoints =
+                    new EndpointsBuilder()
+                            .withNewMetadata()
+                            .withName("endpoints1")
+                            .withNamespace(NAMESPACE)
+                            .endMetadata()
+                            .addNewSubset()
+                            .withAddresses(
+                                    new EndpointAddressBuilder()
+                                            .withIp(ip)
+                                            .withHostname(modifiedTarget.getMetadata().getName())
+                                            .withNewTargetRef()
+                                            .withName(modifiedTarget.getMetadata().getName())
+                                            .withKind(modifiedTarget.getKind())
+                                            .withNamespace(NAMESPACE)
+                                            .endTargetRef()
+                                            .build())
+                            .withPorts(
+                                    new EndpointPortBuilder()
+                                            .withName("jfr-jmx")
+                                            .withPort(port)
+                                            .withProtocol("tcp")
+                                            .build())
+                            .endSubset()
+                            .build();
+            k8sClient.endpoints().inNamespace(NAMESPACE).resource(endpoints).replace();
 
-        MatcherAssert.assertThat(events, Matchers.hasSize(2));
+            latch.await();
+            Thread.sleep(100); // to ensure no more events are coming
 
-        ServiceRef original =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIp, NAMESPACE, port)),
-                        watchedTarget.getMetadata().getName());
-        original.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ip,
-                        AnnotationKey.PORT,
-                        Integer.toString(port),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        watchedTarget.getMetadata().getName()));
+            MatcherAssert.assertThat(events, Matchers.hasSize(2));
 
-        ServiceRef modified =
-                new ServiceRef(
-                        null,
-                        URI.create(
-                                String.format(
-                                        "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
-                                        transformedIp, NAMESPACE, port)),
-                        modifiedTarget.getMetadata().getName());
-        modified.setCryostatAnnotations(
-                Map.of(
-                        AnnotationKey.REALM,
-                        "KubernetesApi",
-                        AnnotationKey.HOST,
-                        ip,
-                        AnnotationKey.PORT,
-                        Integer.toString(port),
-                        AnnotationKey.NAMESPACE,
-                        NAMESPACE,
-                        AnnotationKey.POD_NAME,
-                        modifiedTarget.getMetadata().getName()));
+            ServiceRef original =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIp, NAMESPACE, port)),
+                            watchedTarget.getMetadata().getName());
+            original.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ip,
+                            AnnotationKey.PORT,
+                            Integer.toString(port),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            watchedTarget.getMetadata().getName()));
 
-        TargetDiscoveryEvent foundEvent = events.remove();
-        MatcherAssert.assertThat(foundEvent.getEventKind(), Matchers.equalTo(EventKind.FOUND));
-        MatcherAssert.assertThat(foundEvent.getServiceRef(), Matchers.equalTo(original));
+            ServiceRef modified =
+                    new ServiceRef(
+                            null,
+                            URI.create(
+                                    String.format(
+                                            "service:jmx:rmi:///jndi/rmi://%s.%s.pod:%d/jmxrmi",
+                                            transformedIp, NAMESPACE, port)),
+                            modifiedTarget.getMetadata().getName());
+            modified.setCryostatAnnotations(
+                    Map.of(
+                            AnnotationKey.REALM,
+                            "KubernetesApi",
+                            AnnotationKey.HOST,
+                            ip,
+                            AnnotationKey.PORT,
+                            Integer.toString(port),
+                            AnnotationKey.NAMESPACE,
+                            NAMESPACE,
+                            AnnotationKey.POD_NAME,
+                            modifiedTarget.getMetadata().getName()));
 
-        TargetDiscoveryEvent modifiedEvent = events.remove();
-        MatcherAssert.assertThat(
-                modifiedEvent.getEventKind(), Matchers.equalTo(EventKind.MODIFIED));
-        MatcherAssert.assertThat(modifiedEvent.getServiceRef(), Matchers.equalTo(modified));
+            TargetDiscoveryEvent foundEvent = events.remove();
+            MatcherAssert.assertThat(foundEvent.getEventKind(), Matchers.equalTo(EventKind.FOUND));
+            MatcherAssert.assertThat(foundEvent.getServiceRef(), Matchers.equalTo(original));
+
+            TargetDiscoveryEvent modifiedEvent = events.remove();
+            MatcherAssert.assertThat(
+                    modifiedEvent.getEventKind(), Matchers.equalTo(EventKind.MODIFIED));
+            MatcherAssert.assertThat(modifiedEvent.getServiceRef(), Matchers.equalTo(modified));
+        }
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1861

## Description of the change:
Adds environment variables for customizing the behaviour of the builtin k8s Endpoints discovery mechanism. Rather than always looking for ports named `jfr-jmx` or numbered `9091`, this allows the deploying user to specify a list of acceptable names and a list of acceptable numbers that should be matched, both of them comma-separated. The names list can be set to the empty list by using the value `-`, and the number list can be set to the empty list by using the value `0`. If these variables are not defined or have empty values then they default to the singleton lists of `jfr-jmx` and `9091` respectively, maintaining the previous behaviour.

## Motivation for the change:
For users deploying Cryostat into scenarios where a port named `jfr-jmx` or numbered `9091` already exists for another purpose, this allows Cryostat to be dropped in with only minor configuration so that the Kubernetes Endpoints discovery mechanism can still be used, but does not mistakenly see non-JMX service ports as connectable targets when they really are not.

## How to manually test:
1. I used helm, ex.: `helm install cryostat --set core.image.repository=quay.io/andrewazores/cryostat --set core.image.tag=2.5.0-k8s-discovery-3 --set pvc.enabled=true --set core.route.enabled=true ./charts/cryostat`
2. Then I used the Operator's `make sample_app` to get a `quarkus-test` sample application
3. Then I used `oc edit deployment cryostat` to set/edit `CRYOSTAT_DISCOVERY_K8S_PORT_NAMES` and `CRYOSTAT_DISCOVERY_K8S_PORT_NUMBERS`, and `oc edit service quarkus-test` to change the port name/number on the sample app.
