### PR TITLE
ci(tags): do not tag images as 'latest'

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -53,7 +53,7 @@ jobs:
         IMAGE_VERSION: ${{ needs.build-and-test-amd64.outputs.image-version }}
       run: |
           podman load -i cryostat-amd64.tar
-          podman tag quay.io/cryostat/cryostat:latest $CRYOSTAT_IMG:$IMAGE_VERSION-linux-amd64
+          podman tag $CRYOSTAT_IMG:$IMAGE_VERSION-linux-amd64
     - uses: actions/download-artifact@v3
       with:
         name: cryostat-arm64
@@ -62,21 +62,14 @@ jobs:
         IMAGE_VERSION: ${{ needs.build-and-test-arm64.outputs.image-version }}
       run: |
           podman load -i cryostat-arm64.tar
-          podman tag quay.io/cryostat/cryostat:latest $CRYOSTAT_IMG:$IMAGE_VERSION-linux-arm64
+          podman tag $CRYOSTAT_IMG:$IMAGE_VERSION-linux-arm64
     - name: Create OCI Manifest
       id: create-manifest
       env:
         IMAGE_VERSION: ${{ needs.build-and-test-amd64.outputs.image-version }}
       run: |
         podman manifest create $CRYOSTAT_IMG:$IMAGE_VERSION containers-storage:$CRYOSTAT_IMG:$IMAGE_VERSION-linux-amd64 containers-storage:$CRYOSTAT_IMG:$IMAGE_VERSION-linux-arm64
-        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
-          podman tag \
-          ${{ env.CRYOSTAT_IMG }}:$IMAGE_VERSION \
-          ${{ env.CRYOSTAT_IMG }}:latest
-          echo "tags=$IMAGE_VERSION latest" >> "$GITHUB_OUTPUT"
-        else
-          echo "tags=$IMAGE_VERSION" >> "$GITHUB_OUTPUT"
-        fi
+        echo "tags=$IMAGE_VERSION" >> "$GITHUB_OUTPUT"
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat3/issues/469

Any CI-built images from this repository should no longer be tagged as `latest`.
