### PR TITLE
feat(matchexpressions): expressions can reference target JFR event type IDs

### DIFF
--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -274,9 +274,9 @@ public class MatchExpressionEvaluator {
             return List.of(
                     EnvOption.declarations(
                             Decls.newFunction(
-                                    "eventTypeIds",
+                                    "jfrEventTypeIds",
                                     Decls.newOverload(
-                                            "eventTypeIds_void",
+                                            "jfrEventTypeIds_void",
                                             List.of(
                                                     Decls.newObjectType(
                                                             SimplifiedTarget.class.getName())),
@@ -288,14 +288,14 @@ public class MatchExpressionEvaluator {
             return List.of(
                     ProgramOption.functions(
                             Overload.unary(
-                                    "eventTypeIds",
+                                    "jfrEventTypeIds",
                                     (arg) ->
                                             ListT.newStringArrayList(
-                                                    getEventTypeIds(
+                                                    getJfrEventTypeIds(
                                                             (SimplifiedTarget) arg.value())))));
         }
 
-        private String[] getEventTypeIds(SimplifiedTarget st) {
+        private String[] getJfrEventTypeIds(SimplifiedTarget st) {
             Target target = Target.find("id", st.id()).singleResult();
             try {
                 return connectionManager.executeConnectedTask(

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -124,7 +124,7 @@ public class MatchExpressionEvaluator {
     }
 
     @CacheResult(cacheName = CACHE_NAME)
-    boolean load(Target target, String matchExpression) throws ScriptException {
+    boolean load(String matchExpression, Target target) throws ScriptException {
         Script script = createScript(matchExpression);
         return script.execute(Boolean.class, Map.of("target", SimplifiedTarget.from(target)));
     }
@@ -159,7 +159,7 @@ public class MatchExpressionEvaluator {
         MatchExpressionApplies evt = new MatchExpressionApplies(matchExpression);
         try {
             evt.begin();
-            return load(target, matchExpression.script);
+            return load(matchExpression.script, target);
         } catch (CompletionException e) {
             if (e.getCause() instanceof ScriptException) {
                 throw (ScriptException) e.getCause();

--- a/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
+++ b/src/main/java/io/cryostat/expressions/MatchExpressionEvaluator.java
@@ -296,7 +296,6 @@ public class MatchExpressionEvaluator {
         }
 
         private String[] getEventTypeIds(SimplifiedTarget st) {
-            Log.infov("Target: {0}", st);
             Target target = Target.find("id", st.id()).singleResult();
             try {
                 return connectionManager.executeConnectedTask(

--- a/src/test/java/io/cryostat/expressions/MatchExpressionsTest.java
+++ b/src/test/java/io/cryostat/expressions/MatchExpressionsTest.java
@@ -72,7 +72,18 @@ public class MatchExpressionsTest extends AbstractTransactionalTestBase {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"true, 200, true", "false, 200, false", "this is garbage, 400, false"})
+    @CsvSource(
+            delimiter = '|',
+            value = {
+                "true | 200 | true",
+                "false | 200 | false",
+                "this is garbage | 400 | false",
+                "target.alias == 'selftest' | 200 | true",
+                "target.alias == '' | 200 | false",
+                "eventTypeIds(target).exists(x, x.contains('jdk')) | 200 | true",
+                "eventTypeIds(target).exists(t, t.contains('nonsense')) | 200 | false",
+                "eventTypeIds(target).exists(x, t.contains('wrong binding')) | 400 | false",
+            })
     public void testExpressionTest(String expr, int status, boolean expectTargets) {
         int id = defineSelfCustomTarget();
 

--- a/src/test/java/io/cryostat/expressions/MatchExpressionsTest.java
+++ b/src/test/java/io/cryostat/expressions/MatchExpressionsTest.java
@@ -80,9 +80,9 @@ public class MatchExpressionsTest extends AbstractTransactionalTestBase {
                 "this is garbage | 400 | false",
                 "target.alias == 'selftest' | 200 | true",
                 "target.alias == '' | 200 | false",
-                "eventTypeIds(target).exists(x, x.contains('jdk')) | 200 | true",
-                "eventTypeIds(target).exists(t, t.contains('nonsense')) | 200 | false",
-                "eventTypeIds(target).exists(x, t.contains('wrong binding')) | 400 | false",
+                "jfrEventTypeIds(target).exists(x, x.contains('jdk')) | 200 | true",
+                "jfrEventTypeIds(target).exists(t, t.contains('nonsense')) | 200 | false",
+                "jfrEventTypeIds(target).exists(x, t.contains('wrong binding')) | 400 | false",
             })
     public void testExpressionTest(String expr, int status, boolean expectTargets) {
         int id = defineSelfCustomTarget();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/733#issuecomment-2524038050
Related to https://github.com/cryostatio/cryostat/issues/727
Related to https://github.com/cryostatio/cryostat/issues/548

## Description of the change:
See https://github.com/cryostatio/cryostat/pull/733#issuecomment-2524038050

## Motivation for the change:
Enables the creation of match expressions that evaluate the JFR event types available on a given target JVM. This probably isn't very useful for Stored Credentials, but for Automated Rules it will couple well with #733 , as well as with custom application-level JFR events. It becomes possible to define Automated Rules that use a preset or custom event template containing framework- or application-level events, and only activate on targets where those event types are actually present. For example, a Rule can be created that matches Quarkus applications which have the `quarkus-jfr` extension enabled.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O`
3. Open UI
4. Go to Automated Rules > Create
5. See https://github.com/cryostatio/cryostat/pull/733#issuecomment-2524038050 .  In #733 Cryostat itself adds the `quarkus-jfr` extension, so if these two PRs are combined then the Quarkus-specific events referenced in that comment can be used. Otherwise, an event type ID like `jdk.CPULoad` can be used to test the expression evaluation.
