### PR TITLE
fix(target): handle creating short form custom target

### DIFF
--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -16,6 +16,7 @@
 package io.cryostat.configuration;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.management.remote.JMXServiceURL;
 import javax.script.ScriptException;
 
 import io.cryostat.core.log.Logger;
@@ -49,6 +51,7 @@ import com.google.gson.JsonObject;
 import dagger.Lazy;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.openjdk.jmc.rjmx.ConnectionToolkit;
 
 public class CredentialsManager
         extends AbstractEventEmitter<CredentialsManager.CredentialsEvent, String> {
@@ -163,14 +166,25 @@ public class CredentialsManager
         return -1;
     }
 
+    public JMXServiceURL createServiceURL(String host, int port) throws MalformedURLException {
+        return ConnectionToolkit.createServiceURL(host, port);
+    }
+
     public Credentials getCredentialsByTargetId(String targetId) throws ScriptException {
         try {
             for (ServiceRef service : this.platformClient.listDiscoverableServices()) {
                 URI uri = service.getServiceUri();
                 boolean match = false;
                 boolean isJmx = URIUtil.isJmxUrl(uri);
+                boolean isShortForm = targetId.matches("localhost:\\d+");
+
                 if (isJmx) {
                     match = Objects.equals(uri.toString(), targetId);
+                } else if (isShortForm) {
+                    String[] parts = targetId.split(":");
+                    String host = parts[0];
+                    int port = Integer.parseInt(parts[1]);
+                    targetId = ConnectionToolkit.createServiceURL(host, port).toString();
                 } else {
                     URI in = new URI(targetId);
                     match = Objects.equals(uri, in);
@@ -182,7 +196,7 @@ public class CredentialsManager
                 }
             }
             return null;
-        } catch (URISyntaxException use) {
+        } catch (URISyntaxException | MalformedURLException use) {
             throw new IllegalStateException(use);
         }
     }

--- a/src/main/java/io/cryostat/configuration/CredentialsManager.java
+++ b/src/main/java/io/cryostat/configuration/CredentialsManager.java
@@ -16,7 +16,6 @@
 package io.cryostat.configuration;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -31,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.management.remote.JMXServiceURL;
 import javax.script.ScriptException;
 
 import io.cryostat.core.log.Logger;
@@ -51,7 +49,6 @@ import com.google.gson.JsonObject;
 import dagger.Lazy;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
-import org.openjdk.jmc.rjmx.ConnectionToolkit;
 
 public class CredentialsManager
         extends AbstractEventEmitter<CredentialsManager.CredentialsEvent, String> {
@@ -166,25 +163,14 @@ public class CredentialsManager
         return -1;
     }
 
-    public JMXServiceURL createServiceURL(String host, int port) throws MalformedURLException {
-        return ConnectionToolkit.createServiceURL(host, port);
-    }
-
     public Credentials getCredentialsByTargetId(String targetId) throws ScriptException {
         try {
             for (ServiceRef service : this.platformClient.listDiscoverableServices()) {
                 URI uri = service.getServiceUri();
                 boolean match = false;
                 boolean isJmx = URIUtil.isJmxUrl(uri);
-                boolean isShortForm = targetId.matches("localhost:\\d+");
-
                 if (isJmx) {
                     match = Objects.equals(uri.toString(), targetId);
-                } else if (isShortForm) {
-                    String[] parts = targetId.split(":");
-                    String host = parts[0];
-                    int port = Integer.parseInt(parts[1]);
-                    targetId = ConnectionToolkit.createServiceURL(host, port).toString();
                 } else {
                     URI in = new URI(targetId);
                     match = Objects.equals(uri, in);
@@ -196,7 +182,7 @@ public class CredentialsManager
                 }
             }
             return null;
-        } catch (URISyntaxException | MalformedURLException use) {
+        } catch (URISyntaxException use) {
             throw new IllegalStateException(use);
         }
     }

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -131,6 +131,10 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
         try {
             MultiMap attrs = params.getFormAttributes();
             String connectUrl = attrs.get("connectUrl");
+
+            if (StringUtils.isBlank(connectUrl)) {
+                throw new ApiException(400, "\"connectUrl\" form parameter must be provided");
+            }
             // check incase custom target has short form connection url (i.e `localhost:0`,
             // etc)
             if (connectUrl.matches("localhost:\\d+")) {
@@ -138,9 +142,6 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
                 String host = connectUrlParts[0];
                 int port = Integer.parseInt(connectUrlParts[1]);
                 connectUrl = ConnectionToolkit.createServiceURL(host, port).toString();
-            }
-            if (StringUtils.isBlank(connectUrl)) {
-                throw new ApiException(400, "\"connectUrl\" form parameter must be provided");
             }
             String alias = attrs.get("alias");
             if (StringUtils.isBlank(alias)) {

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.openjdk.jmc.rjmx.ConnectionToolkit;
+
 import io.cryostat.configuration.CredentialsManager;
 import io.cryostat.core.log.Logger;
 import io.cryostat.core.net.Credentials;
@@ -50,7 +52,6 @@ import com.google.gson.Gson;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import org.apache.commons.lang3.StringUtils;
-import org.openjdk.jmc.rjmx.ConnectionToolkit;
 
 class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
 
@@ -153,16 +154,19 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             }
 
             MultiMap queries = params.getQueryParams();
-            boolean dryRun = StringUtils.isNotBlank(queries.get("dryrun"))
-                    && Boolean.valueOf(queries.get("dryrun"));
-            boolean storeCredentials = StringUtils.isNotBlank(queries.get("storeCredentials"))
-                    && Boolean.valueOf(queries.get("storeCredentials"));
+            boolean dryRun =
+                    StringUtils.isNotBlank(queries.get("dryrun"))
+                            && Boolean.valueOf(queries.get("dryrun"));
+            boolean storeCredentials =
+                    StringUtils.isNotBlank(queries.get("storeCredentials"))
+                            && Boolean.valueOf(queries.get("storeCredentials"));
 
             String username = attrs.get("username");
             String password = attrs.get("password");
-            Optional<Credentials> credentials = StringUtils.isBlank(username) || StringUtils.isBlank(password)
-                    ? Optional.empty()
-                    : Optional.of(new Credentials(username, password));
+            Optional<Credentials> credentials =
+                    StringUtils.isBlank(username) || StringUtils.isBlank(password)
+                            ? Optional.empty()
+                            : Optional.of(new Credentials(username, password));
 
             if (storeCredentials && credentials.isPresent()) {
                 String matchExpression = CredentialsManager.targetIdToMatchExpression(connectUrl);

--- a/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/TargetsPostHandler.java
@@ -137,7 +137,9 @@ class TargetsPostHandler extends AbstractV2RequestHandler<ServiceRef> {
             }
             // check incase custom target has short form connection url (i.e `localhost:0`,
             // etc)
-            if (connectUrl.matches("localhost:\\d+")) {
+            connectUrl = connectUrl.strip();
+            boolean isShortForm = connectUrl.matches("^[^\\s/:]+:\\d+$");
+            if (isShortForm) {
                 String[] connectUrlParts = connectUrl.split(":");
                 String host = connectUrlParts[0];
                 int port = Integer.parseInt(connectUrlParts[1]);

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -119,7 +119,7 @@ public class CustomTargetsIT extends StandardSelfTest {
         String expectedConnectUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
         JsonObject body = response.get().getJsonObject("data").getJsonObject("result");
         MatcherAssert.assertThat(
-                body.getString("connectUrl"), Matchers.equalTo(expectedConnectUrl));
+                body.getString("connectUrl").strip(), Matchers.equalTo(expectedConnectUrl.strip()));
         MatcherAssert.assertThat(body.getString("alias"), Matchers.equalTo("self"));
     }
 
@@ -223,7 +223,7 @@ public class CustomTargetsIT extends StandardSelfTest {
 
         JsonObject body = response.get().getJsonObject("data").getJsonObject("result");
         MatcherAssert.assertThat(
-                body.getString("connectUrl"), Matchers.equalTo(expectedConnectUrl));
+                body.getString("connectUrl").strip(), Matchers.equalTo(expectedConnectUrl.strip()));
         MatcherAssert.assertThat(body.getString("alias"), Matchers.equalTo("self"));
 
         JsonObject result1 = resultFuture1.get();
@@ -239,7 +239,7 @@ public class CustomTargetsIT extends StandardSelfTest {
         MatcherAssert.assertThat(storedCredential.id, Matchers.any(Integer.class));
         MatcherAssert.assertThat(
                 storedCredential.matchExpression,
-                Matchers.equalTo("target.connectUrl == \"" + expectedConnectUrl + "\""));
+                Matchers.equalTo("target.connectUrl == \"" + expectedConnectUrl.strip() + "\""));
         MatcherAssert.assertThat(
                 storedCredential.numMatchingTargets, Matchers.equalTo(Integer.valueOf(1)));
 
@@ -247,8 +247,8 @@ public class CustomTargetsIT extends StandardSelfTest {
         JsonObject event = result2.getJsonObject("message").getJsonObject("event");
         MatcherAssert.assertThat(event.getString("kind"), Matchers.equalTo("FOUND"));
         MatcherAssert.assertThat(
-                event.getJsonObject("serviceRef").getString("connectUrl"),
-                Matchers.equalTo(expectedConnectUrl));
+                event.getJsonObject("serviceRef").getString("connectUrl").strip(),
+                Matchers.equalTo(expectedConnectUrl.strip()));
         MatcherAssert.assertThat(
                 event.getJsonObject("serviceRef").getString("alias"), Matchers.equalTo("self"));
     }
@@ -335,9 +335,9 @@ public class CustomTargetsIT extends StandardSelfTest {
                                                     Matchers.equalTo("LOST"));
                                             MatcherAssert.assertThat(
                                                     event.getJsonObject("serviceRef")
-                                                            .getString("connectUrl"),
+                                                            .getString("connectUrl").strip(),
                                                     Matchers.equalTo(
-                                                            "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"));
+                                                            "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi".strip()));
                                             MatcherAssert.assertThat(
                                                     event.getJsonObject("serviceRef")
                                                             .getString("alias"),
@@ -356,7 +356,7 @@ public class CustomTargetsIT extends StandardSelfTest {
                         Collections.singletonList(jmxServiceUrl), StandardCharsets.UTF_8);
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
-                .delete("/api/v2/targets/" + encodedUrl)
+                .delete("/api/v2/targets/" + encodedUrl.strip())
                 .send(
                         ar -> {
                             assertRequestStatus(ar, response);

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -362,7 +362,6 @@ public class CustomTargetsIT extends StandardSelfTest {
                         });
 
         latch.await(5, TimeUnit.SECONDS);
-
     }
 
     @Test

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -15,8 +15,8 @@
  */
 package itest;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -37,6 +37,7 @@ import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import itest.util.http.JvmIdWebRequest;
 import itest.util.http.StoredCredential;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -350,7 +351,9 @@ public class CustomTargetsIT extends StandardSelfTest {
                 });
 
         String jmxServiceUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
-        String encodedUrl = URLEncoder.encode(jmxServiceUrl, StandardCharsets.UTF_8);
+        String encodedUrl =
+                URLEncodedUtils.formatSegments(
+                        Collections.singletonList(jmxServiceUrl), StandardCharsets.UTF_8);
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
                 .delete("/api/v2/targets/" + encodedUrl)
@@ -377,7 +380,6 @@ public class CustomTargetsIT extends StandardSelfTest {
                         });
         JsonArray body = response.get();
         MatcherAssert.assertThat(body, Matchers.notNullValue());
-
         MatcherAssert.assertThat(body.size(), Matchers.equalTo(1));
 
         JsonObject selfJdp =

--- a/src/test/java/itest/CustomTargetsIT.java
+++ b/src/test/java/itest/CustomTargetsIT.java
@@ -116,10 +116,10 @@ public class CustomTargetsIT extends StandardSelfTest {
                                     ar.result().statusCode(), Matchers.equalTo(202));
                             response.complete(ar.result().bodyAsJsonObject());
                         });
-        String expectedConnectUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
         JsonObject body = response.get().getJsonObject("data").getJsonObject("result");
         MatcherAssert.assertThat(
-                body.getString("connectUrl").strip(), Matchers.equalTo(expectedConnectUrl.strip()));
+                body.getString("connectUrl"),
+                Matchers.equalTo("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"));
         MatcherAssert.assertThat(body.getString("alias"), Matchers.equalTo("self"));
     }
 
@@ -219,11 +219,10 @@ public class CustomTargetsIT extends StandardSelfTest {
                         });
         latch.await(30, TimeUnit.SECONDS);
 
-        String expectedConnectUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
-
         JsonObject body = response.get().getJsonObject("data").getJsonObject("result");
         MatcherAssert.assertThat(
-                body.getString("connectUrl").strip(), Matchers.equalTo(expectedConnectUrl.strip()));
+                body.getString("connectUrl"),
+                Matchers.equalTo("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"));
         MatcherAssert.assertThat(body.getString("alias"), Matchers.equalTo("self"));
 
         JsonObject result1 = resultFuture1.get();
@@ -239,7 +238,9 @@ public class CustomTargetsIT extends StandardSelfTest {
         MatcherAssert.assertThat(storedCredential.id, Matchers.any(Integer.class));
         MatcherAssert.assertThat(
                 storedCredential.matchExpression,
-                Matchers.equalTo("target.connectUrl == \"" + expectedConnectUrl.strip() + "\""));
+                Matchers.equalTo(
+                        "target.connectUrl =="
+                                + " \"service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi\""));
         MatcherAssert.assertThat(
                 storedCredential.numMatchingTargets, Matchers.equalTo(Integer.valueOf(1)));
 
@@ -247,8 +248,8 @@ public class CustomTargetsIT extends StandardSelfTest {
         JsonObject event = result2.getJsonObject("message").getJsonObject("event");
         MatcherAssert.assertThat(event.getString("kind"), Matchers.equalTo("FOUND"));
         MatcherAssert.assertThat(
-                event.getJsonObject("serviceRef").getString("connectUrl").strip(),
-                Matchers.equalTo(expectedConnectUrl.strip()));
+                event.getJsonObject("serviceRef").getString("connectUrl"),
+                Matchers.equalTo("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"));
         MatcherAssert.assertThat(
                 event.getJsonObject("serviceRef").getString("alias"), Matchers.equalTo("self"));
     }
@@ -335,9 +336,9 @@ public class CustomTargetsIT extends StandardSelfTest {
                                                     Matchers.equalTo("LOST"));
                                             MatcherAssert.assertThat(
                                                     event.getJsonObject("serviceRef")
-                                                            .getString("connectUrl").strip(),
+                                                            .getString("connectUrl"),
                                                     Matchers.equalTo(
-                                                            "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi".strip()));
+                                                            "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"));
                                             MatcherAssert.assertThat(
                                                     event.getJsonObject("serviceRef")
                                                             .getString("alias"),
@@ -350,10 +351,11 @@ public class CustomTargetsIT extends StandardSelfTest {
                     }
                 });
 
-        String jmxServiceUrl = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";
         String encodedUrl =
                 URLEncodedUtils.formatSegments(
-                        Collections.singletonList(jmxServiceUrl), StandardCharsets.UTF_8);
+                        Collections.singletonList(
+                                "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"),
+                        StandardCharsets.UTF_8);
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
         webClient
                 .delete("/api/v2/targets/" + encodedUrl.strip())


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1867

## Description of the change:
Handle bug when short form custom target i.e `localhost:0` is created. 
## Motivation for the change:
mentioned by @cmah88:  https://github.com/cryostatio/cryostat/issues/1867#issue-2101109011
## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
