### PR TITLE
feat(preset): add preset template and rule for Hibernate JFR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.15.3</quarkus.platform.version>
     <quarkus-quinoa.version>2.5.1</quarkus-quinoa.version>
-    <org.hibernate.orm.hibernate.jfr.version>6.6.1.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match these version? -->
+    <org.hibernate.orm.hibernate.jfr.version>6.6.4.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match this version? -->
     <org.codehaus.mojo.build.helper.plugin.version>3.6.0</org.codehaus.mojo.build.helper.plugin.version>
     <org.codehaus.mojo.exec.plugin.version>3.5.0</org.codehaus.mojo.exec.plugin.version>
     <assembly-plugin.version>3.7.1</assembly-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.15.3</quarkus.platform.version>
     <quarkus-quinoa.version>2.5.1</quarkus-quinoa.version>
+    <org.hibernate.orm.hibernate.jfr.version>6.6.1.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match these version? -->
     <org.codehaus.mojo.build.helper.plugin.version>3.6.0</org.codehaus.mojo.build.helper.plugin.version>
     <org.codehaus.mojo.exec.plugin.version>3.5.0</org.codehaus.mojo.exec.plugin.version>
     <assembly-plugin.version>3.7.1</assembly-plugin.version>
@@ -198,6 +199,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-jfr</artifactId>
+      <version>${org.hibernate.orm.hibernate.jfr.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.15.3</quarkus.platform.version>
     <quarkus-quinoa.version>2.5.1</quarkus-quinoa.version>
-    <org.hibernate.orm.hibernate.jfr.version>6.6.4.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match this version? -->
+    <org.hibernate.orm.hibernate.jfr.version>6.6.3.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match this version? -->
     <org.codehaus.mojo.build.helper.plugin.version>3.6.0</org.codehaus.mojo.build.helper.plugin.version>
     <org.codehaus.mojo.exec.plugin.version>3.5.0</org.codehaus.mojo.exec.plugin.version>
     <assembly-plugin.version>3.7.1</assembly-plugin.version>

--- a/src/main/docker/include/rule_presets/hibernate.json
+++ b/src/main/docker/include/rule_presets/hibernate.json
@@ -1,0 +1,7 @@
+{
+    "name": "hibernate",
+    "description": "Preset Automated Rule for enabling Hibernate ORM events when available",
+    "eventSpecifier": "template=Hibernate,type=PRESET",
+    "matchExpression": "jfrEventTypeIds(target).exists(x, x.startsWith(\"org.hibernate.orm.\"))",
+    "enabled": false
+}

--- a/src/main/docker/include/rule_presets/quarkus.json
+++ b/src/main/docker/include/rule_presets/quarkus.json
@@ -2,6 +2,6 @@
     "name": "quarkus",
     "description": "Preset Automated Rule for enabling Quarkus framework-specific events when available",
     "eventSpecifier": "template=Quarkus,type=PRESET",
-    "matchExpression": "jfrEventTypeIds(target).exists(x, x.startsWith(\"quarkus\"))",
+    "matchExpression": "jfrEventTypeIds(target).exists(x, x.startsWith(\"quarkus.\"))",
     "enabled": false
 }

--- a/src/main/docker/include/template_presets/hibernate.jfc
+++ b/src/main/docker/include/template_presets/hibernate.jfc
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="Hibernate" description="Hibernate ORM events" provider="Cryostat">
+  <event name="org.hibernate.orm.CacheGet">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.CachePut">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.DirtyCalculationEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.FlushEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.JdbcBatchExecution">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.JdbcConnectionAcquisition">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.JdbcConnectionRelease">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.JdbcPreparedStatementCreation">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.JdbcPreparedStatementExecution">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.PartialFlushEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.PrePartialFlushEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.SessionClosed">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="org.hibernate.orm.SessionOpen">
+    <setting name="enabled">true</setting>
+  </event>
+</configuration>

--- a/src/main/docker/include/template_presets/quarkus.jfc
+++ b/src/main/docker/include/template_presets/quarkus.jfc
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration version="2.0" label="Quarkus" description="Quarkus-specific REST events" provider="Cryostat">
-    <event name="quarkus.Rest">
-      <setting name="enabled">true</setting>
-    </event>
-    <event name="quarkus.RestStart">
-      <setting name="enabled">true</setting>
-    </event>
-    <event name="quarkus.RestEnd">
-      <setting name="enabled">true</setting>
-    </event>
+  <event name="quarkus.Rest">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="quarkus.RestStart">
+    <setting name="enabled">true</setting>
+  </event>
+  <event name="quarkus.RestEnd">
+    <setting name="enabled">true</setting>
+  </event>
 </configuration>

--- a/src/test/java/itest/PresetTemplatesIT.java
+++ b/src/test/java/itest/PresetTemplatesIT.java
@@ -16,6 +16,8 @@
 package itest;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -33,9 +35,13 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
 public class PresetTemplatesIT extends StandardSelfTest {
+
+    static final String[] TEMPLATE_NAMES = new String[] {"Quarkus", "Hibernate"};
 
     @Test
     public void shouldListPresetTemplates() throws Exception {
@@ -50,14 +56,19 @@ public class PresetTemplatesIT extends StandardSelfTest {
                     future.complete(ar.result().bodyAsJsonArray());
                 });
         JsonArray response = future.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        MatcherAssert.assertThat(response.size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(response.size(), Matchers.equalTo(TEMPLATE_NAMES.length));
     }
 
-    @Test
-    public void shouldHavePresetQuarkusTemplate() throws Exception {
-        String url = "/api/v4/event_templates/PRESET/Quarkus";
+    static List<String> templateNames() {
+        return Arrays.asList(TEMPLATE_NAMES);
+    }
+
+    @ParameterizedTest
+    @MethodSource("templateNames")
+    public void shouldHaveExpectedPresetTemplates(String templateName) throws Exception {
+        String url = String.format("/api/v4/event_templates/PRESET/%s", templateName);
         File file =
-                downloadFile(url, "quarkus", ".jfc")
+                downloadFile(url, templateName, ".jfc")
                         .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .toFile();
 
@@ -77,7 +88,7 @@ public class PresetTemplatesIT extends StandardSelfTest {
 
         MatcherAssert.assertThat(labelAttr, Matchers.notNullValue());
 
-        String templateName = labelAttr.getExplicitValue();
-        MatcherAssert.assertThat(templateName, Matchers.equalTo("Quarkus"));
+        String name = labelAttr.getExplicitValue();
+        MatcherAssert.assertThat(name, Matchers.equalTo(templateName));
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #736
See also #548
Depends on https://github.com/cryostatio/cryostat/pull/749
Based on https://github.com/cryostatio/cryostat/pull/749

## Description of the change:
Adds a Preset Event Template for Hibernate JFR events, which are enabled by the `hibernate-jfr` dependency. Any application using Hibernate which also has this JAR on its classpath should have the relevant JFR event types registered, and they can be emitted simply by starting a recording with them enabled. Also adds an Automated Rule which detects the presence of these event types in the target JVM, for ease of enablement by the end user.

## Motivation for the change:
Provides a quick and easy way for Cryostat + Hibernate users to get very detailed profiling information about the internals of their Hibernate sessions, transactions, etc. - simply install the `hibernate-jfr` dependency, redeploy the target application, and turn on the preset Automated Rule for Hibernate.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O`
3. Open Web UI
4. Go to Automated Rules view
5. Enable the Hibernate rule
6. An `auto_hibernate` recording should be started in Cryostat. Click around the UI a bunch to generate load, then download the recording. `jfr print --events 'org.hibernate.orm.*' auto_hibernate.jfr` should reveal lots of JFR data.
