### PR TITLE
chore(matchExpressions): revert #625 rename target.isAgent match expression to target.agent to fit current nomenclature

### DIFF
--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -190,6 +190,7 @@ type RuntimeMetrics {
 
 type Target {
   activeRecordings(filter: ActiveRecordingsFilterInput): ActiveRecordings
+  agent: Boolean!
   alias: String!
   annotations: Annotations!
   archivedRecordings(filter: ArchivedRecordingsFilterInput): ArchivedRecordings

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -223,7 +223,7 @@ public class MatchExpressionEvaluator {
      * expression-relevant fields exposed, connection URI exposed as a String, etc.
      */
     private static record SimplifiedTarget(
-            boolean isAgent,
+            boolean agent,
             String connectUrl,
             String alias,
             @Nullable String jvmId,

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -223,7 +223,7 @@ public class MatchExpressionEvaluator {
      * expression-relevant fields exposed, connection URI exposed as a String, etc.
      */
     private static record SimplifiedTarget(
-            boolean agent,
+            boolean isAgent,
             String connectUrl,
             String alias,
             @Nullable String jvmId,
@@ -242,7 +242,7 @@ public class MatchExpressionEvaluator {
 
         static SimplifiedTarget from(Target target) {
             return new SimplifiedTarget(
-                    target.agent(),
+                    target.isAgent(),
                     target.connectUrl.toString(),
                     target.alias,
                     target.jvmId,

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -113,7 +113,7 @@ public class Target extends PanacheEntity {
     public DiscoveryNode discoveryNode;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public boolean agent() {
+    public boolean isAgent() {
         return AgentConnection.isAgentConnection(connectUrl);
     }
 


### PR DESCRIPTION

This reverts commit 0313522d15c9e43488385d914fb01b7dba711793, but keeps target.agent match expression field.

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat-web/issues/1325
