### PR TITLE
test(itest): increase timeouts for CI

### DIFF
--- a/src/test/java/itest/bases/StandardSelfTest.java
+++ b/src/test/java/itest/bases/StandardSelfTest.java
@@ -64,8 +64,8 @@ public abstract class StandardSelfTest {
     private static final ExecutorService WORKER = Executors.newCachedThreadPool();
     public static final Logger logger = Logger.getLogger(StandardSelfTest.class);
     public static final ObjectMapper mapper;
-    public static final int REQUEST_TIMEOUT_SECONDS = 15;
-    public static final int DISCOVERY_DEADLINE_SECONDS = 10;
+    public static final int REQUEST_TIMEOUT_SECONDS = 30;
+    public static final int DISCOVERY_DEADLINE_SECONDS = 60;
     public static final TestWebClient webClient = Utils.getWebClient();
     public static volatile String selfCustomTargetLocation;
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See recent CI runs. The arm64 test runs frequently time out waiting for discovery, but with enough re-runs they will pass. This looks like it's likely just a combination of total CI load and the fact that the arm64 runs are running in cross-architecture emulation, which dramatically slows things down.
