### PR TITLE
ci(oci): enable parallel builds in OCI format

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -116,11 +116,13 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.CI_IMG }}
+        oci: true
         archs: amd64, arm64
         tags: ${{ env.IMAGE_VERSION }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
         extra-args: |
           --ulimit=nofile=4096:4096
           --ignorefile=.dockerignore.builder
+          --jobs=2
         containerfiles: |
           ./src/main/docker/Dockerfile.builder
     - name: Push to quay.io


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #567

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
