### PR TITLE
test(smoketest): restore healthcheck, remove obsolete version declarations

### DIFF
--- a/compose/auth_proxy.yml
+++ b/compose/auth_proxy.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     expose:

--- a/compose/auth_proxy_https.yml
+++ b/compose/auth_proxy_https.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/cryostat-grafana.yml
+++ b/compose/cryostat-grafana.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -36,14 +36,12 @@ services:
         -Dcom.sun.management.jmxremote.ssl=false
         -Dcom.sun.management.jmxremote.local.only=false
     restart: unless-stopped
-    # FIXME reenable this check. Somehow after upgrading to Quarkus 3.8, this check fails with 'connection refused',
-    # but the container comes up successfully without it and shelling into the container later to run curl succeeds
-    # healthcheck:
-    #   test: curl --fail http://cryostat:${CRYOSTAT_HTTP_PORT}/health/liveness || exit 1
-    #   interval: 10s
-    #   retries: 3
-    #   start_period: 30s
-    #   timeout: 5s
+    healthcheck:
+      test: curl --fail http://cryostat:${CRYOSTAT_HTTP_PORT}/health/liveness || exit 1
+      interval: 10s
+      retries: 3
+      start_period: 30s
+      timeout: 5s
 
 volumes:
   jmxtls_cfg:

--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     deploy:

--- a/compose/cryostat_docker.yml
+++ b/compose/cryostat_docker.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/cryostat_k8s.yml
+++ b/compose/cryostat_k8s.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/db-viewer.yml
+++ b/compose/db-viewer.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db-viewer:
     depends_on:

--- a/compose/db.yml
+++ b/compose/db.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/grafana_no_proxy.yml
+++ b/compose/grafana_no_proxy.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/jfr-datasource.yml
+++ b/compose/jfr-datasource.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/no_proxy.yml
+++ b/compose/no_proxy.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     hostname: cryostat

--- a/compose/reports.yml
+++ b/compose/reports.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/s3-cloudserver.yml
+++ b/compose/s3-cloudserver.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/s3-localstack.yml
+++ b/compose/s3-localstack.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/s3-minio.yml
+++ b/compose/s3-minio.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/s3-none.yml
+++ b/compose/s3-none.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     environment:

--- a/compose/s3-seaweed.yml
+++ b/compose/s3-seaweed.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   cryostat:
     depends_on:

--- a/compose/s3_no_proxy.yml
+++ b/compose/s3_no_proxy.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   s3:
     ports:

--- a/compose/sample_apps/gameserver-jdk11.yml
+++ b/compose/sample_apps/gameserver-jdk11.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gameserver-jdk11:
     depends_on:

--- a/compose/sample_apps/gameserver-jdk17.yml
+++ b/compose/sample_apps/gameserver-jdk17.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gameserver-jdk17:
     depends_on:

--- a/compose/sample_apps/gameserver-jdk21.yml
+++ b/compose/sample_apps/gameserver-jdk21.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gameserver-jdk21:
     depends_on:

--- a/compose/sample_apps/opensearch.yml
+++ b/compose/sample_apps/opensearch.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   opensearch-node:
     image: docker.io/opensearchproject/opensearch:latest

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   quarkus-cryostat-agent:
     image: ${QUARKUS_TEST_IMAGE:-quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest}

--- a/compose/sample_apps/quarkus-cryostat-agent_https.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent_https.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   quarkus-cryostat-agent:
     environment:

--- a/compose/sample_apps/spring-boot-2-7.yml
+++ b/compose/sample_apps/spring-boot-2-7.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   spring-boot-2-7:
     depends_on:

--- a/compose/sample_apps/spring-boot-3.yml
+++ b/compose/sample_apps/spring-boot-3.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   spring-boot-3:
     depends_on:

--- a/compose/sample_apps/vertx-cryostat-agent.yml
+++ b/compose/sample_apps/vertx-cryostat-agent.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   vertx-agent-1:
     depends_on:

--- a/compose/sample_apps/wildfly-23.yml
+++ b/compose/sample_apps/wildfly-23.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   wildfly-23:
     depends_on:

--- a/compose/sample_apps/wildfly-28.yml
+++ b/compose/sample_apps/wildfly-28.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   wildfly-28:
     depends_on:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #609

## Description of the change:
1. Restores the Cryostat healthcheck which was disabled in #609. This mysteriously stopped working on that upgrade. Now after updating my workstation to Fedora 40, which comes with newer versions of `docker-compose` and things, it complained that the container did not have a defined healthcheck. Re-enabling the old one now seems to work.
2. Removes the 'version' declarations from compose manifests. The newer `docker-compose` version warns that these declarations are deprecated/obsolete and will be ignored.

## Motivation for the change:
After upgrading my workstation from Fedora 39 to 40, these changes are required for `bash smoketest.bash -t` to work as normal again.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
