### PR TITLE
fix(uri-validation): Validate URI ranges for discovery plugins and related targets

### DIFF
--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -201,8 +201,15 @@ public class Discovery {
                             callbackUri));
         }
 
-        // TODO apply URI range validation to the remote address
         InetAddress remoteAddress = getRemoteAddress(ctx);
+        URI remoteURI = new URI(remoteAddress.getHostAddress());
+        if (!uriUtil.validateUri(remoteURI)) {
+            throw new BadRequestException(
+                    String.format(
+                            "Remote Address of \"%s\" is unacceptable with the"
+                                    + " current URI range settings",
+                            remoteURI));
+        }
         URI location;
         DiscoveryPlugin plugin;
         if (StringUtils.isNotBlank(pluginId) && StringUtils.isNotBlank(priorToken)) {
@@ -312,6 +319,14 @@ public class Discovery {
         plugin.realm.children.addAll(body);
         for (var b : body) {
             if (b.target != null) {
+                // URI range validation
+                if (!uriUtil.validateUri(b.target.connectUrl)) {
+                    throw new BadRequestException(
+                            String.format(
+                                    "Connect URL of \"%s\" is unacceptable with the"
+                                            + " current URI range settings",
+                                    b.target.connectUrl));
+                }
                 b.target.discoveryNode = b;
                 b.target.discoveryNode.parent = plugin.realm;
                 b.parent = plugin.realm;

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.targets;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.recordings.ActiveRecording;
+import io.cryostat.util.URIUtil;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
@@ -278,6 +280,7 @@ public class Target extends PanacheEntity {
     @ApplicationScoped
     static class Listener {
 
+        @Inject URIUtil uriUtil;
         @Inject Logger logger;
         @Inject EventBus bus;
 
@@ -290,7 +293,17 @@ public class Target extends PanacheEntity {
             if (!Objects.equals(encodedAlias, target.alias)) {
                 target.alias = encodedAlias;
             }
-
+            try {
+                if (!uriUtil.validateUri(target.connectUrl)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Connect URL of \"%s\" is unacceptable with the"
+                                            + " current URI range settings",
+                                    target.connectUrl));
+                }
+            } catch (MalformedURLException me) {
+                throw new IllegalArgumentException();
+            }
             if (target.labels == null) {
                 target.labels = new HashMap<>();
             }

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -302,7 +302,7 @@ public class Target extends PanacheEntity {
                                     target.connectUrl));
                 }
             } catch (MalformedURLException me) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(me);
             }
             if (target.labels == null) {
                 target.labels = new HashMap<>();


### PR DESCRIPTION
Hi,

This addresses https://github.com/cryostatio/cryostat/issues/685 , adding URI range validation to discovery plugins and related targets, and validating the target connecturl range in the prePersist hooks.

