### PR TITLE
build(multiarch): multistage multiarch builder to ensure native dependencies match arch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 *
+!pom.xml
+!mvnw
+!.mvn
+!m2/*
+!src
+!target
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,4 @@
 *
-!pom.xml
-!mvnw
-!.mvn
-!m2/*
-!src
-!target
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*

--- a/.dockerignore.builder
+++ b/.dockerignore.builder
@@ -1,0 +1,14 @@
+*
+!pom.xml
+!mvnw
+!.mvn
+!m2/*
+!src/main/java
+!src/main/resources
+!src/main/webui
+!src/main/docker/include/*
+!target
+!target/*-runner
+!target/*-runner.jar
+!target/lib/*
+!target/quarkus-app/*

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -122,9 +122,11 @@ jobs:
         image: ${{ env.CI_IMG }}
         archs: amd64, arm64
         tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
-        extra-args: >-
-          --ulimit nofile=4096:4096
-          --ignorefile .dockerignore.builder
+        extra-args: |
+          --ulimit
+          nofile=4096:4096
+          --ignorefile
+          .dockerignore.builder
         containerfile: ./src/main/docker/Dockerfile.builder
     - name: Push to quay.io
       id: push-to-quay

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -123,10 +123,8 @@ jobs:
         archs: amd64, arm64
         tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
         extra-args: |
-          --ulimit
-          nofile=4096:4096
-          --ignorefile
-          .dockerignore.builder
+          --ulimit=nofile=4096:4096
+          --ignorefile=.dockerignore.builder
         containerfile: ./src/main/docker/Dockerfile.builder
     - name: Push to quay.io
       id: push-to-quay

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -122,7 +122,9 @@ jobs:
         image: ${{ env.CI_IMG }}
         archs: amd64, arm64
         tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
-        extra-args: --ulimit nofile=4096:4096
+        extra-args: >-
+          --ulimit nofile=4096:4096
+          --ignorefile .dockerignore.builder
         containerfile: ./src/main/docker/Dockerfile.builder
     - name: Push to quay.io
       id: push-to-quay

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -56,6 +56,8 @@ jobs:
     if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
     - name: Install qemu
+      if: ${{ inputs.build-arch != 'amd64' }}
+      continue-on-error: true
       run: |
         sudo apt-get update
         sudo apt-get install -y qemu-user-static
@@ -110,6 +112,8 @@ jobs:
     - name: Delete local integration test image
       run: podman rmi ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
       continue-on-error: true
+    - name: Clear dockerignore
+      run: echo '' > .dockerignore
     - name: Build container images and manifest
       if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}
       id: buildah-build
@@ -118,8 +122,8 @@ jobs:
         image: ${{ env.CI_IMG }}
         archs: amd64, arm64
         tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
-        containerfiles: |
-          ./src/main/docker/Dockerfile.jvm
+        extra-args: --ulimit nofile=4096:4096
+        containerfile: ./src/main/docker/Dockerfile.builder
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -112,8 +112,6 @@ jobs:
     - name: Delete local integration test image
       run: podman rmi ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
       continue-on-error: true
-    - name: Clear dockerignore
-      run: echo '' > .dockerignore
     - name: Build container images and manifest
       if: ${{ matrix.java == '17' && github.repository_owner == 'cryostatio' }}
       id: buildah-build

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -56,8 +56,6 @@ jobs:
     if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
     - name: Install qemu
-      if: ${{ inputs.build-arch != 'amd64' }}
-      continue-on-error: true
       run: |
         sudo apt-get update
         sudo apt-get install -y qemu-user-static

--- a/src/main/docker/Dockerfile.builder
+++ b/src/main/docker/Dockerfile.builder
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.19-1 AS builder
+ARG TARGETARCH
+USER root
+WORKDIR /tmp/build
+COPY .mvn/ .mvn
+COPY pom.xml mvnw .
+COPY src/main/java src/main/java
+COPY src/main/resources src/main/resources
+COPY src/main/webui src/main/webui
+COPY src/main/docker/include src/main/docker/include
+RUN ./mvnw -Dmaven.repo.local=/tmp/build/m2/repository -B -U -Dmaven.test.skip=true -Dlicense.skip=true -Dspotless.check.skip=true -Dquarkus.container-image.build=false -Dbuild.arch=$TARGETARCH package
+
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.19-1
+ENV LANGUAGE='en_US:en'
+EXPOSE 8181
+USER 185
+LABEL io.cryostat.component=cryostat3
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+COPY --from=builder --chown=185 /tmp/build/src/main/docker/include/cryostat.jfc /usr/lib/jvm/jre/lib/jfr/
+COPY --from=builder --chown=185 /tmp/build/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=builder --chown=185 /tmp/build/target/quarkus-app/*.jar /deployments/
+COPY --from=builder --chown=185 /tmp/build/target/quarkus-app/app/ /deployments/app/
+COPY --from=builder --chown=185 /tmp/build/target/quarkus-app/quarkus/ /deployments/quarkus/


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #372

## Description of the change:
Adds `Dockerfile.multiarch`, a multi-stage build that starts with an arch-specific builder and ends with an image that copies all the built assets into the runtime base image. The arch-specific builder picks up the `$TARGETARCH` environment variable and passes that to Maven as `-Dbuild.arch` - see https://github.com/cryostatio/cryostat3/pull/371 .

## Motivation for the change:
A manual build for the host machine's native arch would look like:

```
$ podman build --ignorefile .dockerignore.builder --ulimit nofile=4096:4096 . -f src/main/docker/Dockerfile.builder -t quay.io/cryostatcryostat:4.0.0-dev
```

The `--ulimit nofile=4096:4096` works around a "Too many open files" error that would come up during the Maven build otherwise.

Building explicitly for x86_64 would look like:

```
$ podman build --ignorefile .dockerignore.builder --arch amd64 --ulimit nofile=4096:4096 . -f src/main/docker/Dockerfile.builder -t quay.io/andrewazores/cryostat:4.0.0-builder ; podman image prune -f
```

and likewise, building for aarch64:

```
$ podman build --ignorefile .dockerignore.builder --arch arm64 --ulimit nofile=4096:4096 . -f src/main/docker/Dockerfile.builder -t quay.io/andrewazores/cryostat:4.0.0-builder ; podman image prune -f
```

If I wrote it properly, then the CI changes included should allow this to be plugged into the existing `buildah-build` workflow action to produce arch-specific containers and bundle those into a multiarch image/manifest to publish to quay.io. This avoids the complexity of running the entire GitHub workflow with an architecture matrix and duplicating a lot of work and manually assembling the multiarch image and manifest at the end, as is done in the old 2.x repo.

`TODO`: look into optimizing the build speed:

- the CI runner will have already built the container for its own native arch to run tests and check for schema changes, so the Maven local repository at least should already be populated, ~~along with the web-client's `node_modules`~~ (`node_modules` is copied in now, but `~/.m2` is not). These caches could be copied into the multistage builder so that it doesn't need to redownload everything again. This is all built from scratch from sources anyway so sharing the cache from the outer runner action into the image build should be fine - no different than using those cached artifacts for the current container build process.
- can some of the outer runner action's build outputs also be copied into the container? Things like Java bytecode and the web-client built assets bundle, which are arch-independent. This should also speed up the container's build, if the toolchain is able to detect that these assets are already built - especially when using `qemu` to cross-compile. However there are some compiled native binaries inside of `node_modules` and things that would need to be rebuilt anyway.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*