### PR TITLE
fix(eventtemplates): log warning and continue if declarative Event Template already exists

### DIFF
--- a/src/main/java/io/cryostat/events/S3TemplateService.java
+++ b/src/main/java/io/cryostat/events/S3TemplateService.java
@@ -115,6 +115,8 @@ public class S3TemplateService implements MutableTemplateService {
                                         | InvalidXmlException
                                         | InvalidEventTemplateException e) {
                                     logger.error(e);
+                                } catch (IllegalArgumentException e) {
+                                    logger.warn(e);
                                 }
                             });
         } catch (IOException e) {
@@ -225,8 +227,7 @@ public class S3TemplateService implements MutableTemplateService {
             var template = createTemplate(model);
             var existing = getTemplates();
             if (existing.stream().anyMatch(t -> Objects.equals(t.getName(), template.getName()))) {
-                throw new IllegalArgumentException(
-                        String.format("Duplicate event template name: %s", template.getName()));
+                throw new DuplicateTemplateException(template.getName());
             }
             storage.putObject(
                     PutObjectRequest.builder()
@@ -356,5 +357,11 @@ public class S3TemplateService implements MutableTemplateService {
                 .map(i -> i.getValue())
                 .findFirst()
                 .get();
+    }
+
+    static class DuplicateTemplateException extends IllegalArgumentException {
+        DuplicateTemplateException(String templateName) {
+            super(String.format("Event Template with name \"%s\" already exists", templateName));
+        }
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #718

## Description of the change:
Tolerate already existing Event Templates when loading from container filesystem at startup.

## Motivation for the change:
Declarative configurations for Event Templates (ie defining them by mounting files to the container, ex. by Operator CR linking to ConfigMaps) should be tolerant of the templates already existing, since they will already exist in the remote S3 storage service if the Cryostat container has been restarted, for example.

## How to manually test:
1. See associated Helm PR. Deploy with that, then `oc rollout restart deployment cryostat-v4` to trigger the case where the template already exists in storage. With this PR, Cryostat should log a warning and continue. Without this PR, Cryostat will not catch the exception and will fail startup, leading to a container restart loop.
