### PR TITLE
ci(rename): correct CI paths for repo rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: enabled
 contact_links:
   - name: Cryostat Community Support
-    url: https://github.com/cryostatio/cryostat3/discussions
+    url: https://github.com/cryostatio/cryostat/discussions
     about: Ask general questions about Cryostat here!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-# Welcome to Cryostat3! 👋
+# Welcome to Cryostat! 👋
 ## Before contributing, make sure you have:
-* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
+* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
 * [ ] Linked a relevant issue which this PR resolves
 * [ ] Linked any other relevant issues, PR's, or documentation, if any
 * [ ] Resolved all conflicts, if any

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -227,12 +227,12 @@ jobs:
         wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O "${HOME}/bin/yq"
         chmod +x "${HOME}/bin/yq"
         export PATH="${HOME}/bin:${PATH}"
-        bash /home/runner/work/cryostat3/cryostat3/schema/update.bash 90 15
+        bash /home/runner/work/cryostat/cryostat/schema/update.bash 90 15
         set +e
-        git diff -U10 --exit-code /home/runner/work/cryostat3/cryostat3/schema/openapi.yaml > /home/runner/work/openapi.diff
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff
         echo "openapi_status=$?" >> "$GITHUB_OUTPUT"
         echo "openapi_diff_file=openapi.diff" >> "$GITHUB_OUTPUT"
-        git diff -U10 --exit-code /home/runner/work/cryostat3/cryostat3/schema/schema.graphql > /home/runner/work/graphql.diff
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff
         echo "graphql_status=$?" >> "$GITHUB_OUTPUT"
         echo "graphql_diff_file=graphql.diff" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
