### PR TITLE
feat(diagnostic): implement diagnostics class with gc invocation operation

### DIFF
--- a/compose/sample_apps/gameserver-jdk11.yml
+++ b/compose/sample_apps/gameserver-jdk11.yml
@@ -34,4 +34,6 @@ services:
       ENABLE_JMX: "true"
       JMX_HOST: gameserver-jdk11
       JMX_PORT: "7091"
-      JVM_OPTS: -javaagent:/opt/cryostat/agent.jar
+      JVM_OPTS: >-
+        -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
+        -javaagent:/opt/cryostat/agent.jar

--- a/compose/sample_apps/gameserver-jdk17.yml
+++ b/compose/sample_apps/gameserver-jdk17.yml
@@ -34,6 +34,8 @@ services:
       ENABLE_JMX: "true"
       JMX_HOST: gameserver-jdk17
       JMX_PORT: "7092"
-      JVM_OPTS: -javaagent:/opt/cryostat/agent.jar
+      JVM_OPTS: >-
+        -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
+        -javaagent:/opt/cryostat/agent.jar
     volumes:
       - ${DIR}/compose/auth_certs:/auth_certs:z

--- a/compose/sample_apps/gameserver-jdk21.yml
+++ b/compose/sample_apps/gameserver-jdk21.yml
@@ -34,6 +34,8 @@ services:
       ENABLE_JMX: "true"
       JMX_HOST: gameserver-jdk21
       JMX_PORT: "7093"
-      JVM_OPTS: -javaagent:/opt/cryostat/agent.jar
+      JVM_OPTS: >-
+        -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
+        -javaagent:/opt/cryostat/agent.jar
     volumes:
       - ${DIR}/compose/auth_certs:/auth_certs:z

--- a/compose/sample_apps/opensearch.yml
+++ b/compose/sample_apps/opensearch.yml
@@ -7,7 +7,8 @@ services:
       discovery.type: single-node
       # Reference: https://opensearch.org/docs/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: password4Opense@rch
-      OPENSEARCH_JAVA_OPTS: >
+      OPENSEARCH_JAVA_OPTS: >-
+        -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
         -Dcom.sun.management.jmxremote.autodiscovery=true
         -Dcom.sun.management.jmxremote
         -Dcom.sun.management.jmxremote.port=9292

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -12,6 +12,7 @@ services:
       JAVA_OPTS_APPEND: >-
         -Dquarkus.http.host=0.0.0.0
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+        -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
         -javaagent:/deployments/app/cryostat-agent.jar
         -Dcom.sun.management.jmxremote.autodiscovery=false
         -Dcom.sun.management.jmxremote

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -656,6 +656,26 @@ info:
   version: 4.0.0-snapshot
 openapi: 3.0.3
 paths:
+  /api/beta/diagnostics/targets/{targetId}/gc:
+    post:
+      parameters:
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "201":
+          description: Created
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Diagnostics
   /api/beta/fs/recordings:
     get:
       responses:

--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.diagnostic;
+
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("/api/beta/diagnostics/targets/{targetId}")
+public class Diagnostics {
+
+    @Inject TargetConnectionManager targetConnectionManager;
+
+    @Path("/gc")
+    @RolesAllowed("write")
+    @Blocking
+    @POST
+    public void gc(@RestPath long targetId) {
+        targetConnectionManager.executeConnectedTask(
+                Target.getTargetById(targetId),
+                conn -> conn.invokeMBeanOperation("java.lang:type=Memory", "gc", null, null, Void.class));
+    }
+}

--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -37,6 +37,8 @@ public class Diagnostics {
     public void gc(@RestPath long targetId) {
         targetConnectionManager.executeConnectedTask(
                 Target.getTargetById(targetId),
-                conn -> conn.invokeMBeanOperation("java.lang:type=Memory", "gc", null, null, Void.class));
+                conn ->
+                        conn.invokeMBeanOperation(
+                                "java.lang:type=Memory", "gc", null, null, Void.class));
     }
 }

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -107,6 +107,18 @@ class AgentConnection implements JFRConnection {
     }
 
     @Override
+    public <T> T invokeMBeanOperation(
+            String beanName,
+            String operation,
+            Object[] parameters,
+            String[] signature,
+            Class<T> returnType) {
+        return client.invokeMBeanOperation(beanName, operation, parameters, signature, returnType)
+                .await()
+                .atMost(client.getTimeout());
+    }
+
+    @Override
     public int getPort() {
         return getUri().getPort();
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/133
Depends on https://github.com/cryostatio/cryostat-core/pull/459
~~**NOTE** Since this depends on an addition to `-core`, which publishes snapshot builds but for which the CI to do so is currently broken, *this cannot be merged* until that CI failure is resolved. Otherwise, Cryostat (and the associated upcoming Agent PR) will fail to build and all CI will be failing.~~

## Description of the change:
Implements the Agent HTTP delegation side of the MBean operation invocation request, and adds a beta API endpoint which invokes the GC operation on the Agent HTTP or JMX connection to the specified Target JVM.

## Motivation for the change:
Combined with the `-core` change and upcoming `-agent` and `-web` changes, this will allow the user to click a button in the Cryostat UI to send a request to their Target JVM requesting that it perform a garbage collection.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
