### PR TITLE
feat(async): long-running async job API

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1,18 +1,6 @@
 ---
 components:
   schemas:
-    AnalysisResult:
-      properties:
-        evaluation:
-          $ref: '#/components/schemas/Evaluation'
-        name:
-          type: string
-        score:
-          format: double
-          type: number
-        topic:
-          type: string
-      type: object
     Annotations:
       properties:
         cryostat:
@@ -239,19 +227,6 @@ components:
         - id
         - realm
       type: object
-    Evaluation:
-      properties:
-        explanation:
-          type: string
-        solution:
-          type: string
-        suggestions:
-          items:
-            $ref: '#/components/schemas/Suggestion'
-          type: array
-        summary:
-          type: string
-      type: object
     Event:
       properties:
         clazz:
@@ -307,6 +282,16 @@ components:
     GitInfo:
       properties:
         hash:
+          type: string
+      type: object
+    HttpServerResponse:
+      properties:
+        chunked:
+          type: boolean
+        statusCode:
+          format: int32
+          type: integer
+        statusMessage:
           type: string
       type: object
     Instant:
@@ -552,15 +537,6 @@ components:
         description:
           type: string
         name:
-          type: string
-      type: object
-    Suggestion:
-      properties:
-        name:
-          type: string
-        setting:
-          type: string
-        value:
           type: string
       type: object
     Target:
@@ -1225,8 +1201,13 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
       responses:
-        "202":
+        "200":
           content:
             text/plain:
               schema:
@@ -1456,20 +1437,13 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
       responses:
-        "202":
-          content:
-            text/plain:
-              schema:
-                type: string
-          description: OK
         "200":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  $ref: '#/components/schemas/AnalysisResult'
-                type: object
           description: OK
         "401":
           description: Not Authorized
@@ -2133,11 +2107,11 @@ paths:
             type: integer
       requestBody:
         content:
-          text/plain:
+          application/json:
             schema:
-              type: string
+              $ref: '#/components/schemas/HttpServerResponse'
       responses:
-        "202":
+        "200":
           content:
             text/plain:
               schema:
@@ -2147,10 +2121,6 @@ paths:
           description: Not Authorized
         "403":
           description: Not Allowed
-        "404":
-          description: Not Found
-        "502":
-          description: Target not Reachable
       security:
         - SecurityScheme: []
       tags:
@@ -2170,8 +2140,13 @@ paths:
           schema:
             format: int64
             type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
       responses:
-        "202":
+        "200":
           content:
             text/plain:
               schema:
@@ -2200,20 +2175,13 @@ paths:
           schema:
             format: int64
             type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
       responses:
         "200":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  $ref: '#/components/schemas/AnalysisResult'
-                type: object
-          description: OK
-        "202":
-          content:
-            text/plain:
-              schema:
-                type: string
           description: OK
         "401":
           description: Not Authorized

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2131,7 +2131,7 @@ paths:
             schema:
               type: string
       responses:
-        "200":
+        "202":
           content:
             text/plain:
               schema:
@@ -2141,6 +2141,10 @@ paths:
           description: Not Authorized
         "403":
           description: Not Allowed
+        "404":
+          description: Not Found
+        "502":
+          description: Target not Reachable
       security:
         - SecurityScheme: []
       tags:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1226,7 +1226,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        "202":
           content:
             text/plain:
               schema:
@@ -1457,6 +1457,29 @@ paths:
           schema:
             type: string
       responses:
+        "202":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: OK
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+        - SecurityScheme: []
+      tags:
+        - Reports
+  /api/v4/jobs/{jobId}:
+    get:
+      parameters:
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+      responses:
         "200":
           content:
             application/json:
@@ -1472,7 +1495,7 @@ paths:
       security:
         - SecurityScheme: []
       tags:
-        - Reports
+        - Jobs
   /api/v4/rules:
     get:
       responses:
@@ -2165,7 +2188,7 @@ paths:
             format: int64
             type: integer
       responses:
-        "200":
+        "202":
           content:
             text/plain:
               schema:
@@ -2195,13 +2218,11 @@ paths:
             format: int64
             type: integer
       responses:
-        "200":
+        "202":
           content:
-            application/json:
+            text/plain:
               schema:
-                additionalProperties:
-                  $ref: '#/components/schemas/AnalysisResult'
-                type: object
+                type: string
           description: OK
         "401":
           description: Not Authorized

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1463,23 +1463,6 @@ paths:
               schema:
                 type: string
           description: OK
-        "401":
-          description: Not Authorized
-        "403":
-          description: Not Allowed
-      security:
-        - SecurityScheme: []
-      tags:
-        - Reports
-  /api/v4/jobs/{jobId}:
-    get:
-      parameters:
-        - in: path
-          name: jobId
-          required: true
-          schema:
-            type: string
-      responses:
         "200":
           content:
             application/json:
@@ -1495,7 +1478,7 @@ paths:
       security:
         - SecurityScheme: []
       tags:
-        - Jobs
+        - Reports
   /api/v4/rules:
     get:
       responses:
@@ -2218,6 +2201,14 @@ paths:
             format: int64
             type: integer
       responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  $ref: '#/components/schemas/AnalysisResult'
+                type: object
+          description: OK
         "202":
           content:
             text/plain:

--- a/src/main/java/io/cryostat/Producers.java
+++ b/src/main/java/io/cryostat/Producers.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ForkJoinPool;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.sys.FileSystem;
+import io.cryostat.recordings.ArchiveRequestGenerator;
 
 import io.quarkus.arc.DefaultBean;
 import io.vertx.mutiny.core.Vertx;
@@ -73,6 +74,15 @@ public class Producers {
     public static InterruptibleReportGenerator produceInterruptibleReportGenerator() {
         boolean singleThread = Runtime.getRuntime().availableProcessors() < 2;
         return new InterruptibleReportGenerator(
+                singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
+    }
+
+    @Produces
+    @RequestScoped
+    @DefaultBean
+    public static ArchiveRequestGenerator produceArchiveRequestGenerator() {
+        boolean singleThread = Runtime.getRuntime().availableProcessors() < 2;
+        return new ArchiveRequestGenerator(
                 singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
     }
 

--- a/src/main/java/io/cryostat/Producers.java
+++ b/src/main/java/io/cryostat/Producers.java
@@ -81,9 +81,7 @@ public class Producers {
     @RequestScoped
     @DefaultBean
     public static LongRunningRequestGenerator produceArchiveRequestGenerator() {
-        boolean singleThread = Runtime.getRuntime().availableProcessors() < 2;
-        return new LongRunningRequestGenerator(
-                singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
+        return new LongRunningRequestGenerator();
     }
 
     @Produces

--- a/src/main/java/io/cryostat/Producers.java
+++ b/src/main/java/io/cryostat/Producers.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ForkJoinPool;
 import io.cryostat.core.reports.InterruptibleReportGenerator;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.sys.FileSystem;
-import io.cryostat.recordings.ArchiveRequestGenerator;
+import io.cryostat.recordings.LongRunningRequestGenerator;
 
 import io.quarkus.arc.DefaultBean;
 import io.vertx.mutiny.core.Vertx;
@@ -80,9 +80,9 @@ public class Producers {
     @Produces
     @RequestScoped
     @DefaultBean
-    public static ArchiveRequestGenerator produceArchiveRequestGenerator() {
+    public static LongRunningRequestGenerator produceArchiveRequestGenerator() {
         boolean singleThread = Runtime.getRuntime().availableProcessors() < 2;
-        return new ArchiveRequestGenerator(
+        return new LongRunningRequestGenerator(
                 singleThread ? Executors.newSingleThreadExecutor() : ForkJoinPool.commonPool());
     }
 

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -151,7 +151,7 @@ public class ActiveRecordings {
                         "Request created: ("
                                 + request.getId()
                                 + ", "
-                                + request.getRecording().name
+                                + request.recording().name
                                 + ")");
                 response.endHandler(
                         (e) -> bus.publish(ArchiveRequestGenerator.ARCHIVE_ADDRESS, request));

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -235,10 +235,10 @@ public class ActiveRecordings {
             throws Exception {
         // Send an intermediate response back to the client while another thread handles the upload
         // request
-        logger.info("Creating grafana upload request");
+        logger.trace("Creating grafana upload request");
         GrafanaActiveUploadRequest request =
                 new GrafanaActiveUploadRequest(UUID.randomUUID().toString(), remoteId, targetId);
-        logger.info(
+        logger.trace(
                 "Request created: ("
                         + request.getId()
                         + ", "

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -148,8 +148,7 @@ public class ActiveRecordings {
                                 + ", "
                                 + request.getRecording().name
                                 + ")");
-                return Uni.createFrom()
-                        .future(generator.performArchive(request, bus, recordingHelper));
+                return Uni.createFrom().future(generator.performArchive(request));
             // return recordingHelper.archiveRecording(activeRecording, null, null).name();
             default:
                 throw new BadRequestException(body);

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -106,7 +106,7 @@ public class ActiveRecordings {
     @Blocking
     @Path("/{remoteId}")
     @RolesAllowed("write")
-    public Uni<String> patch(@RestPath long targetId, @RestPath long remoteId, String body)
+    public String patch(@RestPath long targetId, @RestPath long remoteId, String body)
             throws Exception {
         Target target = Target.find("id", targetId).singleResult();
         Optional<ActiveRecording> recording =
@@ -148,8 +148,8 @@ public class ActiveRecordings {
                                 + ", "
                                 + request.getRecording().name
                                 + ")");
-                return Uni.createFrom().future(generator.performArchive(request));
-            // return recordingHelper.archiveRecording(activeRecording, null, null).name();
+                bus.publish(ArchiveRequestGenerator.ARCHIVE_ADDRESS, request);
+                return request.getId();
             default:
                 throw new BadRequestException(body);
         }

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -15,7 +15,6 @@
  */
 package io.cryostat.recordings;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
@@ -25,10 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.libcryostat.templates.Template;
 import io.cryostat.libcryostat.templates.TemplateType;
+import io.cryostat.recordings.ArchiveRequestGenerator.ArchiveRequest;
 import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.targets.Target;
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -64,6 +66,8 @@ public class ActiveRecordings {
 
     @Inject ObjectMapper mapper;
     @Inject RecordingHelper recordingHelper;
+    @Inject ArchiveRequestGenerator generator;
+    @Inject EventBus bus;
     @Inject Logger logger;
 
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
@@ -102,7 +106,7 @@ public class ActiveRecordings {
     @Blocking
     @Path("/{remoteId}")
     @RolesAllowed("write")
-    public String patch(@RestPath long targetId, @RestPath long remoteId, String body)
+    public Uni<String> patch(@RestPath long targetId, @RestPath long remoteId, String body)
             throws Exception {
         Target target = Target.find("id", targetId).singleResult();
         Optional<ActiveRecording> recording =
@@ -121,18 +125,32 @@ public class ActiveRecordings {
                         .atMost(connectionFailedTimeout);
                 return null;
             case "save":
-                try {
-                    // FIXME this operation might take a long time to complete, depending on the
-                    // amount of JFR data in the target and the speed of the connection between the
-                    // target and Cryostat. We should not make the client wait until this operation
-                    // completes before sending a response - it should be async. Here we should just
-                    // return an Accepted response, and if a failure occurs that should be indicated
-                    // as a websocket notification.
-                    return recordingHelper.archiveRecording(activeRecording, null, null).name();
-                } catch (IOException ioe) {
-                    logger.warn(ioe);
-                    return null;
-                }
+                // FIXME this operation might take a long time to complete, depending on the
+                // amount of JFR data in the target and the speed of the connection between the
+                // target and Cryostat. We should not make the client wait until this operation
+                // completes before sending a response - it should be async. Here we should just
+                // return an Accepted response, and if a failure occurs that should be indicated
+                // as a websocket notification.
+
+                /*
+                 * Desired workflow:
+                 *   Client sends a PATCH request to Cryostat
+                 *   Cryostat receives the PATCH and checks that the specified active recording exists and that the target JVM is reachable (ex. try to open a connection and do something relatively lightweight like compute its JVM ID). If this check succeeds respond to the PATCH with 202, if it fails respond with a 404 (recording not found) or 502 (target not reachable) etc.
+                 *   In the background, Cryostat creates the S3 file upload request, opens a target connection, pipes the bytes, etc. - same as steps 2-5 above
+                 *   Cryostat emits a WebSocket notification, either indicating task successful completion or task failure.
+                 */
+                logger.info("Ceating request");
+                ArchiveRequest request =
+                        new ArchiveRequest(UUID.randomUUID().toString(), activeRecording);
+                logger.info(
+                        "Request created: ("
+                                + request.getId()
+                                + ", "
+                                + request.getRecording().name
+                                + ")");
+                return Uni.createFrom()
+                        .future(generator.performArchive(request, bus, recordingHelper));
+            // return recordingHelper.archiveRecording(activeRecording, null, null).name();
             default:
                 throw new BadRequestException(body);
         }

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -38,10 +38,16 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class ArchiveRequestGenerator {
 
-    public static final String ARCHIVE_ADDRESS = ArchiveRequestGenerator.class.getName();
+    public static final String ARCHIVE_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.ArchiveRequest";
     public static final String GRAFANA_ARCHIVE_ADDRESS =
-            GrafanaArchiveUploadRequest.class.getName();
-    public static final String GRAFANA_ACTIVE_ADDRESS = GrafanaActiveUploadRequest.class.getName();
+            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaArchiveUploadRequest";
+    public static final String GRAFANA_ACTIVE_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaActiveUploadRequest";
+    public static final String ARCHIVE_REPORT_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.ArchiveReportRequest";
+    public static final String ACTIVE_REPORT_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.ActiveReportRequest";
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
     private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailed";
     private static final String GRAFANA_UPLOAD_SUCCESS = "GrafanaUploadSuccess";
@@ -185,6 +191,38 @@ public class ArchiveRequestGenerator {
 
         public long getTargetId() {
             return targetId;
+        }
+    }
+
+    public record ArchivedReportRequest(String id, Pair<String, String> pair) {
+
+        public ArchivedReportRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(pair);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Pair<String, String> getPair() {
+            return pair;
+        }
+    }
+
+    public record ActiveReportRequest(String id, ActiveRecording recording) {
+
+        public ActiveReportRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(recording);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public ActiveRecording getRecording() {
+            return recording;
         }
     }
 }

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import io.cryostat.ws.MessagingServer;
+import io.cryostat.ws.Notification;
+
+import io.vertx.mutiny.core.eventbus.EventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArchiveRequestGenerator {
+
+    private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
+    private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailed";
+    private final ExecutorService archiveThread = Executors.newCachedThreadPool();
+    private final ExecutorService executor;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public ArchiveRequestGenerator(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public Future<String> performArchive(
+            ArchiveRequest request, EventBus bus, RecordingHelper recordingHelper) {
+        Objects.requireNonNull(request.getRecording());
+        return archiveThread.submit(
+                () -> {
+                    logger.debug("Job ID: " + request.getId() + " submitted.");
+                    try {
+                        recordingHelper.archiveRecording(request.getRecording(), null, null).name();
+                        bus.publish(
+                                MessagingServer.class.getName(),
+                                new Notification(
+                                        ARCHIVE_RECORDING_SUCCESS,
+                                        Map.of("jobId", request.getId())));
+                        return request.getId();
+                    } catch (Exception e) {
+                        bus.publish(
+                                MessagingServer.class.getName(),
+                                new Notification(
+                                        ARCHIVE_RECORDING_FAIL, Map.of("jobId", request.getId())));
+                        throw new CompletionException(e);
+                    }
+                });
+    }
+
+    public static class ArchiveRequest {
+
+        private String id;
+        private ActiveRecording recording;
+
+        public ArchiveRequest(String id, ActiveRecording recording) {
+            this.id = id;
+            this.recording = recording;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public ActiveRecording getRecording() {
+            return recording;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -15,12 +15,14 @@
  */
 package io.cryostat.recordings;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
@@ -28,6 +30,8 @@ import io.quarkus.vertx.ConsumeEvent;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +39,22 @@ import org.slf4j.LoggerFactory;
 public class ArchiveRequestGenerator {
 
     public static final String ARCHIVE_ADDRESS = "io.cryostat.recordings.ArchiveRequestGenerator";
+    public static final String GRAFANA_ARCHIVE_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaArchiveUploadRequest";
+    public static final String GRAFANA_ACTIVE_ADDRESS =
+            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaActiveUploadRequest";
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
     private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailed";
+    private static final String GRAFANA_UPLOAD_SUCCESS = "GrafanaUploadSuccess";
+    private static final String GRAFANA_UPLOAD_FAIL = "GrafanaUploadFailed";
     private final ExecutorService executor;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject private EventBus bus;
     @Inject private RecordingHelper recordingHelper;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration timeout;
 
     public ArchiveRequestGenerator(ExecutorService executor) {
         this.executor = executor;
@@ -81,6 +94,48 @@ public class ArchiveRequestGenerator {
         }
     }
 
+    @ConsumeEvent(value = GRAFANA_ARCHIVE_ADDRESS)
+    public void onMessage(GrafanaArchiveUploadRequest request) {
+        try {
+            logger.info("Job ID: " + request.getId() + " submitted.");
+            String result =
+                    recordingHelper
+                            .uploadToJFRDatasource(request.getPair())
+                            .await()
+                            .atMost(timeout);
+            logger.info("Grafana upload complete, firing notification");
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(GRAFANA_UPLOAD_SUCCESS, Map.of("jobId", request.getId())));
+        } catch (Exception e) {
+            logger.warn("Exception thrown while servicing request: ", e);
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(GRAFANA_UPLOAD_FAIL, Map.of("jobId", request.getId())));
+        }
+    }
+
+    @ConsumeEvent(value = GRAFANA_ACTIVE_ADDRESS)
+    public void onMessage(GrafanaActiveUploadRequest request) {
+        try {
+            logger.info("Job ID: " + request.getId() + " submitted.");
+            String result =
+                    recordingHelper
+                            .uploadToJFRDatasource(request.getTargetId(), request.getRemoteId())
+                            .await()
+                            .atMost(timeout);
+            logger.info("Grafana upload complete, firing notification");
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(GRAFANA_UPLOAD_SUCCESS, Map.of("jobId", request.getId())));
+        } catch (Exception e) {
+            logger.warn("Exception thrown while servicing request: ", e);
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(GRAFANA_UPLOAD_FAIL, Map.of("jobId", request.getId())));
+        }
+    }
+
     public record ArchiveRequest(String id, ActiveRecording recording) {
 
         public ArchiveRequest {
@@ -94,6 +149,43 @@ public class ArchiveRequestGenerator {
 
         public ActiveRecording getRecording() {
             return recording;
+        }
+    }
+
+    public record GrafanaArchiveUploadRequest(String id, Pair<String, String> pair) {
+
+        public GrafanaArchiveUploadRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(pair);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Pair<String, String> getPair() {
+            return pair;
+        }
+    }
+
+    public record GrafanaActiveUploadRequest(String id, long remoteId, long targetId) {
+
+        public GrafanaActiveUploadRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(remoteId);
+            Objects.requireNonNull(targetId);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public long getRemoteId() {
+            return remoteId;
+        }
+
+        public long getTargetId() {
+            return targetId;
         }
     }
 }

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import io.cryostat.ConfigProperties;
-import io.cryostat.core.reports.InterruptibleReportGenerator.AnalysisResult;
 import io.cryostat.reports.ReportsService;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
@@ -111,11 +110,7 @@ public class ArchiveRequestGenerator {
     public void onMessage(GrafanaArchiveUploadRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");
-            String result =
-                    recordingHelper
-                            .uploadToJFRDatasource(request.getPair())
-                            .await()
-                            .atMost(timeout);
+            recordingHelper.uploadToJFRDatasource(request.getPair()).await().atMost(timeout);
             logger.info("Grafana upload complete, firing notification");
             bus.publish(
                     MessagingServer.class.getName(),
@@ -132,11 +127,10 @@ public class ArchiveRequestGenerator {
     public void onMessage(GrafanaActiveUploadRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");
-            String result =
-                    recordingHelper
-                            .uploadToJFRDatasource(request.getTargetId(), request.getRemoteId())
-                            .await()
-                            .atMost(timeout);
+            recordingHelper
+                    .uploadToJFRDatasource(request.getTargetId(), request.getRemoteId())
+                    .await()
+                    .atMost(timeout);
             logger.info("Grafana upload complete, firing notification");
             bus.publish(
                     MessagingServer.class.getName(),
@@ -153,13 +147,11 @@ public class ArchiveRequestGenerator {
     public void onMessage(ActiveReportRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");
-            Map<String, AnalysisResult> result =
-                    reportsService.reportFor(request.recording).await().atMost(timeout);
+            reportsService.reportFor(request.recording).await().atMost(timeout);
             logger.info("Report generation complete, firing notification");
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(
-                            REPORT_SUCCESS, Map.of("result", result, "jobId", request.getId())));
+                    new Notification(REPORT_SUCCESS, Map.of("jobId", request.getId())));
         } catch (Exception e) {
             logger.warn("Exception thrown while servicing request: ", e);
             bus.publish(
@@ -172,16 +164,14 @@ public class ArchiveRequestGenerator {
     public void onMessage(ArchivedReportRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");
-            Map<String, AnalysisResult> result =
-                    reportsService
-                            .reportFor(request.getPair().getKey(), request.getPair().getValue())
-                            .await()
-                            .atMost(timeout);
+            reportsService
+                    .reportFor(request.getPair().getKey(), request.getPair().getValue())
+                    .await()
+                    .atMost(timeout);
             logger.info("Report generation complete, firing notification");
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(
-                            REPORT_SUCCESS, Map.of("result", result, "jobId", request.getId())));
+                    new Notification(REPORT_SUCCESS, Map.of("jobId", request.getId())));
         } catch (Exception e) {
             logger.warn("Exception thrown while servicing request: ", e);
             bus.publish(

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -38,11 +38,10 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class ArchiveRequestGenerator {
 
-    public static final String ARCHIVE_ADDRESS = "io.cryostat.recordings.ArchiveRequestGenerator";
+    public static final String ARCHIVE_ADDRESS = ArchiveRequestGenerator.class.getName();
     public static final String GRAFANA_ARCHIVE_ADDRESS =
-            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaArchiveUploadRequest";
-    public static final String GRAFANA_ACTIVE_ADDRESS =
-            "io.cryostat.recordings.ArchiveRequestGenerator.GrafanaActiveUploadRequest";
+            GrafanaArchiveUploadRequest.class.getName();
+    public static final String GRAFANA_ACTIVE_ADDRESS = GrafanaActiveUploadRequest.class.getName();
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
     private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailed";
     private static final String GRAFANA_UPLOAD_SUCCESS = "GrafanaUploadSuccess";
@@ -94,7 +93,7 @@ public class ArchiveRequestGenerator {
         }
     }
 
-    @ConsumeEvent(value = GRAFANA_ARCHIVE_ADDRESS)
+    @ConsumeEvent(value = GRAFANA_ARCHIVE_ADDRESS, blocking = true)
     public void onMessage(GrafanaArchiveUploadRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");
@@ -115,7 +114,7 @@ public class ArchiveRequestGenerator {
         }
     }
 
-    @ConsumeEvent(value = GRAFANA_ACTIVE_ADDRESS)
+    @ConsumeEvent(value = GRAFANA_ACTIVE_ADDRESS, blocking = true)
     public void onMessage(GrafanaActiveUploadRequest request) {
         try {
             logger.info("Job ID: " + request.getId() + " submitted.");

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -165,7 +165,10 @@ public class ArchiveRequestGenerator {
                     reportsService.reportFor(request.recording).await().atMost(timeout);
             logger.info("Report generation complete, firing notification");
             jobResults.put(request.getId(), result);
-            bus.publish(MessagingServer.class.getName(), new Notification(REPORT_SUCCESS, result));
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            REPORT_SUCCESS, Map.of("result", result, "jobId", request.getId())));
         } catch (Exception e) {
             logger.warn("Exception thrown while servicing request: ", e);
             bus.publish(
@@ -184,8 +187,10 @@ public class ArchiveRequestGenerator {
                             .await()
                             .atMost(timeout);
             logger.info("Report generation complete, firing notification");
-            jobResults.put(request.getId(), result);
-            bus.publish(MessagingServer.class.getName(), new Notification(REPORT_SUCCESS, result));
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            REPORT_SUCCESS, Map.of("result", result, "jobId", request.getId())));
         } catch (Exception e) {
             logger.warn("Exception thrown while servicing request: ", e);
             bus.publish(

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -65,14 +65,11 @@ public class ArchiveRequestGenerator {
                 });
     }
 
-    public static class ArchiveRequest {
+    public record ArchiveRequest(String id, ActiveRecording recording) {
 
-        private String id;
-        private ActiveRecording recording;
-
-        public ArchiveRequest(String id, ActiveRecording recording) {
-            this.id = id;
-            this.recording = recording;
+        public ArchiveRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(recording);
         }
 
         public String getId() {

--- a/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/ArchiveRequestGenerator.java
@@ -26,9 +26,12 @@ import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
 import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ApplicationScoped
 public class ArchiveRequestGenerator {
 
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
@@ -37,12 +40,14 @@ public class ArchiveRequestGenerator {
     private final ExecutorService executor;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    @Inject private EventBus bus;
+    @Inject private RecordingHelper recordingHelper;
+
     public ArchiveRequestGenerator(ExecutorService executor) {
         this.executor = executor;
     }
 
-    public Future<String> performArchive(
-            ArchiveRequest request, EventBus bus, RecordingHelper recordingHelper) {
+    public Future<String> performArchive(ArchiveRequest request) {
         Objects.requireNonNull(request.getRecording());
         return archiveThread.submit(
                 () -> {

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -492,10 +492,10 @@ public class ArchivedRecordings {
         }
         // Send an intermediate response back to the client while another thread handles the upload
         // request
-        logger.info("Creating grafana upload request");
+        logger.trace("Creating grafana upload request");
         GrafanaArchiveUploadRequest request =
                 new GrafanaArchiveUploadRequest(UUID.randomUUID().toString(), pair);
-        logger.info(
+        logger.trace(
                 "Request created: (" + request.getId() + ", " + request.getPair().toString() + ")");
         response.endHandler(
                 (e) -> bus.publish(LongRunningRequestGenerator.GRAFANA_ARCHIVE_ADDRESS, request));

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -35,7 +35,7 @@ import io.cryostat.StorageBuckets;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.recordings.ActiveRecording.Listener.ArchivedRecordingEvent;
 import io.cryostat.recordings.ActiveRecordings.Metadata;
-import io.cryostat.recordings.ArchiveRequestGenerator.GrafanaArchiveUploadRequest;
+import io.cryostat.recordings.LongRunningRequestGenerator.GrafanaArchiveUploadRequest;
 import io.cryostat.targets.Target;
 import io.cryostat.util.HttpMimeType;
 import io.cryostat.ws.MessagingServer;
@@ -498,7 +498,7 @@ public class ArchivedRecordings {
         logger.info(
                 "Request created: (" + request.getId() + ", " + request.getPair().toString() + ")");
         response.endHandler(
-                (e) -> bus.publish(ArchiveRequestGenerator.GRAFANA_ARCHIVE_ADDRESS, request));
+                (e) -> bus.publish(LongRunningRequestGenerator.GRAFANA_ARCHIVE_ADDRESS, request));
         return request.getId();
     }
 

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -66,25 +66,21 @@ public class LongRunningRequestGenerator {
 
     @ConsumeEvent(value = ARCHIVE_ADDRESS, blocking = true)
     public void onMessage(ArchiveRequest request) {
+        logger.trace("Job ID: " + request.getId() + " submitted.");
         try {
-            logger.trace("Job ID: " + request.getId() + " submitted.");
-            try {
-                String rec = recordingHelper.archiveRecording(request.recording, null, null).name();
-                logger.trace("Recording archived, firing notification");
-                bus.publish(
-                        MessagingServer.class.getName(),
-                        new Notification(
-                                ARCHIVE_RECORDING_SUCCESS,
-                                Map.of("jobId", request.getId(), "recording", rec)));
-            } catch (Exception e) {
-                logger.warn("Archiving failed");
-                bus.publish(
-                        MessagingServer.class.getName(),
-                        new Notification(ARCHIVE_RECORDING_FAIL, Map.of("jobId", request.getId())));
-                throw new CompletionException(e);
-            }
+            String rec = recordingHelper.archiveRecording(request.recording, null, null).name();
+            logger.trace("Recording archived, firing notification");
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            ARCHIVE_RECORDING_SUCCESS,
+                            Map.of("jobId", request.getId(), "recording", rec)));
         } catch (Exception e) {
-            logger.warn("Exception thrown while servicing request: ", e);
+            logger.warn("Archiving failed");
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(ARCHIVE_RECORDING_FAIL, Map.of("jobId", request.getId())));
+            throw new CompletionException(e);
         }
     }
 

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -34,7 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.slf4j.Logger;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class LongRunningRequestGenerator {

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
-public class ArchiveRequestGenerator {
+public class LongRunningRequestGenerator {
 
     public static final String ARCHIVE_ADDRESS =
             "io.cryostat.recordings.ArchiveRequestGenerator.ArchiveRequest";
@@ -66,7 +66,7 @@ public class ArchiveRequestGenerator {
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
     Duration timeout;
 
-    public ArchiveRequestGenerator(ExecutorService executor) {
+    public LongRunningRequestGenerator(ExecutorService executor) {
         this.executor = executor;
     }
 
@@ -84,7 +84,8 @@ public class ArchiveRequestGenerator {
                         bus.publish(
                                 MessagingServer.class.getName(),
                                 new Notification(
-                                        ARCHIVE_RECORDING_SUCCESS, Map.of("recording", rec)));
+                                        ARCHIVE_RECORDING_SUCCESS,
+                                        Map.of("jobId", request.getId(), "recording", rec)));
                         return request.getId();
                     } catch (Exception e) {
                         logger.info("Archiving failed");

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -905,6 +905,7 @@ public class RecordingHelper {
 
             URI connectUrl = recording.target.connectUrl;
 
+            /*
             var event =
                     new ArchivedRecordingEvent(
                             ActiveRecordings.RecordingEventCategory.ARCHIVED_CREATED,
@@ -912,7 +913,7 @@ public class RecordingHelper {
             bus.publish(event.category().category(), event.payload().recording());
             bus.publish(
                     MessagingServer.class.getName(),
-                    new Notification(event.category().category(), event.payload()));
+                    new Notification(event.category().category(), event.payload()));*/
         }
         return new ArchivedRecording(
                 recording.target.jvmId,

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -18,7 +18,6 @@ package io.cryostat.recordings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -891,29 +890,6 @@ public class RecordingHelper {
             // Amazon S3 couldn't be contacted for a response, or the client
             // couldn't parse the response from Amazon S3.
             throw e;
-        }
-        if (expiry == null) {
-            ArchivedRecording archivedRecording =
-                    new ArchivedRecording(
-                            recording.target.jvmId,
-                            filename,
-                            downloadUrl(recording.target.jvmId, filename),
-                            reportUrl(recording.target.jvmId, filename),
-                            recording.metadata,
-                            accum,
-                            now.getEpochSecond());
-
-            URI connectUrl = recording.target.connectUrl;
-
-            /*
-            var event =
-                    new ArchivedRecordingEvent(
-                            ActiveRecordings.RecordingEventCategory.ARCHIVED_CREATED,
-                            ArchivedRecordingEvent.Payload.of(connectUrl, archivedRecording));
-            bus.publish(event.category().category(), event.payload().recording());
-            bus.publish(
-                    MessagingServer.class.getName(),
-                    new Notification(event.category().category(), event.payload()));*/
         }
         return new ArchivedRecording(
                 recording.target.jvmId,

--- a/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
@@ -16,7 +16,6 @@
 package io.cryostat.reports;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.openjdk.jmc.flightrecorder.rules.IRule;
@@ -115,15 +114,15 @@ class MemoryCachingReportsService implements ReportsService {
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
         return (quarkusCache || memoryCache)
-                && !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key))
-                && !delegate.keyExists(recording);
+                && (activeCache.as(CaffeineCache.class).keySet().contains(key)
+                        || delegate.keyExists(recording));
     }
 
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = recordingHelper.archivedRecordingKey(jvmId, filename);
         return (quarkusCache || memoryCache)
-                && !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key))
-                && !delegate.keyExists(jvmId, filename);
+                && (archivedCache.as(CaffeineCache.class).keySet().contains(key)
+                        || delegate.keyExists(jvmId, filename));
     }
 }

--- a/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
@@ -114,12 +114,14 @@ class MemoryCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
-        return !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key));
+        return !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key))
+                && !delegate.keyExists(recording);
     }
 
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = recordingHelper.archivedRecordingKey(jvmId, filename);
-        return !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key));
+        return !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key))
+                && !delegate.keyExists(jvmId, filename);
     }
 }

--- a/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
@@ -16,6 +16,7 @@
 package io.cryostat.reports;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.openjdk.jmc.flightrecorder.rules.IRule;
@@ -27,6 +28,7 @@ import io.cryostat.recordings.RecordingHelper;
 
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CaffeineCache;
 import io.smallrye.mutiny.Uni;
 import jakarta.annotation.Priority;
 import jakarta.decorator.Decorator;
@@ -107,5 +109,17 @@ class MemoryCachingReportsService implements ReportsService {
     @Override
     public Uni<Map<String, AnalysisResult>> reportFor(String jvmId, String filename) {
         return reportFor(jvmId, filename, r -> true);
+    }
+
+    @Override
+    public boolean keyExists(ActiveRecording recording) {
+        String key = ReportsService.key(recording);
+        return !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key));
+    }
+
+    @Override
+    public boolean keyExists(String jvmId, String filename) {
+        String key = recordingHelper.archivedRecordingKey(jvmId, filename);
+        return !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key));
     }
 }

--- a/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
@@ -114,14 +114,16 @@ class MemoryCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
-        return !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key))
+        return (quarkusCache || memoryCache)
+                && !Objects.isNull(activeCache.as(CaffeineCache.class).getIfPresent(key))
                 && !delegate.keyExists(recording);
     }
 
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = recordingHelper.archivedRecordingKey(jvmId, filename);
-        return !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key))
+        return (quarkusCache || memoryCache)
+                && !Objects.isNull(archivedCache.as(CaffeineCache.class).getIfPresent(key))
                 && !delegate.keyExists(jvmId, filename);
     }
 }

--- a/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/MemoryCachingReportsService.java
@@ -113,7 +113,7 @@ class MemoryCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
-        return (quarkusCache || memoryCache)
+        return (quarkusCache && memoryCache)
                 && (activeCache.as(CaffeineCache.class).keySet().contains(key)
                         || delegate.keyExists(recording));
     }
@@ -121,7 +121,7 @@ class MemoryCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = recordingHelper.archivedRecordingKey(jvmId, filename);
-        return (quarkusCache || memoryCache)
+        return (quarkusCache && memoryCache)
                 && (archivedCache.as(CaffeineCache.class).keySet().contains(key)
                         || delegate.keyExists(jvmId, filename));
     }

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -20,9 +20,9 @@ import java.util.UUID;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.StorageBuckets;
-import io.cryostat.recordings.ArchiveRequestGenerator;
-import io.cryostat.recordings.ArchiveRequestGenerator.ActiveReportRequest;
-import io.cryostat.recordings.ArchiveRequestGenerator.ArchivedReportRequest;
+import io.cryostat.recordings.LongRunningRequestGenerator;
+import io.cryostat.recordings.LongRunningRequestGenerator.ActiveReportRequest;
+import io.cryostat.recordings.LongRunningRequestGenerator.ArchivedReportRequest;
 import io.cryostat.recordings.RecordingHelper;
 import io.cryostat.targets.Target;
 
@@ -55,7 +55,7 @@ public class Reports {
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
     Duration timeout;
 
-    @Inject ArchiveRequestGenerator generator;
+    @Inject LongRunningRequestGenerator generator;
     @Inject StorageBuckets storageBuckets;
     @Inject RecordingHelper helper;
     @Inject ReportsService reportsService;
@@ -99,8 +99,8 @@ public class Reports {
         ArchivedReportRequest request =
                 new ArchivedReportRequest(UUID.randomUUID().toString(), pair);
         response.bodyEndHandler(
-                (e) -> bus.publish(ArchiveRequestGenerator.ARCHIVE_REPORT_ADDRESS, request));
-        return Response.ok(request.getId())
+                (e) -> bus.publish(LongRunningRequestGenerator.ARCHIVE_REPORT_ADDRESS, request));
+        return Response.ok(request.getId(), MediaType.TEXT_PLAIN)
                 .status(202)
                 .location(
                         UriBuilder.fromUri(
@@ -140,7 +140,7 @@ public class Reports {
         ActiveReportRequest request =
                 new ActiveReportRequest(UUID.randomUUID().toString(), recording);
         response.bodyEndHandler(
-                (e) -> bus.publish(ArchiveRequestGenerator.ACTIVE_REPORT_ADDRESS, request));
+                (e) -> bus.publish(LongRunningRequestGenerator.ACTIVE_REPORT_ADDRESS, request));
         // TODO implement query parameter for evaluation predicate
         return Response.ok(request.getId())
                 .status(202)

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -139,12 +139,8 @@ public class Reports {
         logger.info("Cache miss. Creating active reports request");
         ActiveReportRequest request =
                 new ActiveReportRequest(UUID.randomUUID().toString(), recording);
-        // This doesn't get fired
         response.bodyEndHandler(
-                (e) -> {
-                    logger.info("Did we get here? Firing Active report event");
-                    bus.publish(ArchiveRequestGenerator.ACTIVE_REPORT_ADDRESS, request);
-                });
+                (e) -> bus.publish(ArchiveRequestGenerator.ACTIVE_REPORT_ADDRESS, request));
         // TODO implement query parameter for evaluation predicate
         return Response.ok(request.getId())
                 .status(202)

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -15,12 +15,11 @@
  */
 package io.cryostat.reports;
 
-import java.util.Map;
+import java.time.Duration;
 import java.util.UUID;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.StorageBuckets;
-import io.cryostat.core.reports.InterruptibleReportGenerator.AnalysisResult;
 import io.cryostat.recordings.ArchiveRequestGenerator;
 import io.cryostat.recordings.ArchiveRequestGenerator.ActiveReportRequest;
 import io.cryostat.recordings.ArchiveRequestGenerator.ArchivedReportRequest;
@@ -39,6 +38,7 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
@@ -51,6 +51,9 @@ public class Reports {
 
     @ConfigProperty(name = ConfigProperties.ARCHIVED_REPORTS_STORAGE_CACHE_NAME)
     String bucket;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration timeout;
 
     @Inject ArchiveRequestGenerator generator;
     @Inject StorageBuckets storageBuckets;
@@ -69,29 +72,39 @@ public class Reports {
 
     @GET
     @Blocking
-    @Path("/api/v4/jobs/{jobId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @RolesAllowed("read")
-    public Map<String, AnalysisResult> getFromJobId(@RestPath String jobId) {
-        logger.info("Retrieving result for Job ID: " + jobId);
-        return generator.getAnalysisResult(jobId);
-    }
-
-    @GET
-    @Blocking
     @Path("/api/v4/reports/{encodedKey}")
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed("read")
-    public String get(HttpServerResponse response, @RestPath String encodedKey) {
+    // Response isn't strongly typed which allows us to return either the Analysis result
+    // or a job ID String along with setting different Status codes.
+    // TODO: Is there a cleaner way to accomplish this?
+    public Response get(HttpServerResponse response, @RestPath String encodedKey) {
         // TODO implement query parameter for evaluation predicate
-        logger.info("Creating archived reports request");
         var pair = helper.decodedKey(encodedKey);
+
+        // Check if we have a cached result already for this report
+        if (reportsService.keyExists(pair.getKey(), pair.getValue())) {
+            return Response.ok(
+                            reportsService
+                                    .reportFor(pair.getKey(), pair.getValue())
+                                    .await()
+                                    .atMost(timeout),
+                            MediaType.APPLICATION_JSON)
+                    .status(200)
+                    .build();
+        }
+
+        // If we don't have a cached result, delegate to the ArchiveRequestGenerator
+        // and return the job ID with a location header.
+        logger.info("Cache miss. Creating archived reports request");
         ArchivedReportRequest request =
                 new ArchivedReportRequest(UUID.randomUUID().toString(), pair);
         response.endHandler(
                 (e) -> bus.publish(ArchiveRequestGenerator.ARCHIVE_REPORT_ADDRESS, request));
-        return request.getId();
-        // return reportsService.reportFor(pair.getKey(), pair.getValue());
+        return Response.ok(request.getId())
+                .status(202)
+                .header("Location", "/api/v4/reports/" + encodedKey)
+                .build();
     }
 
     @GET
@@ -99,23 +112,38 @@ public class Reports {
     @Path("/api/v4/targets/{targetId}/reports/{recordingId}")
     @Produces({MediaType.APPLICATION_JSON})
     @RolesAllowed("read")
-    public String getActive(
+    // Response isn't strongly typed which allows us to return either the Analysis result
+    // or a job ID String along with setting different Status codes.
+    // TODO: Is there a cleaner way to accomplish this?
+    public Response getActive(
             HttpServerResponse response, @RestPath long targetId, @RestPath long recordingId)
             throws Exception {
-
-        logger.info("Creating active reports request");
         var target = Target.getTargetById(targetId);
         var recording = target.getRecordingById(recordingId);
         if (recording == null) {
             throw new NotFoundException();
         }
 
+        // Check if we've already cached a result for this report, return it if so
+        if (reportsService.keyExists(recording)) {
+            return Response.ok(reportsService.reportFor(recording).await().atMost(timeout))
+                    .status(200)
+                    .build();
+        }
+
+        // If there isn't a cached result available, delegate to the ArchiveRequestGenerator
+        // and return the job ID with a location header.
+        logger.info("Cache miss. Creating active reports request");
         ActiveReportRequest request =
                 new ActiveReportRequest(UUID.randomUUID().toString(), recording);
         response.endHandler(
                 (e) -> bus.publish(ArchiveRequestGenerator.ACTIVE_REPORT_ADDRESS, request));
         // TODO implement query parameter for evaluation predicate
-        return request.getId();
-        // return reportsService.reportFor(recording);
+        return Response.ok(request.getId())
+                .status(202)
+                .header(
+                        "Location",
+                        "/api/v4/targets/" + target.targetId() + "/reports/" + recordingId)
+                .build();
     }
 }

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -95,7 +95,7 @@ public class Reports {
 
         // If we don't have a cached result, delegate to the ArchiveRequestGenerator
         // and return the job ID with a location header.
-        logger.info("Cache miss. Creating archived reports request");
+        logger.trace("Cache miss. Creating archived reports request");
         ArchivedReportRequest request =
                 new ArchivedReportRequest(UUID.randomUUID().toString(), pair);
         response.bodyEndHandler(
@@ -136,7 +136,7 @@ public class Reports {
 
         // If there isn't a cached result available, delegate to the ArchiveRequestGenerator
         // and return the job ID with a location header.
-        logger.info("Cache miss. Creating active reports request");
+        logger.trace("Cache miss. Creating active reports request");
         ActiveReportRequest request =
                 new ActiveReportRequest(UUID.randomUUID().toString(), recording);
         response.bodyEndHandler(

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -142,7 +142,7 @@ public class Reports {
         response.bodyEndHandler(
                 (e) -> bus.publish(LongRunningRequestGenerator.ACTIVE_REPORT_ADDRESS, request));
         // TODO implement query parameter for evaluation predicate
-        return Response.ok(request.getId())
+        return Response.ok(request.getId(), MediaType.TEXT_PLAIN)
                 .status(202)
                 .location(
                         UriBuilder.fromUri(

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -15,10 +15,12 @@
  */
 package io.cryostat.reports;
 
+import java.util.Map;
 import java.util.UUID;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.StorageBuckets;
+import io.cryostat.core.reports.InterruptibleReportGenerator.AnalysisResult;
 import io.cryostat.recordings.ArchiveRequestGenerator;
 import io.cryostat.recordings.ArchiveRequestGenerator.ActiveReportRequest;
 import io.cryostat.recordings.ArchiveRequestGenerator.ArchivedReportRequest;
@@ -50,6 +52,7 @@ public class Reports {
     @ConfigProperty(name = ConfigProperties.ARCHIVED_REPORTS_STORAGE_CACHE_NAME)
     String bucket;
 
+    @Inject ArchiveRequestGenerator generator;
     @Inject StorageBuckets storageBuckets;
     @Inject RecordingHelper helper;
     @Inject ReportsService reportsService;
@@ -62,6 +65,16 @@ public class Reports {
         if (storageCacheEnabled) {
             storageBuckets.createIfNecessary(bucket);
         }
+    }
+
+    @GET
+    @Blocking
+    @Path("/api/v4/jobs/{jobId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed("read")
+    public Map<String, AnalysisResult> getFromJobId(@RestPath String jobId) {
+        logger.info("Retrieving result for Job ID: " + jobId);
+        return generator.getAnalysisResult(jobId);
     }
 
     @GET

--- a/src/main/java/io/cryostat/reports/ReportsService.java
+++ b/src/main/java/io/cryostat/reports/ReportsService.java
@@ -39,4 +39,8 @@ public interface ReportsService {
     static String key(ActiveRecording recording) {
         return String.format("%s/%d", recording.target.jvmId, recording.id);
     }
+
+    public boolean keyExists(ActiveRecording recording);
+
+    public boolean keyExists(String jvmId, String filename);
 }

--- a/src/main/java/io/cryostat/reports/ReportsServiceImpl.java
+++ b/src/main/java/io/cryostat/reports/ReportsServiceImpl.java
@@ -117,4 +117,14 @@ class ReportsServiceImpl implements ReportsService {
             super(cause);
         }
     }
+
+    @Override
+    public boolean keyExists(ActiveRecording recording) {
+        return false;
+    }
+
+    @Override
+    public boolean keyExists(String jvmId, String filename) {
+        return false;
+    }
 }

--- a/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
@@ -172,12 +172,12 @@ class StorageCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
-        return checkStorage(key).await().atMost(timeout);
+        return enabled && checkStorage(key).await().atMost(timeout);
     }
 
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = recordingHelper.archivedRecordingKey(jvmId, filename);
-        return checkStorage(key).await().atMost(timeout);
+        return enabled && checkStorage(key).await().atMost(timeout);
     }
 }

--- a/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
@@ -64,6 +64,9 @@ class StorageCachingReportsService implements ReportsService {
     @ConfigProperty(name = ConfigProperties.ARCHIVED_REPORTS_EXPIRY_DURATION)
     Duration expiry;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration timeout;
+
     @Inject S3Client storage;
     @Inject RecordingHelper recordingHelper;
     @Inject ObjectMapper mapper;
@@ -164,5 +167,17 @@ class StorageCachingReportsService implements ReportsService {
     @Override
     public Uni<Map<String, AnalysisResult>> reportFor(String jvmId, String filename) {
         return reportFor(jvmId, filename, r -> true);
+    }
+
+    @Override
+    public boolean keyExists(ActiveRecording recording) {
+        String key = ReportsService.key(recording);
+        return checkStorage(key).await().atMost(timeout);
+    }
+
+    @Override
+    public boolean keyExists(String jvmId, String filename) {
+        String key = recordingHelper.archivedRecordingKey(jvmId, filename);
+        return checkStorage(key).await().atMost(timeout);
     }
 }

--- a/src/test/java/io/cryostat/reports/ReportsTest.java
+++ b/src/test/java/io/cryostat/reports/ReportsTest.java
@@ -85,7 +85,7 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                         .all()
                         .when()
                         .pathParams(Map.of("targetId", targetId))
-                        .formParam("recordingName", "activeRecordingsTest")
+                        .formParam("recordingName", "activeRecordingsTestReports")
                         .formParam("events", "template=Continuous")
                         .pathParam("targetId", targetId)
                         .post("/api/v4/targets/{targetId}/recordings")
@@ -111,9 +111,9 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                 .all()
                 .and()
                 .assertThat()
-                .statusCode(200)
-                .contentType(ContentType.JSON)
-                .body("size()", Matchers.greaterThan(0));
+                .statusCode(202)
+                .contentType(ContentType.TEXT)
+                .body(Matchers.any(String.class));
 
         given().log()
                 .all()
@@ -136,7 +136,7 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                         .all()
                         .when()
                         .pathParams(Map.of("targetId", targetId))
-                        .formParam("recordingName", "activeRecordingsTest")
+                        .formParam("recordingName", "activeRecordingsTestReportsURL")
                         .formParam("events", "template=Continuous")
                         .pathParam("targetId", targetId)
                         .post("/api/v4/targets/{targetId}/recordings")
@@ -163,9 +163,9 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                 .all()
                 .and()
                 .assertThat()
-                .statusCode(200)
-                .contentType(ContentType.JSON)
-                .body("size()", Matchers.greaterThan(0));
+                .statusCode(202)
+                .contentType(ContentType.TEXT)
+                .body(Matchers.any(String.class));
 
         given().log()
                 .all()

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -145,12 +145,6 @@ public class RecordingWorkflowTest extends StandardSelfTest {
                             });
             archiveLatch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             JsonObject archiveNotification = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            System.out.println(
-                    "[Did we get here?] "
-                            + archiveNotification
-                                    .getJsonObject("message")
-                                    .getString("recording")
-                                    .toString());
             archivedRecordingFilenames.add(
                     archiveNotification.getJsonObject("message").getString("recording").toString());
             // check that the in-memory recording list hasn't changed

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -18,9 +18,12 @@ package itest;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -35,7 +38,6 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.codec.BodyCodec;
 import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import jdk.jfr.consumer.RecordedEvent;
@@ -48,6 +50,8 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 @QuarkusTestResource(LocalStackResource.class)
 public class RecordingWorkflowTest extends StandardSelfTest {
+
+    private final ExecutorService worker = ForkJoinPool.commonPool();
 
     static final String TEST_RECORDING_NAME = "workflow_itest";
     static final String TARGET_ALIAS = "selftest";
@@ -113,19 +117,42 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             // save a copy of the partial recording dump
             MultiMap saveHeaders = MultiMap.caseInsensitiveMultiMap();
             saveHeaders.add(HttpHeaders.CONTENT_TYPE.toString(), HttpMimeType.PLAINTEXT.mime());
-            String archivedRecordingFilename =
-                    webClient
-                            .extensions()
-                            .patch(
-                                    String.format(
-                                            "/api/v4/targets/%d/recordings/%d",
-                                            getSelfReferenceTargetId(), TEST_REMOTE_ID),
-                                    saveHeaders,
-                                    Buffer.buffer("SAVE"),
-                                    REQUEST_TIMEOUT_SECONDS)
-                            .bodyAsString();
-            archivedRecordingFilenames.add(archivedRecordingFilename);
-
+            webClient
+                    .extensions()
+                    .patch(
+                            String.format(
+                                    "/api/v4/targets/%d/recordings/%d",
+                                    getSelfReferenceTargetId(), TEST_REMOTE_ID),
+                            saveHeaders,
+                            Buffer.buffer("SAVE"),
+                            REQUEST_TIMEOUT_SECONDS)
+                    .bodyAsString();
+            // Wait for the archive request to conclude, the server won't block the client
+            // while it performs the archive so we need to wait.
+            CountDownLatch archiveLatch = new CountDownLatch(1);
+            Future<JsonObject> future =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification(
+                                                    "ArchiveRecordingSuccess", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    archiveLatch.countDown();
+                                }
+                            });
+            archiveLatch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            JsonObject archiveNotification = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            System.out.println(
+                    "[Did we get here?] "
+                            + archiveNotification
+                                    .getJsonObject("message")
+                                    .getString("recording")
+                                    .toString());
+            archivedRecordingFilenames.add(
+                    archiveNotification.getJsonObject("message").getString("recording").toString());
             // check that the in-memory recording list hasn't changed
             CompletableFuture<JsonArray> listRespFuture3 = new CompletableFuture<>();
             webClient
@@ -219,10 +246,9 @@ public class RecordingWorkflowTest extends StandardSelfTest {
 
             String reportUrl = recordingInfo.getString("reportUrl");
 
-            HttpResponse<JsonObject> reportResponse =
+            HttpResponse<Buffer> reportResponse =
                     webClient
                             .get(reportUrl)
-                            .as(BodyCodec.jsonObject())
                             .send()
                             .toCompletionStage()
                             .toCompletableFuture()
@@ -230,12 +256,27 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             MatcherAssert.assertThat(
                     reportResponse.statusCode(),
                     Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
-            JsonObject report = reportResponse.body();
+            MatcherAssert.assertThat(reportResponse.bodyAsString(), Matchers.notNullValue());
 
-            Map<?, ?> response = report.getMap();
-            MatcherAssert.assertThat(response, Matchers.notNullValue());
+            // Check that report generation concludes
+            CountDownLatch latch = new CountDownLatch(1);
+            Future<JsonObject> f =
+                    worker.submit(
+                            () -> {
+                                try {
+                                    return expectNotification("ReportSuccess", 15, TimeUnit.SECONDS)
+                                            .get();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
+
+            latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            JsonObject notification = f.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             MatcherAssert.assertThat(
-                    response, Matchers.is(Matchers.aMapWithSize(Matchers.greaterThan(8))));
+                    notification.getJsonObject("message"), Matchers.notNullValue());
         } finally {
             // Clean up what we created
             try {

--- a/src/test/java/itest/UploadRecordingTest.java
+++ b/src/test/java/itest/UploadRecordingTest.java
@@ -109,14 +109,12 @@ public class UploadRecordingTest extends StandardSelfTest {
                                         getSelfReferenceTargetId(), RECORDING_REMOTE_ID),
                                 (Buffer) null,
                                 0);
-
+        // The endpoint should send back a job ID, while it kicks off the upload.
         MatcherAssert.assertThat(resp.statusCode(), Matchers.equalTo(200));
+        MatcherAssert.assertThat(resp.bodyAsString(), Matchers.notNullValue());
 
-        final String expectedUploadResponse =
-                String.format("Uploaded: %s\nSet: %s", DATASOURCE_FILENAME, DATASOURCE_FILENAME);
-
-        MatcherAssert.assertThat(
-                resp.bodyAsString().trim(), Matchers.equalTo(expectedUploadResponse));
+        // Sleep for a bit to give the upload time to complete
+        Thread.sleep(2000);
 
         HttpRequest<Buffer> req = webClient.get("/api/v4/grafana_datasource_url");
         CompletableFuture<JsonObject> respFuture = new CompletableFuture<>();


### PR DESCRIPTION
Fixes #286

Hi, 

This adds a prototype for long running API operations (first step of https://github.com/cryostatio/cryostat/issues/286).

The workflow proceeds as described in the issue:

- Cryostat receives a patch request to archive a recording
- Basic validation is done (check that target is valid and that the recording exists)
- Following this an ArchiveRequest is created that tracks a job ID and the requested recording
- The archive request is then passed on to the ArchiveRequestGenerator (works similarly to the InterruptibleReportsGenerator)
- ArchiveRequestGenerator performs the archiving on a separate thread, firing a notification to the web client for success or failure which includes the job ID

TODO: Web Client needs to be adjusted to account for the new notifications, refreshing the tables when it receives them.
TODO: Implement the same framework for Grafana uploads of active/archived recordings, as well as report generation for active/archived recordings