### PR TITLE
build(deps): bump commons-validator:commons-validator from 1.7 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <org.apache.commons.collections.version>4.4</org.apache.commons.collections.version>
     <org.apache.httpcomponents.version>5.2.1</org.apache.httpcomponents.version>
     <org.apache.commons.lang3.version>3.14.0</org.apache.commons.lang3.version>
-    <org.apache.commons.validator.version>1.7</org.apache.commons.validator.version>
+    <org.apache.commons.validator.version>1.8.0</org.apache.commons.validator.version>
     <org.projectnessie.cel.bom.version>0.4.4</org.projectnessie.cel.bom.version>
     <com.google.protobuf-java.version>3.25.2</com.google.protobuf-java.version>
     <com.nimbusds.jose.jwt.version>9.37.3</com.nimbusds.jose.jwt.version>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/480

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
