### PR TITLE
feat(rules): implement declarative Automated Rules

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -93,6 +93,7 @@ ENTRYPOINT [ "/deployments/app/entrypoint.bash", "/opt/jboss/container/java/run/
 # We make distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 src/main/docker/include/cryostat.jfc /usr/lib/jvm/jre/lib/jfr/
 COPY --chown=185 src/main/docker/include/template_presets/* /opt/cryostat.d/presets.d/
+COPY --chown=185 src/main/docker/include/rule_presets/* /opt/cryostat.d/rules.d/
 COPY --chown=185 src/main/docker/include/genpass.bash /deployments/app/
 COPY --chown=185 src/main/docker/include/entrypoint.bash /deployments/app/
 COPY --chown=185 src/main/docker/include/truststore-setup.bash /deployments/app/

--- a/src/main/docker/include/rule_presets/quarkus.json
+++ b/src/main/docker/include/rule_presets/quarkus.json
@@ -1,0 +1,7 @@
+{
+    "name": "quarkus",
+    "description": "Preset Automated Rule for enabling Quarkus framework-specific events when available",
+    "eventSpecifier": "template=Quarkus,type=PRESET",
+    "matchExpression": "jfrEventTypeIds(target).exists(x, x.contains(\"quarkus\"))",
+    "enabled": false
+}

--- a/src/main/docker/include/rule_presets/quarkus.json
+++ b/src/main/docker/include/rule_presets/quarkus.json
@@ -2,6 +2,6 @@
     "name": "quarkus",
     "description": "Preset Automated Rule for enabling Quarkus framework-specific events when available",
     "eventSpecifier": "template=Quarkus,type=PRESET",
-    "matchExpression": "jfrEventTypeIds(target).exists(x, x.contains(\"quarkus\"))",
+    "matchExpression": "jfrEventTypeIds(target).exists(x, x.startsWith(\"quarkus\"))",
     "enabled": false
 }

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -57,6 +57,7 @@ public class ConfigProperties {
     public static final String CUSTOM_TEMPLATES_DIR = "templates-dir";
     public static final String PRESET_TEMPLATES_DIR = "preset-templates-dir";
     public static final String SSL_TRUSTSTORE_DIR = "ssl.truststore.dir";
+    public static final String RULES_DIR = "rules-dir";
 
     public static final String URI_RANGE = "cryostat.target.uri-range";
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,7 @@ cryostat.target.uri-range=PUBLIC
 cryostat.agent.tls.required=true
 
 conf-dir=/opt/cryostat.d
+rules-dir=${conf-dir}/rules.d
 templates-dir=${conf-dir}/templates.d
 preset-templates-dir=${conf-dir}/presets.d
 ssl.truststore=${conf-dir}/truststore.p12

--- a/src/test/java/itest/PresetRulesIT.java
+++ b/src/test/java/itest/PresetRulesIT.java
@@ -19,11 +19,8 @@ import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.openjdk.jmc.flightrecorder.configuration.events.EventConfiguration;
-import org.openjdk.jmc.flightrecorder.configuration.model.xml.XMLAttributeInstance;
-import org.openjdk.jmc.flightrecorder.configuration.model.xml.XMLModel;
-import org.openjdk.jmc.flightrecorder.configuration.model.xml.XMLTagInstance;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -31,16 +28,15 @@ import io.vertx.ext.web.client.HttpRequest;
 import itest.bases.StandardSelfTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-public class PresetTemplatesIT extends StandardSelfTest {
+public class PresetRulesIT extends StandardSelfTest {
 
     @Test
-    public void shouldListPresetTemplates() throws Exception {
+    public void shouldListPresetRules() throws Exception {
         CompletableFuture<JsonArray> future = new CompletableFuture<>();
-        HttpRequest<Buffer> req = webClient.get("/api/v4/event_templates/PRESET");
+        HttpRequest<Buffer> req = webClient.get("/api/v4/rules");
         req.send(
                 ar -> {
                     if (ar.failed()) {
@@ -54,30 +50,28 @@ public class PresetTemplatesIT extends StandardSelfTest {
     }
 
     @Test
-    public void shouldHavePresetQuarkusTemplate() throws Exception {
-        String url = "/api/v4/event_templates/PRESET/Quarkus";
+    public void shouldHavePresetQuarkusRule() throws Exception {
+        String url = "/api/v4/rules/quarkus";
         File file =
-                downloadFile(url, "quarkus", ".jfc")
+                downloadFile(url, "quarkus", ".json")
                         .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .toFile();
 
-        XMLModel model = EventConfiguration.createModel(file);
-        model.checkErrors();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode json = mapper.readTree(file);
 
-        Assertions.assertFalse(model.hasErrors());
-
-        XMLTagInstance configuration = model.getRoot();
-        XMLAttributeInstance labelAttr = null;
-        for (XMLAttributeInstance attr : configuration.getAttributeInstances()) {
-            if (attr.getAttribute().getName().equals("label")) {
-                labelAttr = attr;
-                break;
-            }
-        }
-
-        MatcherAssert.assertThat(labelAttr, Matchers.notNullValue());
-
-        String templateName = labelAttr.getExplicitValue();
-        MatcherAssert.assertThat(templateName, Matchers.equalTo("Quarkus"));
+        MatcherAssert.assertThat(json.get("name").asText(), Matchers.equalTo("quarkus"));
+        MatcherAssert.assertThat(
+                json.get("description").asText(),
+                Matchers.equalTo(
+                        "Preset Automated Rule for enabling Quarkus framework-specific events when"
+                                + " available"));
+        MatcherAssert.assertThat(
+                json.get("eventSpecifier").asText(),
+                Matchers.equalTo("template=Quarkus,type=PRESET"));
+        MatcherAssert.assertThat(
+                json.get("matchExpression").asText(),
+                Matchers.equalTo("jfrEventTypeIds(target).exists(x, x.contains(\"quarkus\"))"));
+        MatcherAssert.assertThat(json.get("enabled").asBoolean(), Matchers.is(false));
     }
 }

--- a/src/test/java/itest/PresetRulesIT.java
+++ b/src/test/java/itest/PresetRulesIT.java
@@ -71,7 +71,7 @@ public class PresetRulesIT extends StandardSelfTest {
                 Matchers.equalTo("template=Quarkus,type=PRESET"));
         MatcherAssert.assertThat(
                 json.get("matchExpression").asText(),
-                Matchers.equalTo("jfrEventTypeIds(target).exists(x, x.contains(\"quarkus\"))"));
+                Matchers.equalTo("jfrEventTypeIds(target).exists(x, x.startsWith(\"quarkus\"))"));
         MatcherAssert.assertThat(json.get("enabled").asBoolean(), Matchers.is(false));
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on https://github.com/cryostatio/cryostat/pull/735
Depends on https://github.com/cryostatio/cryostat/pull/735
Fixes https://github.com/cryostatio/cryostat/issues/548
Fixes https://github.com/cryostatio/cryostat/issues/727

## Description of the change:
Adds a declarative configuration directory for Automated Rules and implements loading definitions from this directory at startup.

## Motivation for the change:
This will allow users to preload Automated Rules into their Cryostat installations without needing to go through the web UI or API calls. It also allows us to ship pre-written Rule definitions as part of the base container image.

For practical usage, end users who are using JMX for target connections should have JMX authentication configured. In that case, https://github.com/cryostatio/cryostat/issues/720 would also need to be complete for the user to make full use of declarative Automated Rules. Otherwise, users can declaratively configure their own Automated Rules, but will still need to go through the UI or API to define the corresponding stored credentials. For users who are using the Cryostat Agent this will already work out of the box, since the Agent registers its own stored credentials.

Since this also provides preset Automated Rules as part of the container image, it's also useful as a way for us to ship example rule configurations for users to reference when crafting their own.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O`
3. Open Web UI
4. Go to Automated Rules view. There should already be a `quarkus` Rule predefined as part of this PR.
5. Cryostat itself is a compatible Target for the `quarkus` Rule. Enable the Rule and an `auto_quarkus` recording should be started on Cryostat. See #735 and #733
