### PR TITLE
fix(discovery): BUILTIN_DISCOVERY_DISABLED can be specified even when PLATFORM is set

### DIFF
--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -109,9 +109,11 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
                                     .onSuccess(
                                             subtree -> storage.update(id, subtree.getChildren()));
                             try {
-                                platform.start();
-                                platform.load(promise);
-                                enabledClients.add(platform);
+                                if (platform.isEnabled()) {
+                                    platform.start();
+                                    platform.load(promise);
+                                    enabledClients.add(platform);
+                                }
                             } catch (Exception e) {
                                 logger.warn(e);
                             }

--- a/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/BuiltInDiscovery.java
@@ -74,6 +74,12 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
                 .distinct()
                 .forEach(
                         platform -> {
+                            if (!platform.isEnabled()) {
+                                logger.info(
+                                        "Skipping built-in discovery with {} : not enabled",
+                                        platform.getClass().getSimpleName());
+                                return;
+                            }
                             logger.info(
                                     "Starting built-in discovery with {}",
                                     platform.getClass().getSimpleName());
@@ -109,11 +115,9 @@ public class BuiltInDiscovery extends AbstractVerticle implements Consumer<Targe
                                     .onSuccess(
                                             subtree -> storage.update(id, subtree.getChildren()));
                             try {
-                                if (platform.isEnabled()) {
-                                    platform.start();
-                                    platform.load(promise);
-                                    enabledClients.add(platform);
-                                }
+                                platform.start();
+                                platform.load(promise);
+                                enabledClients.add(platform);
                             } catch (Exception e) {
                                 logger.warn(e);
                             }

--- a/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryStorage.java
@@ -121,6 +121,11 @@ public class DiscoveryStorage extends AbstractPlatformClientVerticle {
     }
 
     @Override
+    public final boolean isEnabled() {
+        return true;
+    }
+
+    @Override
     public void start(Promise<Void> future) throws Exception {
         pingPrune()
                 .whenComplete(

--- a/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
@@ -35,7 +35,8 @@ public abstract class AbstractPlatformClient implements PlatformClient {
 
     @Override
     public boolean isEnabled() {
-        return !environment.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY);
+        return !Boolean.parseBoolean(
+                environment.getEnv(Variables.DISABLE_BUILTIN_DISCOVERY, "false"));
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/AbstractPlatformClient.java
@@ -19,14 +19,23 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.cryostat.configuration.Variables;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 
 public abstract class AbstractPlatformClient implements PlatformClient {
 
+    protected final Environment environment;
     protected final Set<Consumer<TargetDiscoveryEvent>> discoveryListeners;
 
-    protected AbstractPlatformClient() {
+    protected AbstractPlatformClient(Environment environment) {
+        this.environment = environment;
         this.discoveryListeners = new HashSet<>();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !environment.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/PlatformClient.java
+++ b/src/main/java/io/cryostat/platform/PlatformClient.java
@@ -23,6 +23,9 @@ import io.cryostat.platform.discovery.EnvironmentNode;
 import io.vertx.core.Promise;
 
 public interface PlatformClient {
+
+    boolean isEnabled();
+
     default void start() throws Exception {}
 
     default void load(Promise<EnvironmentNode> promise) {

--- a/src/main/java/io/cryostat/platform/PlatformModule.java
+++ b/src/main/java/io/cryostat/platform/PlatformModule.java
@@ -90,8 +90,6 @@ public abstract class PlatformModule {
             List<String> platforms =
                     Arrays.asList(env.getEnv(Variables.PLATFORM_STRATEGY_ENV_VAR).split(","));
             fn = s -> platforms.contains(s.getClass().getCanonicalName());
-        } else if (env.hasEnv(Variables.DISABLE_BUILTIN_DISCOVERY)) {
-            fn = s -> false;
         } else {
             fn = PlatformDetectionStrategy::isAvailable;
         }

--- a/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/CustomTargetPlatformClient.java
@@ -25,6 +25,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.platform.AbstractPlatformClient;
 import io.cryostat.platform.ServiceRef;
@@ -46,9 +47,15 @@ public class CustomTargetPlatformClient extends AbstractPlatformClient {
     private final SortedSet<ServiceRef> targets;
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Field is never mutated")
-    public CustomTargetPlatformClient(Lazy<DiscoveryStorage> storage) {
+    public CustomTargetPlatformClient(Environment environment, Lazy<DiscoveryStorage> storage) {
+        super(environment);
         this.storage = storage;
         this.targets = new TreeSet<>((u1, u2) -> u1.getServiceUri().compareTo(u2.getServiceUri()));
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformClient.java
@@ -31,6 +31,7 @@ import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.discovery.DiscoveredJvmDescriptor;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.AbstractPlatformClient;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
@@ -47,12 +48,14 @@ public class DefaultPlatformClient extends AbstractPlatformClient
 
     public static final NodeType NODE_TYPE = BaseNodeType.JVM;
 
-    private final Logger logger;
     private final JvmDiscoveryClient discoveryClient;
+    private final Logger logger;
 
-    DefaultPlatformClient(Logger logger, JvmDiscoveryClient discoveryClient) {
-        this.logger = logger;
+    DefaultPlatformClient(
+            Environment environment, JvmDiscoveryClient discoveryClient, Logger logger) {
+        super(environment);
         this.discoveryClient = discoveryClient;
+        this.logger = logger;
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DefaultPlatformStrategy.java
@@ -17,23 +17,27 @@ package io.cryostat.platform.internal;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.net.AuthManager;
 
 import dagger.Lazy;
 
 class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatformClient> {
 
-    private final Logger logger;
+    private final Environment environment;
     private final Lazy<? extends AuthManager> authMgr;
     private final Lazy<JvmDiscoveryClient> discoveryClient;
+    private final Logger logger;
 
     DefaultPlatformStrategy(
-            Logger logger,
+            Environment environment,
             Lazy<? extends AuthManager> authMgr,
-            Lazy<JvmDiscoveryClient> discoveryClient) {
-        this.logger = logger;
+            Lazy<JvmDiscoveryClient> discoveryClient,
+            Logger logger) {
+        this.environment = environment;
         this.authMgr = authMgr;
         this.discoveryClient = discoveryClient;
+        this.logger = logger;
     }
 
     @Override
@@ -44,7 +48,7 @@ class DefaultPlatformStrategy implements PlatformDetectionStrategy<DefaultPlatfo
     @Override
     public DefaultPlatformClient getPlatformClient() {
         logger.info("Selected Default Platform Strategy");
-        return new DefaultPlatformClient(logger, discoveryClient.get());
+        return new DefaultPlatformClient(environment, discoveryClient.get(), logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/DockerPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/DockerPlatformClient.java
@@ -36,6 +36,7 @@ import javax.management.remote.JMXServiceURL;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.AbstractPlatformClient;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
@@ -73,12 +74,14 @@ public class DockerPlatformClient extends AbstractPlatformClient {
     private final CopyOnWriteArrayList<ContainerSpec> containers = new CopyOnWriteArrayList<>();
 
     DockerPlatformClient(
+            Environment environment,
             Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             SocketAddress dockerSocket,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
             Logger logger) {
+        super(environment);
         this.webClient = webClient;
         this.vertx = vertx;
         this.dockerSocket = dockerSocket;

--- a/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/DockerPlatformStrategy.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeoutException;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
@@ -38,29 +39,32 @@ import io.vertx.ext.web.codec.BodyCodec;
 class DockerPlatformStrategy implements PlatformDetectionStrategy<DockerPlatformClient> {
 
     private static final String DOCKER_SOCKET_PATH = "/var/run/docker.sock";
-    private final Logger logger;
     private final Lazy<? extends AuthManager> authMgr;
     private final Lazy<WebClient> webClient;
     private final Lazy<Vertx> vertx;
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
     private final Gson gson;
+    private final Environment environment;
     private final FileSystem fs;
+    private final Logger logger;
 
     DockerPlatformStrategy(
-            Logger logger,
             Lazy<? extends AuthManager> authMgr,
             Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
-            FileSystem fs) {
-        this.logger = logger;
+            Environment environment,
+            FileSystem fs,
+            Logger logger) {
         this.authMgr = authMgr;
         this.webClient = webClient;
         this.vertx = vertx;
         this.connectionToolkit = connectionToolkit;
         this.gson = gson;
+        this.environment = environment;
         this.fs = fs;
+        this.logger = logger;
     }
 
     @Override
@@ -129,7 +133,7 @@ class DockerPlatformStrategy implements PlatformDetectionStrategy<DockerPlatform
     public DockerPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         return new DockerPlatformClient(
-                webClient, vertx, getSocket(), connectionToolkit, gson, logger);
+                environment, webClient, vertx, getSocket(), connectionToolkit, gson, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformClient.java
@@ -35,6 +35,7 @@ import javax.management.remote.JMXServiceURL;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.AbstractPlatformClient;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
@@ -105,10 +106,12 @@ public class KubeApiPlatformClient extends AbstractPlatformClient {
             new ConcurrentHashMap<>();
 
     KubeApiPlatformClient(
+            Environment environment,
             Collection<String> namespaces,
             KubernetesClient k8sClient,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Logger logger) {
+        super(environment);
         this.namespaces = new HashSet<>(namespaces);
         this.k8sClient = k8sClient;
         this.connectionToolkit = connectionToolkit;

--- a/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/KubeApiPlatformStrategy.java
@@ -39,18 +39,18 @@ import org.apache.commons.lang3.StringUtils;
 
 class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatformClient> {
 
-    protected final Logger logger;
     protected final Lazy<? extends AuthManager> authMgr;
     protected final Environment env;
     protected final FileSystem fs;
     protected final Lazy<JFRConnectionToolkit> connectionToolkit;
+    protected final Logger logger;
 
     KubeApiPlatformStrategy(
-            Logger logger,
             Lazy<? extends AuthManager> authMgr,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
-            FileSystem fs) {
+            FileSystem fs,
+            Logger logger) {
         this.logger = logger;
         this.authMgr = authMgr;
         this.connectionToolkit = connectionToolkit;
@@ -73,7 +73,7 @@ class KubeApiPlatformStrategy implements PlatformDetectionStrategy<KubeApiPlatfo
     public KubeApiPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         return new KubeApiPlatformClient(
-                getNamespaces(), createClient(), connectionToolkit, logger);
+                env, getNamespaces(), createClient(), connectionToolkit, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/OpenShiftPlatformStrategy.java
@@ -28,12 +28,12 @@ import io.fabric8.openshift.client.OpenShiftClient;
 class OpenShiftPlatformStrategy extends KubeApiPlatformStrategy {
 
     OpenShiftPlatformStrategy(
-            Logger logger,
             Lazy<? extends AuthManager> authMgr,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
-            FileSystem fs) {
-        super(logger, authMgr, connectionToolkit, env, fs);
+            FileSystem fs,
+            Logger logger) {
+        super(authMgr, connectionToolkit, env, fs, logger);
     }
 
     @Override

--- a/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
+++ b/src/main/java/io/cryostat/platform/internal/PlatformStrategyModule.java
@@ -52,8 +52,8 @@ public abstract class PlatformStrategyModule {
     @Provides
     @Singleton
     static CustomTargetPlatformClient provideCustomTargetPlatformClient(
-            Lazy<DiscoveryStorage> storage) {
-        return new CustomTargetPlatformClient(storage);
+            Environment environment, Lazy<DiscoveryStorage> storage) {
+        return new CustomTargetPlatformClient(environment, storage);
     }
 
     @Provides
@@ -73,54 +73,70 @@ public abstract class PlatformStrategyModule {
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
             FileSystem fs) {
-        return new OpenShiftPlatformStrategy(logger, authManager, connectionToolkit, env, fs);
+        return new OpenShiftPlatformStrategy(authManager, connectionToolkit, env, fs, logger);
     }
 
     @Provides
     @Singleton
     static KubeApiPlatformStrategy provideKubeApiPlatformStrategy(
-            Logger logger,
             Lazy<NoopAuthManager> noopAuthManager,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Environment env,
-            FileSystem fs) {
-        return new KubeApiPlatformStrategy(logger, noopAuthManager, connectionToolkit, env, fs);
+            FileSystem fs,
+            Logger logger) {
+        return new KubeApiPlatformStrategy(noopAuthManager, connectionToolkit, env, fs, logger);
     }
 
     @Provides
     @Singleton
     static PodmanPlatformStrategy providePodmanPlatformStrategy(
-            Logger logger,
             Lazy<NoopAuthManager> noopAuthManager,
             @Named(UNIX_SOCKET_WEBCLIENT) Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
-            FileSystem fs) {
+            Environment environment,
+            FileSystem fs,
+            Logger logger) {
         return new PodmanPlatformStrategy(
-                logger, noopAuthManager, webClient, vertx, connectionToolkit, gson, fs);
+                noopAuthManager,
+                webClient,
+                vertx,
+                connectionToolkit,
+                gson,
+                environment,
+                fs,
+                logger);
     }
 
     @Provides
     @Singleton
     static DockerPlatformStrategy provideDockerPlatformStrategy(
-            Logger logger,
             Lazy<NoopAuthManager> noopAuthManager,
             @Named(UNIX_SOCKET_WEBCLIENT) Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
-            FileSystem fs) {
+            Environment environment,
+            FileSystem fs,
+            Logger logger) {
         return new DockerPlatformStrategy(
-                logger, noopAuthManager, webClient, vertx, connectionToolkit, gson, fs);
+                noopAuthManager,
+                webClient,
+                vertx,
+                connectionToolkit,
+                gson,
+                environment,
+                fs,
+                logger);
     }
 
     @Provides
     @Singleton
     static DefaultPlatformStrategy provideDefaultPlatformStrategy(
-            Logger logger, Lazy<NoopAuthManager> noopAuthManager) {
+            Environment environment, Lazy<NoopAuthManager> noopAuthManager, Logger logger) {
         return new DefaultPlatformStrategy(
-                logger, noopAuthManager, () -> new JvmDiscoveryClient(logger));
+                environment, noopAuthManager, () -> new JvmDiscoveryClient(logger), logger);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformClient.java
@@ -41,6 +41,7 @@ import javax.management.remote.JMXServiceURL;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.AbstractPlatformClient;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
@@ -81,6 +82,7 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
     private final CopyOnWriteArrayList<ContainerSpec> containers = new CopyOnWriteArrayList<>();
 
     PodmanPlatformClient(
+            Environment environment,
             ExecutorService executor,
             Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
@@ -88,6 +90,7 @@ public class PodmanPlatformClient extends AbstractPlatformClient {
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
             Logger logger) {
+        super(environment);
         this.executor = executor;
         this.webClient = webClient;
         this.vertx = vertx;

--- a/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
+++ b/src/main/java/io/cryostat/platform/internal/PodmanPlatformStrategy.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.JFRConnectionToolkit;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
 import io.cryostat.net.AuthManager;
 
@@ -39,29 +40,32 @@ import io.vertx.ext.web.codec.BodyCodec;
 
 class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatformClient> {
 
-    private final Logger logger;
     private final Lazy<? extends AuthManager> authMgr;
     private final Lazy<WebClient> webClient;
     private final Lazy<Vertx> vertx;
     private final Lazy<JFRConnectionToolkit> connectionToolkit;
     private final Gson gson;
+    private final Environment environment;
     private final FileSystem fs;
+    private final Logger logger;
 
     PodmanPlatformStrategy(
-            Logger logger,
             Lazy<? extends AuthManager> authMgr,
             Lazy<WebClient> webClient,
             Lazy<Vertx> vertx,
             Lazy<JFRConnectionToolkit> connectionToolkit,
             Gson gson,
-            FileSystem fs) {
-        this.logger = logger;
+            Environment environment,
+            FileSystem fs,
+            Logger logger) {
         this.authMgr = authMgr;
         this.webClient = webClient;
         this.vertx = vertx;
         this.connectionToolkit = connectionToolkit;
         this.gson = gson;
+        this.environment = environment;
         this.fs = fs;
+        this.logger = logger;
     }
 
     @Override
@@ -130,6 +134,7 @@ class PodmanPlatformStrategy implements PlatformDetectionStrategy<PodmanPlatform
     public PodmanPlatformClient getPlatformClient() {
         logger.info("Selected {} Strategy", getClass().getSimpleName());
         return new PodmanPlatformClient(
+                environment,
                 Executors.newSingleThreadExecutor(),
                 webClient,
                 vertx,

--- a/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/CustomTargetPlatformClientTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.management.remote.JMXServiceURL;
 
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.discovery.DiscoveryStorage;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.TargetDiscoveryEvent;
@@ -61,11 +62,12 @@ class CustomTargetPlatformClientTest {
         }
     }
 
+    @Mock Environment env;
     @Mock DiscoveryStorage storage;
 
     @BeforeEach
     void setup() {
-        this.client = new CustomTargetPlatformClient(() -> storage);
+        this.client = new CustomTargetPlatformClient(env, () -> storage);
     }
 
     @Test

--- a/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/DefaultPlatformClientTest.java
@@ -34,6 +34,7 @@ import io.cryostat.core.net.discovery.DiscoveredJvmDescriptor;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.EventKind;
 import io.cryostat.core.net.discovery.JvmDiscoveryClient.JvmDiscoveryEvent;
+import io.cryostat.core.sys.Environment;
 import io.cryostat.platform.ServiceRef;
 import io.cryostat.platform.ServiceRef.AnnotationKey;
 import io.cryostat.platform.TargetDiscoveryEvent;
@@ -56,13 +57,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DefaultPlatformClientTest {
 
-    @Mock Logger logger;
+    @Mock Environment env;
     @Mock JvmDiscoveryClient discoveryClient;
+    @Mock Logger logger;
     DefaultPlatformClient client;
 
     @BeforeEach
     void setup() {
-        this.client = new DefaultPlatformClient(logger, discoveryClient);
+        this.client = new DefaultPlatformClient(env, discoveryClient, logger);
     }
 
     @Test

--- a/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
+++ b/src/test/java/io/cryostat/platform/internal/KubeApiPlatformClientTest.java
@@ -73,7 +73,7 @@ class KubeApiPlatformClientTest {
     void setup() throws Exception {
         this.platformClient =
                 new KubeApiPlatformClient(
-                        List.of(NAMESPACE), k8sClient, () -> connectionToolkit, logger);
+                        env, List.of(NAMESPACE), k8sClient, () -> connectionToolkit, logger);
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1864

## Description of the change:
Removes `BUILTIN_DISCOVERY_DISABLED` environment variable from the platform detection selection logic. This is an unfortunate and very old design decision I made that the platform integration is coupled to both the default auth manager as well as platform-specific target discovery mechanism. This made sense when originally implemented because it never made sense for platform-specific discovery mechanisms to overlap, but with the advent of custom targets and later the pluggable discovery API, and then with support for both Podman and Docker API, this is clearly no longer a good assumption and no longer a good abstraction.

This results in a bug where the variable used to control turning off all of these built-in discovery mechanisms is evaluated in the same place as where we determine which platform detection strategies to enable, which therefore also implicates the AuthManagers. We want to be able to do automatic platform auth (OpenShift is the only one that exists now) integration while also allowing users to turn off built-in discovery in case it causes problems or they intend not to use it.

The fix applied in this patch is to allow platform detection as a whole to either work by the usual automatic detection mechanisms, or to allow the user to use the `CRYOSTAT_PLATFORM` environment variable to specify the list of platforms to enable explicitly. The `BUILTIN_DISCOVERY_DISABLED` variable is not checked until later, after the platform strategies are selected. Once all the strategies are selected the DiscoveryStorage, which integrates all of the mechanisms into one data repository, turns each one on only if its new `isEnabled()` method returns true. For Custom Targets and Discovery Storage itself (the pluggable API) this is always true, but for the other built-in discovery mechanisms (Kubernetes API, Podman, Docker) the check depends on `BUILTIN_DISCOVERY_DISABLED` not being set to `true`.

## How to manually test:
1. `./mvnw clean package ; podman image prune -f ; podman tag quay.io/cryostat/cryostat:latest quay.io/$MY_QUAY_USERNAME/cryostat:pr-1865-1`
2. `podman push quay.io/$MY_QUAY_USERNAME/cryostat:pr-1865-1`
3. `cd cryostat-operator`
4. `oc new-project pr1865`
5. `DEPLOY_NAMESPACE=$(oc project -q) CORE_IMG=quay.io/$MY_QUAY_USERNAME/cryostat:pr-1865-1 make deploy`
6. `make create_cryostat_cr ; make sample_app`
7. Open web-client, log in with OpenShift, accept permissions, etc. Verify that Cryostat itself and the sample app appear under the KubernetesApi heading in the target dropdown and in the KubernetesApi Realm in Topology.
8. `oc patch -n $(oc project -q) cryostat/cryostat-sample -p '{"spec":{"targetDiscoveryOptions":{"builtInDiscoveryDisabled":true}}}'` to flip the switch and turn off builtin discovery
9. Wait for rollout replacement to complete, then repeat Step 7. There should be no more KubernetesApi target dropdown header or Realm.
