### PR TITLE
fix(rules): rule archiving and re-activation bugfixes

### DIFF
--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -40,6 +40,7 @@ import io.cryostat.targets.TargetConnectionManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -73,6 +74,7 @@ public class RuleService {
     private final List<JobKey> jobs = new CopyOnWriteArrayList<>();
 
     @Transactional
+    @Blocking
     void onStart(@Observes StartupEvent ev) {
         logger.trace("RuleService started");
         Rule.<Rule>streamAll().filter(r -> r.enabled).forEach(this::applyRuleToMatchingTargets);

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -83,8 +83,7 @@ public class RuleService {
         Rule.<Rule>streamAll().filter(r -> r.enabled).forEach(this::applyRuleToMatchingTargets);
     }
 
-    @Transactional
-    @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY, blocking = true)
+    @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY)
     void onMessage(TargetDiscovery event) {
         switch (event.kind()) {
             case LOST:

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.core.templates.Template;
@@ -76,14 +75,7 @@ public class RuleService {
     @Transactional
     void onStart(@Observes StartupEvent ev) {
         logger.trace("RuleService started");
-        try (Stream<Rule> rules = Rule.streamAll()) {
-            rules.forEach(
-                    rule -> {
-                        if (rule.enabled) {
-                            applyRuleToMatchingTargets(rule);
-                        }
-                    });
-        }
+        Rule.<Rule>streamAll().filter(r -> r.enabled).forEach(this::applyRuleToMatchingTargets);
     }
 
     @ConsumeEvent(value = Rule.RULE_ADDRESS, blocking = true)

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
 import io.cryostat.expressions.MatchExpressionEvaluator;
@@ -46,10 +46,9 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
-import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-import org.projectnessie.cel.tools.ScriptException;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -69,9 +68,10 @@ public class RuleService {
     @Inject EntityManager entityManager;
     @Inject org.quartz.Scheduler quartz;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     private final List<JobKey> jobs = new CopyOnWriteArrayList<>();
-    private final Map<Long, CopyOnWriteArrayList<ActiveRecording>> ruleRecordingMap =
-            new ConcurrentHashMap<>();
 
     @Transactional
     void onStart(@Observes StartupEvent ev) {
@@ -90,8 +90,6 @@ public class RuleService {
     @Transactional
     public void handleRuleModification(RuleEvent event) {
         Rule rule = event.rule();
-        var relatedRecordings =
-                ruleRecordingMap.computeIfAbsent(rule.id, k -> new CopyOnWriteArrayList<>());
         switch (event.category()) {
             case CREATED:
                 if (rule.enabled) {
@@ -103,13 +101,10 @@ public class RuleService {
                     applyRuleToMatchingTargets(rule);
                 } else {
                     cancelTasksForRule(rule);
-                    relatedRecordings.clear();
                 }
                 break;
             case DELETED:
                 cancelTasksForRule(rule);
-                relatedRecordings.clear();
-                ruleRecordingMap.remove(rule.id);
                 break;
             default:
                 break;
@@ -119,21 +114,44 @@ public class RuleService {
     @ConsumeEvent(value = Rule.RULE_ADDRESS + "?clean", blocking = true)
     @Transactional
     public void handleRuleRecordingCleanup(Rule rule) {
-        var relatedRecordings = ruleRecordingMap.get(rule.id);
-        if (relatedRecordings == null) {
-            throw new IllegalStateException("No tasks associated with rule " + rule.id);
+        cancelTasksForRule(rule);
+        var targets =
+                evaluator.getMatchedTargets(rule.matchExpression).stream()
+                        .collect(Collectors.toList());
+        for (var target : targets) {
+            recordingHelper
+                    .getActiveRecording(
+                            target, r -> Objects.equals(r.name, rule.getRecordingName()))
+                    .ifPresent(
+                            recording -> {
+                                try {
+                                    recordingHelper
+                                            .stopRecording(recording)
+                                            .await()
+                                            .atMost(connectionFailedTimeout);
+                                } catch (Exception e) {
+                                    logger.warn(e);
+                                }
+                            });
         }
-        relatedRecordings.forEach(
-                rec -> {
-                    ActiveRecording attachedRecoding = entityManager.merge(rec);
-                    attachedRecoding.state = RecordingState.STOPPED;
-                    attachedRecoding.persist();
-                    // the RULE_ADDRESS will handle the task cancellations + removal
-                });
     }
 
     void activate(Rule rule, Target target) throws Exception {
-        var options = createRecordingOptions(rule);
+        Target attachedTarget = Target.<Target>find("id", target.id).singleResult();
+        recordingHelper
+                .getActiveRecording(
+                        attachedTarget, r -> Objects.equals(r.name, rule.getRecordingName()))
+                .ifPresent(
+                        rec -> {
+                            try {
+                                recordingHelper
+                                        .stopRecording(rec)
+                                        .await()
+                                        .atMost(connectionFailedTimeout);
+                            } catch (Exception e) {
+                                logger.warn(e);
+                            }
+                        });
 
         Pair<String, TemplateType> pair = recordingHelper.parseEventSpecifier(rule.eventSpecifier);
         Template template =
@@ -142,17 +160,13 @@ public class RuleService {
         ActiveRecording recording =
                 recordingHelper
                         .startRecording(
-                                target,
+                                attachedTarget,
                                 RecordingReplace.STOPPED,
                                 template,
-                                options,
+                                createRecordingOptions(rule),
                                 Map.of("rule", rule.name))
                         .await()
                         .atMost(Duration.ofSeconds(10));
-        Target attachedTarget = entityManager.merge(target);
-
-        var relatedRecordings = ruleRecordingMap.get(rule.id);
-        relatedRecordings.add(recording);
 
         if (rule.isArchiver()) {
             scheduleArchival(rule, attachedTarget, recording);
@@ -170,24 +184,13 @@ public class RuleService {
     }
 
     void applyRuleToMatchingTargets(Rule rule) {
-        try (Stream<Target> targets = Target.streamAll()) {
-            targets.filter(
-                            target -> {
-                                try {
-                                    return evaluator.applies(rule.matchExpression, target);
-                                } catch (ScriptException e) {
-                                    logger.warn(e);
-                                    return false;
-                                }
-                            })
-                    .forEach(
-                            target -> {
-                                try {
-                                    activate(rule, target);
-                                } catch (Exception e) {
-                                    logger.error(e);
-                                }
-                            });
+        var targets = evaluator.getMatchedTargets(rule.matchExpression);
+        for (var target : targets) {
+            try {
+                activate(rule, target);
+            } catch (Exception e) {
+                logger.error(e);
+            }
         }
     }
 
@@ -210,7 +213,7 @@ public class RuleService {
         Map<String, Object> data = jobDetail.getJobDataMap();
         data.put("rule", rule.id);
         data.put("target", target.id);
-        data.put("recording", recording.id);
+        data.put("recording", recording.remoteId);
 
         Trigger trigger =
                 TriggerBuilder.newTrigger()
@@ -241,22 +244,18 @@ public class RuleService {
                     evaluator.getMatchedTargets(rule.matchExpression).stream()
                             .map(t -> t.jvmId)
                             .collect(Collectors.toList());
-            jobs.forEach(
-                    jk -> {
-                        if (targets.contains(jk.getGroup())) {
-                            try {
-                                quartz.deleteJob(jk);
-                            } catch (SchedulerException e) {
-                                logger.error(
-                                        "Failed to delete job "
-                                                + jk.getName()
-                                                + " for rule "
-                                                + rule.name);
-                            } finally {
-                                jobs.remove(jk);
-                            }
-                        }
-                    });
+            for (var jk : jobs) {
+                if (targets.contains(jk.getGroup())) {
+                    try {
+                        quartz.deleteJob(jk);
+                    } catch (SchedulerException e) {
+                        logger.error(
+                                "Failed to delete job " + jk.getName() + " for rule " + rule.name);
+                    } finally {
+                        jobs.remove(jk);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
+++ b/src/main/java/io/cryostat/rules/ScheduledArchiveJob.java
@@ -54,7 +54,15 @@ class ScheduledArchiveJob implements Job {
         long targetId = (long) ctx.getJobDetail().getJobDataMap().get("target");
         Target target = Target.find("id", targetId).singleResult();
         long recordingId = (long) ctx.getJobDetail().getJobDataMap().get("recording");
-        ActiveRecording recording = ActiveRecording.find("id", recordingId).singleResult();
+        ActiveRecording recording =
+                recordingHelper.getActiveRecording(target, recordingId).orElseThrow();
+
+        if (recording == null) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Target %s did not have recording with remote ID %d",
+                            target.connectUrl, recordingId));
+        }
 
         Queue<String> previousRecordings = new ArrayDeque<>(rule.preservedArchives);
 


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #517

## Description of the change:
Fixes up some issues that arose due to previous refactorings, where collections were improperly modified during traversal, or methods went from blocking operations to returning `Uni`s which went ignored, or active recordings were improperly left running, or duplicate target definitions were not de-duplicated by JVM ID and thus were acted on multiple times.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Ot`
3. Create an automated rule using the JSON below
4. Verify that targets have the active recording created and started
5. Verify that rule archives copies, then prunes extras later
6. Disable rule with `clean` option checked and ensure recordings are stopped
7. Re-enable rule and ensure recordings are restarted

```json
{
  "id": 1,
  "name": "test",
  "description": "",
  "matchExpression": "target.connectUrl.startsWith('service') && target.jvmId != null",
  "eventSpecifier": "template=Continuous,type=TARGET",
  "archivalPeriodSeconds": 20,
  "initialDelaySeconds": 0,
  "preservedArchives": 2,
  "maxAgeSeconds": 0,
  "maxSizeBytes": 26214400,
  "enabled": true
}
```