### PR TITLE
fix(recordings): uploaded archives should be viewable with Grafana

### DIFF
--- a/src/main/java/io/cryostat/recordings/Recordings.java
+++ b/src/main/java/io/cryostat/recordings/Recordings.java
@@ -805,7 +805,12 @@ public class Recordings {
     @RolesAllowed("write")
     public Response uploadArchivedToGrafanaBeta(
             @RestPath String connectUrl, @RestPath String filename) throws Exception {
-        var jvmId = Target.getTargetByConnectUrl(URI.create(connectUrl)).jvmId;
+        String jvmId;
+        if ("uploads".equals(connectUrl)) {
+            jvmId = "uploads";
+        } else {
+            jvmId = Target.getTargetByConnectUrl(URI.create(connectUrl)).jvmId;
+        }
         return Response.status(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(
                         URI.create(


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #540 

## Description of the change:

Consider connectUrl `uploads` as special case to use  `uploads` as the `jvmId`. 

## Motivation for the change:

Uploaded archives can now be viewed with Grafana.

## How to manually test:
1. Built the cryostat container image or use CI snapshot image.
2. Launch local smoketest with `bash smoketest.bash -O`.
3. Upload any JFR file with the UI. The action should complete successfully and the archive should show up.
4. Click on the far-right 3-dot and select `View in Grafana...`. This action should be work as expected.
