### PR TITLE
build(deps): replace direct fabric8 kubernetes-client with quarkus kubernetes-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <surefire-plugin.version>3.3.1</surefire-plugin.version>
     <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     <failsafe-plugin.version>3.3.1</failsafe-plugin.version>
-    <io.fabric8.client.version>6.10.0</io.fabric8.client.version>
     <failsafe.rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</failsafe.rerunFailingTestsCount>
   </properties>
   <dependencyManagement>
@@ -188,6 +187,18 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-quartz</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>
@@ -201,6 +212,10 @@
     <dependency>
       <groupId>io.quarkiverse.amazonservices</groupId>
       <artifactId>quarkus-amazon-s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kubernetes-client</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -251,27 +266,10 @@
       <version>${com.nimbusds.jose.jwt.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-cache</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-quartz</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
       <version>${com.google.java-format.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>${io.fabric8.client.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -82,6 +82,8 @@ public class KubeApiDiscovery {
 
     @Inject KubeConfig kubeConfig;
 
+    @Inject KubernetesClient client;
+
     @Inject EventBus bus;
 
     @ConfigProperty(name = "cryostat.discovery.kubernetes.enabled")
@@ -111,7 +113,7 @@ public class KubeApiDiscovery {
                                     ns -> {
                                         result.put(
                                                 ns,
-                                                client().endpoints()
+                                                client.endpoints()
                                                         .inNamespace(ns)
                                                         .inform(
                                                                 new EndpointsHandler(),
@@ -188,16 +190,6 @@ public class KubeApiDiscovery {
             logger.trace(e);
         }
         return false;
-    }
-
-    KubernetesClient client() {
-        KubernetesClient client;
-        try {
-            client = kubeConfig.kubeClient();
-        } catch (ConcurrentException e) {
-            throw new IllegalStateException(e);
-        }
-        return client;
     }
 
     private boolean isCompatiblePort(EndpointPort port) {
@@ -471,7 +463,7 @@ public class KubeApiDiscovery {
         }
 
         HasMetadata kubeObj =
-                nodeType.getQueryFunction().apply(client()).apply(namespace).apply(name);
+                nodeType.getQueryFunction().apply(client).apply(namespace).apply(name);
 
         DiscoveryNode node =
                 DiscoveryNode.getNode(
@@ -549,10 +541,6 @@ public class KubeApiDiscovery {
 
         boolean kubeApiAvailable() {
             return StringUtils.isNotBlank(serviceHost.orElse(""));
-        }
-
-        KubernetesClient kubeClient() throws ConcurrentException {
-            return kubeClient.get();
         }
     }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/605

## Description of the change:

Replaces the Fabric8 Kubernetes Client dependency with an equivalent Quarkus Kubernetes Client extension dependency. This uses the Quarkus BOM version so the dependency is kept at an appropriate version compatible with the Quarkus version, including usability in native mode (not relevant at this time, but interesting).

## Motivation for the change:

Since https://github.com/cryostatio/cryostat/pull/601 , Cryostat fails to start on Kubernetes/OpenShift when Kubernetes API discovery is enabled:

```
2024-08-14 14:32:31,741 ERROR [io.qua.run.Application] (main) Failed to start application (with profile [prod]): java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:61)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:32)
Caused by: java.lang.NoClassDefFoundError: io/fabric8/kubernetes/client/dsl/V1FlowControlAPIGroupDSL
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:105)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:65)
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3373)
	at java.base/java.lang.Class.getConstructor0(Class.java:3578)
	at java.base/java.lang.Class.getConstructor(Class.java:2271)
	at io.fabric8.kubernetes.client.KubernetesClientBuilder.build(KubernetesClientBuilder.java:80)
	at io.cryostat.discovery.KubeApiDiscovery$KubeConfig$1.initialize(KubeApiDiscovery.java:524)
	at io.cryostat.discovery.KubeApiDiscovery$KubeConfig$1.initialize(KubeApiDiscovery.java:519)
	at org.apache.commons.lang3.concurrent.LazyInitializer.get(LazyInitializer.java:143)
	at io.cryostat.discovery.KubeApiDiscovery$KubeConfig.kubeClient(KubeApiDiscovery.java:555)
	at io.cryostat.discovery.KubeApiDiscovery_KubeConfig_ClientProxy.kubeClient(Unknown Source)
	at io.cryostat.discovery.KubeApiDiscovery.client(KubeApiDiscovery.java:196)
	at io.cryostat.discovery.KubeApiDiscovery$1.lambda$initialize$0(KubeApiDiscovery.java:114)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.cryostat.discovery.KubeApiDiscovery$1.initialize(KubeApiDiscovery.java:110)
	at io.cryostat.discovery.KubeApiDiscovery$1.initialize(KubeApiDiscovery.java:100)
	at org.apache.commons.lang3.concurrent.LazyInitializer.get(LazyInitializer.java:143)
	at io.cryostat.discovery.KubeApiDiscovery.safeGetInformers(KubeApiDiscovery.java:232)
	at io.cryostat.discovery.KubeApiDiscovery.onAfterStart(KubeApiDiscovery.java:161)
	at io.cryostat.discovery.KubeApiDiscovery_Subclass.onAfterStart$$superforward(Unknown Source)
	at io.cryostat.discovery.KubeApiDiscovery_Subclass$$function$$2.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:73)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:62)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:136)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:107)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.doIntercept(TransactionalInterceptorRequired.java:38)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.intercept(TransactionalInterceptorBase.java:61)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.intercept(TransactionalInterceptorRequired.java:32)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:30)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:27)
	at io.cryostat.discovery.KubeApiDiscovery_Subclass.onAfterStart(Unknown Source)
	at io.cryostat.discovery.KubeApiDiscovery_Observer_onAfterStart_b19dd85e14de7e5bee356bebf2a7b82c53ef16b5.notify(Unknown Source)
	at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:346)
	at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:328)
	at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:82)
	at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:155)
	at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:106)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
	... 13 more
Caused by: java.lang.ClassNotFoundException: io.fabric8.kubernetes.client.dsl.V1FlowControlAPIGroupDSL
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:115)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:65)
	... 57 more
```

## How to manually test:
1. Build PR, or use `quay.io/andrewazores/cryostat:quarkus-k8s-client-1`
2. With a Kubernetes or OpenShift cluster, deploy the image from this PR and ensure Cryostat comes up successfully and can discover targets, ex: `helm install cryostat --set authentication.openshift.enabled=true --set core.route.enabled=true --set core.image.repository=quay.io/andrewazores/cryostat --set core.image.tag=quarkus-k8s-client-1 --set pvc.enabled=true ./charts/cryostat/`
