### PR TITLE
test(smoketest): enable storage encryption

### DIFF
--- a/compose/s3-seaweed.yml
+++ b/compose/s3-seaweed.yml
@@ -26,6 +26,7 @@ services:
       DATA_DIR: /data
       IP_BIND: 0.0.0.0
       WEED_V: "4" # glog logging level
+      REST_ENCRYPTION_ENABLE: "1"
     volumes:
       - seaweed_data:/data
     ports:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-storage/pull/29
https://github.com/cryostatio/cryostat-operator/pull/963

## Description of the change:
Enables optional at-rest encryption on the storage container.

## Motivation for the change:
This adds a small additional layer of security to the object storage. Enabling it in the smoketest helps to ensure it is working transparently.

## How to manually test:
1. Check out PR
2. `./smoketest.bash`
3. `podman logs -r -f compose_s3_1` (or whatever the container gets named on your setup) and ensure that the `-filter.encryptVolumeData` flag is passed to `exec weed`
4. Start a recording on Cryostat or the report generator, archive it, and ensure that the archived file can be downloaded, viewed in Grafana, or have a report generated on it as normal.