### PR TITLE
chore(db): use Flyway migration to set up discovery plugins

### DIFF
--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -200,18 +200,6 @@ public abstract class ContainerDiscovery {
             return;
         }
 
-        DiscoveryNode universe = DiscoveryNode.getUniverse();
-        if (DiscoveryNode.getRealm(getRealm()).isEmpty()) {
-            DiscoveryPlugin plugin = new DiscoveryPlugin();
-            DiscoveryNode node = DiscoveryNode.environment(getRealm(), BaseNodeType.REALM);
-            plugin.realm = node;
-            plugin.builtin = true;
-            universe.children.add(node);
-            node.parent = universe;
-            plugin.persist();
-            universe.persist();
-        }
-
         logger.debugv("Starting {0} client", getRealm());
 
         queryContainers();

--- a/src/main/java/io/cryostat/discovery/CustomDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/CustomDiscovery.java
@@ -35,11 +35,9 @@ import io.cryostat.targets.Target.Annotations;
 import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.util.URIUtil;
 
-import io.quarkus.runtime.StartupEvent;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Consumes;
@@ -73,21 +71,6 @@ public class CustomDiscovery {
 
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
     Duration timeout;
-
-    @Transactional
-    void onStart(@Observes StartupEvent evt) {
-        DiscoveryNode universe = DiscoveryNode.getUniverse();
-        if (DiscoveryNode.getRealm(REALM).isEmpty()) {
-            DiscoveryPlugin plugin = new DiscoveryPlugin();
-            DiscoveryNode node = DiscoveryNode.environment(REALM, BaseNodeType.REALM);
-            plugin.realm = node;
-            plugin.builtin = true;
-            universe.children.add(node);
-            node.parent = universe;
-            plugin.persist();
-            universe.persist();
-        }
-    }
 
     @Transactional(rollbackOn = {JvmIdException.class})
     @POST

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -108,9 +108,6 @@ public class Discovery {
 
     @Transactional
     void onStart(@Observes StartupEvent evt) {
-        // ensure lazily initialized entries are created
-        DiscoveryNode.getUniverse();
-
         DiscoveryPlugin.<DiscoveryPlugin>findAll().list().stream()
                 .filter(p -> !p.builtin)
                 .forEach(

--- a/src/main/java/io/cryostat/discovery/DiscoveryNode.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryNode.java
@@ -107,9 +107,7 @@ public class DiscoveryNode extends PanacheEntity {
 
     public static DiscoveryNode getUniverse() {
         return DiscoveryNode.find(NODE_TYPE, BaseNodeType.UNIVERSE.getKind())
-                .<DiscoveryNode>singleResultOptional()
-                .orElseGet(
-                        () -> environment(BaseNodeType.UNIVERSE.toString(), BaseNodeType.UNIVERSE));
+                .<DiscoveryNode>singleResult();
     }
 
     public static Optional<DiscoveryNode> getRealm(String name) {

--- a/src/main/java/io/cryostat/discovery/JDPDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/JDPDiscovery.java
@@ -71,18 +71,6 @@ public class JDPDiscovery implements Consumer<JvmDiscoveryEvent> {
             return;
         }
 
-        DiscoveryNode universe = DiscoveryNode.getUniverse();
-        if (DiscoveryNode.getRealm(REALM).isEmpty()) {
-            DiscoveryPlugin plugin = new DiscoveryPlugin();
-            DiscoveryNode node = DiscoveryNode.environment(REALM, BaseNodeType.REALM);
-            plugin.realm = node;
-            plugin.builtin = true;
-            universe.children.add(node);
-            node.parent = universe;
-            plugin.persist();
-            universe.persist();
-        }
-
         logger.debug("Starting JDP client");
         jdp.addListener(this);
         try {

--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -140,18 +140,6 @@ public class KubeApiDiscovery {
             return;
         }
 
-        DiscoveryNode universe = DiscoveryNode.getUniverse();
-        if (DiscoveryNode.getRealm(REALM).isEmpty()) {
-            DiscoveryPlugin plugin = new DiscoveryPlugin();
-            DiscoveryNode node = DiscoveryNode.environment(REALM, BaseNodeType.REALM);
-            plugin.realm = node;
-            plugin.builtin = true;
-            universe.children.add(node);
-            node.parent = universe;
-            plugin.persist();
-            universe.persist();
-        }
-
         logger.debugv("Starting {0} client", REALM);
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,7 +9,6 @@ quarkus.http.cors.access-control-allow-credentials=true
 # quarkus.http.cors.methods=GET,PUT,POST,PATCH,OPTIONS
 # quarkus.http.cors.access-control-max-age=1s
 
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 quarkus.flyway.baseline-on-migrate=true
 quarkus.flyway.baseline-version=4.0.0
 quarkus.flyway.migrate-at-start=true
+quarkus.flyway.validate-migration-naming=true
 
 quarkus.naming.enable-jndi=true
 cryostat.discovery.jdp.enabled=false


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #590
Fixes https://github.com/cryostatio/cryostat/issues/549

## Description of the change:
Removes the Quarkus-level startup check and lazy initialization of builtin discovery plugins, replacing these with eager initialization within the database migration scripts handled by Flyway.

## Motivation for the change:
This ensures that discovery nodes and plugins creation is correctly tied to the database schema, and that the expected nodes and plugins are seeded in the database prior to application startup. This allows for cleaner application restart on an existing database instance, since the node creation/removal logic is no longer tied to the application lifecycle - no need for a startup check for node records existing, and if not to lazily initialize them.

This also opens up a nice unit testing possibility, where unit tests can `@Inject Flyway flyway` and then `@AfterEach void cleanup() { flyway.clean(); }`, which has the effect of resetting the database after each test. Without this change, this hook won't work as expected because the discovery nodes/plugins will be wiped from the database too, leaving the application in a bad state for the next tests.

## Testing
1. Check out PR
2. `quarkus dev`, then in another terminal `http :8080/api/v3/discovery` and `http :8080/api/v3/discovery_plugins`
3. Stop the devserver
4. `./mvnw clean package ; podman image prune -f`
5. `./smoketest.bash -Okt`
6. Wait a while, then in another terminal repeat the `http` commands above