### PR TITLE
feat(about): reimplement git build info in /health

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,11 +360,9 @@
             <configuration>
               <executable>git</executable>
               <arguments>
-                <argument>describe</argument>
-                <argument>--tags</argument>
-                <argument>--dirty</argument>
-                <argument>--long</argument>
-                <argument>--always</argument>
+                <argument>rev-parse</argument>
+                <argument>--verify</argument>
+                <argument>HEAD</argument>
               </arguments>
               <outputFile>${project.build.directory}/classes/META-INF/gitinfo</outputFile>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <quarkus-quinoa.version>2.2.5</quarkus-quinoa.version>
     <io.netty.version>4.1.108.Final</io.netty.version>
     <org.codehaus.mojo.build.helper.plugin.version>3.6.0</org.codehaus.mojo.build.helper.plugin.version>
+    <org.codehaus.mojo.exec.plugin.version>3.3.0</org.codehaus.mojo.exec.plugin.version>
     <assembly-plugin.version>3.7.1</assembly-plugin.version>
 
     <com.github.spotbugs.version>4.8.6</com.github.spotbugs.version>
@@ -344,6 +345,31 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${org.codehaus.mojo.exec.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>generate-git-version</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>git</executable>
+              <arguments>
+                <argument>describe</argument>
+                <argument>--tags</argument>
+                <argument>--dirty</argument>
+                <argument>--long</argument>
+                <argument>--always</argument>
+              </arguments>
+              <outputFile>${project.build.directory}/classes/META-INF/gitinfo</outputFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/io/cryostat/BuildInfo.java
+++ b/src/main/java/io/cryostat/BuildInfo.java
@@ -57,7 +57,7 @@ public class BuildInfo {
                                                         RESOURCE_LOCATION)))
                         .trim();
             } catch (Exception e) {
-                logger.error("Version retrieval exception", e);
+                logger.warn("Version retrieval exception", e);
                 return "unknown";
             }
         }

--- a/src/main/java/io/cryostat/BuildInfo.java
+++ b/src/main/java/io/cryostat/BuildInfo.java
@@ -39,34 +39,28 @@ public class BuildInfo {
     }
 
     public class GitInfo {
-        private volatile String gitDescribe;
-
         @JsonProperty("describe")
-        public synchronized String getDescription() {
-            if (gitDescribe == null) {
-                try (BufferedReader br =
-                        new BufferedReader(
-                                new InputStreamReader(
-                                        Thread.currentThread()
-                                                .getContextClassLoader()
-                                                .getResourceAsStream(RESOURCE_LOCATION),
-                                        StandardCharsets.UTF_8))) {
-                    gitDescribe =
-                            br.lines()
-                                    .findFirst()
-                                    .orElseThrow(
-                                            () ->
-                                                    new IllegalStateException(
-                                                            String.format(
-                                                                    "Resource file %s is empty",
-                                                                    RESOURCE_LOCATION)))
-                                    .trim();
-                } catch (Exception e) {
-                    logger.error("Version retrieval exception", e);
-                    gitDescribe = "unknown";
-                }
+        public String getDescription() {
+            try (BufferedReader br =
+                    new BufferedReader(
+                            new InputStreamReader(
+                                    Thread.currentThread()
+                                            .getContextClassLoader()
+                                            .getResourceAsStream(RESOURCE_LOCATION),
+                                    StandardCharsets.UTF_8))) {
+                return br.lines()
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                String.format(
+                                                        "Resource file %s is empty",
+                                                        RESOURCE_LOCATION)))
+                        .trim();
+            } catch (Exception e) {
+                logger.error("Version retrieval exception", e);
+                return "unknown";
             }
-            return gitDescribe;
         }
     }
 }

--- a/src/main/java/io/cryostat/BuildInfo.java
+++ b/src/main/java/io/cryostat/BuildInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class BuildInfo {
+
+    private static final String RESOURCE_LOCATION = "META-INF/gitinfo";
+
+    @Inject Logger logger;
+
+    private volatile String version;
+
+    public synchronized String getGitInfo() {
+        if (version == null) {
+            try (BufferedReader br =
+                    new BufferedReader(
+                            new InputStreamReader(
+                                    Thread.currentThread()
+                                            .getContextClassLoader()
+                                            .getResourceAsStream(RESOURCE_LOCATION),
+                                    StandardCharsets.UTF_8))) {
+                version =
+                        br.lines()
+                                .findFirst()
+                                .orElseThrow(
+                                        () ->
+                                                new IllegalStateException(
+                                                        String.format(
+                                                                "Resource file %s is empty",
+                                                                RESOURCE_LOCATION)))
+                                .trim();
+            } catch (Exception e) {
+                logger.error("Version retrieval exception", e);
+                version = "unknown";
+            }
+        }
+        return version;
+    }
+}

--- a/src/main/java/io/cryostat/BuildInfo.java
+++ b/src/main/java/io/cryostat/BuildInfo.java
@@ -39,8 +39,7 @@ public class BuildInfo {
     }
 
     public class GitInfo {
-        @JsonProperty("describe")
-        public String getDescription() {
+        public String getHash() {
             try (BufferedReader br =
                     new BufferedReader(
                             new InputStreamReader(

--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -64,8 +64,9 @@ class Health {
     @ConfigProperty(name = ConfigProperties.REPORTS_SIDECAR_URL)
     String reportsClientURL;
 
-    @Inject Logger logger;
+    @Inject BuildInfo buildInfo;
     @Inject WebClient webClient;
+    @Inject Logger logger;
 
     @GET
     @Blocking
@@ -98,6 +99,8 @@ class Health {
                         Map.of(
                                 "cryostatVersion",
                                 String.format("v%s", version),
+                                "buildInfo",
+                                Map.of("git", buildInfo.getGitInfo()),
                                 "dashboardConfigured",
                                 dashboardURL.isPresent(),
                                 "dashboardAvailable",

--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -99,8 +99,8 @@ class Health {
                         Map.of(
                                 "cryostatVersion",
                                 String.format("v%s", version),
-                                "buildInfo",
-                                Map.of("git", buildInfo.getGitInfo()),
+                                "build",
+                                buildInfo,
                                 "dashboardConfigured",
                                 dashboardURL.isPresent(),
                                 "dashboardAvailable",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #550

## Description of the change:
Stores the output of `git rev-parse` in `META-INF/gitinfo` similar to what the 2.x build did with `git describe`. Then, `GET /health` includes this string in its output as a nested JSON property, rather than replacing the version string.

## Motivation for the change:
Easier identification of development builds and linking to exact sources for all builds.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Ok`
3. `http :8080/health`
