### PR TITLE
feat(k8s): implement wildcard All Namespaces discovery

### DIFF
--- a/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeApiDiscovery.java
@@ -133,6 +133,10 @@ public class KubeApiDiscovery implements ResourceEventHandler<Endpoints> {
                                         .inform(
                                                 KubeApiDiscovery.this,
                                                 informerResyncPeriod.toMillis()));
+                        logger.debugv(
+                                "Started Endpoints SharedInformer for all namespaces with resync"
+                                        + " period {0}",
+                                informerResyncPeriod);
                     } else {
                         kubeConfig
                                 .getWatchNamespaces()

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -135,8 +135,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                                 KubeEndpointSlicesDiscovery.this,
                                                 informerResyncPeriod.toMillis()));
                         logger.debugv(
-                                "Started Endpoints SharedInformer for all namespaces with resync"
-                                        + " period {0}",
+                                "Started EndpointSlice SharedInformer for all namespaces with"
+                                        + " resync period {0}",
                                 informerResyncPeriod);
                     } else {
                         kubeConfig
@@ -155,8 +155,9 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                                                     informerResyncPeriod
                                                                             .toMillis()));
                                             logger.debugv(
-                                                    "Started Endpoints SharedInformer for namespace"
-                                                            + " \"{0}\" with resync period {1}",
+                                                    "Started EndpointSlice SharedInformer for"
+                                                        + " namespace \"{0}\" with resync period"
+                                                        + " {1}",
                                                     ns, informerResyncPeriod);
                                         });
                     }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -297,12 +297,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 for (String addr : addresses) {
                     var ref = endpoint.getTargetRef();
                     if (ref == null) {
-                        logger.debugv(
-                                "Endpoints object {0} in {1} with address {2} had a null"
-                                        + " targetRef",
-                                endpoints.getMetadata().getName(),
-                                endpoints.getMetadata().getNamespace(),
-                                addr.getIp());
                         continue;
                     }
                     tts.add(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,8 @@ cryostat.discovery.kubernetes.port-numbers=
 cryostat.discovery.kubernetes.namespaces=
 cryostat.discovery.kubernetes.namespace-path=/var/run/secrets/kubernetes.io/serviceaccount/namespace
 cryostat.discovery.kubernetes.resync-period=30s
+# TODO thoroughly test if discovery Informers can now be trusted and forced resync can be disabled/removed
+cryostat.discovery.kubernetes.force-resync.enabled=true
 kubernetes.service.host=
 
 quarkus.test.integration-test-profile=test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #722
Depends on #689
Based on #689
Depends on #740

## Description of the change:
Handles the `*` value in Kubernetes discovery namespaces as a wildcard indicating "All Namespaces". When this is found then, rather than creating an Endpoints Informer for each target namespace, Cryostat creates a single Informer for Endpoints in any namespace in the cluster. A few pieces of supporting logic are modified to suit this change, ex. grabbing the client-side cache (in Cryostat application memory) and doing per-namespace filtering of Endpoints objects found in that cluster-wide Informer, rather than having each Informer's cache already be segmented by namespace.

## Motivation for the change:
When suitably deployed in a Kubernetes cluster - with accompanying ClusterRole(Binding) to allow the serviceaccount to discover Endpoints cluster-wide - this allows the user to install a single Cryostat instance and have visibility of applications in any namespace. This also includes the possibility that namespaces are created or deleted within Cryostat's lifetime. Users should take care to carefully select the port names/numbers that will be deemed as compatible targets, since Cryostat will see every single Endpoints object in the cluster. Cryostat may also see a *large* number of update events from Kubernetes if the cluster is large and active with many Endpoints changes, which may be burdensome and resource intensive.

## How to manually test:
1. See https://github.com/cryostatio/cryostat-helm/pull/213
