### PR TITLE
fix(tls): use TLS by default in the Agent Client

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -22,6 +22,7 @@ services:
       CRYOSTAT_DISCOVERY_JDP_ENABLED: ${CRYOSTAT_DISCOVERY_JDP_ENABLED:-true}
       CRYOSTAT_DISCOVERY_PODMAN_ENABLED: ${CRYOSTAT_DISCOVERY_PODMAN_ENABLED:-true}
       CRYOSTAT_DISCOVERY_DOCKER_ENABLED: ${CRYOSTAT_DISCOVERY_DOCKER_ENABLED:-true}
+      CRYOSTAT_AGENT_TLS_REQUIRED: ${ENFORCE_AGENT_TLS:-true}
       JAVA_OPTS_APPEND: >-
         -XX:+FlightRecorder
         -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -26,6 +26,7 @@ DEPLOY_GRAFANA=${DEPLOY_GRAFANA:-true}
 DRY_RUN=${DRY_RUN:-false}
 USE_TLS=${USE_TLS:-true}
 SAMPLE_APPS_USE_TLS=${SAMPLE_APPS_USE_TLS:-true}
+ENFORCE_AGENT_TLS=${ENFORCE_AGENT_TLS:-true}
 
 display_usage() {
     echo "Usage:"
@@ -91,6 +92,7 @@ while getopts "hs:prGtAOVXc:bnk" opt; do
             ;;
         A)
             SAMPLE_APPS_USE_TLS=false
+            ENFORCE_AGENT_TLS=false
             ;;
         O)
             PULL_IMAGES=false

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -60,5 +60,5 @@ public class ConfigProperties {
 
     public static final String URI_RANGE = "cryostat.target.uri-range";
 
-    public static final String AGENT_TLS_ENABLED = "cryostat.agent.tls.enabled";
+    public static final String AGENT_TLS_REQUIRED = "cryostat.agent.tls.required";
 }

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -59,4 +59,6 @@ public class ConfigProperties {
     public static final String SSL_TRUSTSTORE_DIR = "ssl.truststore.dir";
 
     public static final String URI_RANGE = "cryostat.target.uri-range";
+
+    public static final String AGENT_TLS_ENABLED = "cryostat.agent.tls.enabled";
 }

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -215,7 +215,7 @@ public class Discovery {
                             remoteURI));
         }
 
-        if (agentTlsRequired && !remoteURI.getScheme().equals("https")) {
+        if (agentTlsRequired && !callbackUri.getScheme().equals("https")) {
             throw new BadRequestException(
                     String.format(
                             "TLS for agent connections is required by (%s)",
@@ -339,7 +339,7 @@ public class Discovery {
                                             + " current URI range settings",
                                     b.target.connectUrl));
                 }
-                if (agentTlsRequired && !b.target.connectUrl.getScheme().equals("https")) {
+                if (agentTlsRequired && !plugin.callback.getScheme().equals("https")) {
                     throw new BadRequestException(
                             String.format(
                                     "TLS for agent connections is required by (%s)",

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -339,12 +339,23 @@ public class Discovery {
                                             + " current URI range settings",
                                     b.target.connectUrl));
                 }
-                if (agentTlsRequired && !b.target.connectUrl.getScheme().equals("https")) {
-                    throw new BadRequestException(
-                            String.format(
-                                    "TLS for agent connections is required by (%s)",
-                                    ConfigProperties.AGENT_TLS_REQUIRED));
+                if (!uriUtil.isJmxUrl(b.target.connectUrl)) {
+                    if (agentTlsRequired && !b.target.connectUrl.getScheme().equals("https")) {
+                        throw new BadRequestException(
+                                String.format(
+                                        "TLS for agent connections is required by (%s)",
+                                        ConfigProperties.AGENT_TLS_REQUIRED));
+                    }
+                    if (!b.target.connectUrl.getScheme().equals("https")
+                            && !b.target.connectUrl.getScheme().equals("http")) {
+                        throw new BadRequestException(
+                                String.format(
+                                        "Target connect URL is neither JMX nor HTTP(S): (%s)",
+                                        b.target.connectUrl.toString()));
+                    }
                 }
+                // Continue since we've verified the connect URL is either JMX or HTTPS with
+                // TLS verification enabled, or HTTP with TLS verification disabled.
                 b.target.discoveryNode = b;
                 b.target.discoveryNode.parent = plugin.realm;
                 b.parent = plugin.realm;

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -339,7 +339,7 @@ public class Discovery {
                                             + " current URI range settings",
                                     b.target.connectUrl));
                 }
-                if (agentTlsRequired && !plugin.callback.getScheme().equals("https")) {
+                if (agentTlsRequired && !b.target.connectUrl.getScheme().equals("https")) {
                     throw new BadRequestException(
                             String.format(
                                     "TLS for agent connections is required by (%s)",

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -71,6 +71,9 @@ public class AgentClient {
 
     public static final String NULL_CREDENTIALS = "No credentials found for agent";
 
+    @ConfigProperty(name = ConfigProperties.AGENT_TLS_ENABLED)
+    private boolean TLS_ENABLED;
+
     private final Target target;
     private final WebClient webClient;
     private final Duration httpTimeout;

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -462,7 +462,7 @@ public class AgentClient {
         HttpRequest<T> req =
                 webClient
                         .request(mtd, getUri().getPort(), getUri().getHost(), path)
-                        .ssl("https".equals(getUri().getScheme()) && tlsEnabled)
+                        .ssl("https".equals(getUri().getScheme()))
                         .timeout(httpTimeout.toMillis())
                         .followRedirects(true)
                         .as(codec)

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -71,7 +71,7 @@ public class AgentClient {
 
     public static final String NULL_CREDENTIALS = "No credentials found for agent";
 
-    @ConfigProperty(name = ConfigProperties.AGENT_TLS_ENABLED)
+    @ConfigProperty(name = ConfigProperties.AGENT_TLS_REQUIRED)
     private boolean tlsEnabled;
 
     private final Target target;
@@ -451,7 +451,7 @@ public class AgentClient {
                     String.format(
                             "Agent is configured with TLS enabled (%s) but the agent URI is not an"
                                     + " https connection.",
-                            ConfigProperties.AGENT_TLS_ENABLED));
+                            ConfigProperties.AGENT_TLS_REQUIRED));
         }
 
         Credential credential =

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -28,6 +28,7 @@ import org.openjdk.jmc.rjmx.common.ConnectionException;
 import org.openjdk.jmc.rjmx.common.IConnectionHandle;
 import org.openjdk.jmc.rjmx.common.ServiceNotAvailableException;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.core.net.CryostatFlightRecorderService;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.templates.RemoteTemplateService;
@@ -40,6 +41,8 @@ import io.cryostat.libcryostat.sys.Clock;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 class AgentConnection implements JFRConnection {
@@ -47,6 +50,9 @@ class AgentConnection implements JFRConnection {
     private final AgentClient client;
     private final TemplateService customTemplateService;
     private final Logger logger = Logger.getLogger(getClass());
+
+    @ConfigProperty(name = ConfigProperties.AGENT_TLS_ENABLED)
+    private static boolean TLS_ENABLED;
 
     AgentConnection(AgentClient client, TemplateService customTemplateService) {
         this.client = client;
@@ -86,7 +92,11 @@ class AgentConnection implements JFRConnection {
     }
 
     public static boolean isAgentConnection(URI uri) {
-        return Set.of("http", "https", "cryostat-agent").contains(uri.getScheme());
+        if (TLS_ENABLED) {
+            return Set.of("https", "cryostat-agent").contains(uri.getScheme());
+        } else {
+            return Set.of("http", "https", "cryostat-agent").contains(uri.getScheme());
+        }
     }
 
     @Override

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -41,7 +41,6 @@ import io.cryostat.libcryostat.sys.Clock;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -16,6 +16,7 @@
 package io.cryostat.targets;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Set;
 
@@ -50,8 +51,8 @@ class AgentConnection implements JFRConnection {
     private final TemplateService customTemplateService;
     private final Logger logger = Logger.getLogger(getClass());
 
-    @ConfigProperty(name = ConfigProperties.AGENT_TLS_ENABLED)
-    private static boolean TLS_ENABLED;
+    @ConfigProperty(name = ConfigProperties.AGENT_TLS_REQUIRED)
+    private static boolean TLS_REQUIRED;
 
     AgentConnection(AgentClient client, TemplateService customTemplateService) {
         this.client = client;
@@ -161,8 +162,15 @@ class AgentConnection implements JFRConnection {
         @Inject S3TemplateService customTemplateService;
         @Inject Logger logger;
 
-        public AgentConnection createConnection(Target target) {
-            return new AgentConnection(clientFactory.create(target), customTemplateService);
+        public AgentConnection createConnection(Target target) throws MalformedURLException {
+            if (TLS_REQUIRED && target.connectUrl.getScheme().equals("https")) {
+                return new AgentConnection(clientFactory.create(target), customTemplateService);
+            } else {
+                throw new MalformedURLException(
+                        String.format(
+                                "Agent connections are required to be TLS by (%s)",
+                                ConfigProperties.AGENT_TLS_REQUIRED));
+            }
         }
     }
 }

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -91,11 +91,7 @@ class AgentConnection implements JFRConnection {
     }
 
     public static boolean isAgentConnection(URI uri) {
-        if (TLS_ENABLED) {
-            return Set.of("https", "cryostat-agent").contains(uri.getScheme());
-        } else {
-            return Set.of("http", "https", "cryostat-agent").contains(uri.getScheme());
-        }
+        return Set.of("http", "https", "cryostat-agent").contains(uri.getScheme());
     }
 
     @Override

--- a/src/main/java/io/cryostat/util/URIUtil.java
+++ b/src/main/java/io/cryostat/util/URIUtil.java
@@ -53,7 +53,7 @@ public class URIUtil {
         return URIRange.fromString(uriRange).validate(uri.getHost());
     }
 
-    boolean isJmxUrl(URI uri) {
+    public boolean isJmxUrl(URI uri) {
         try {
             new JMXServiceURL(uri.toString());
             return true;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,7 +46,7 @@ cryostat.http.proxy.path=/
 
 cryostat.target.uri-range=PUBLIC
 
-cryostat.agent.tls.enabled=true
+cryostat.agent.tls.required=true
 
 conf-dir=/opt/cryostat.d
 templates-dir=${conf-dir}/templates.d

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,8 @@ cryostat.http.proxy.path=/
 
 cryostat.target.uri-range=PUBLIC
 
+cryostat.agent.tls.enabled=true
+
 conf-dir=/opt/cryostat.d
 templates-dir=${conf-dir}/templates.d
 preset-templates-dir=${conf-dir}/presets.d


### PR DESCRIPTION
Hi,

This is the other half to https://github.com/cryostatio/cryostat-agent/pull/554 , enforcing TLS by default on the server side for agent communication. Controlled by a configuration option cryostat.agent.tls.enabled

Addresses https://github.com/cryostatio/cryostat/issues/686