### PR TITLE
fix(credentials): ensure deletion occurs within transaction context

### DIFF
--- a/src/main/java/io/cryostat/JsonRequestFilter.java
+++ b/src/main/java/io/cryostat/JsonRequestFilter.java
@@ -19,9 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,7 +44,7 @@ public class JsonRequestFilter implements ContainerRequestFilter {
                     "/api/v4/matchExpressions",
                     "/api/v4/graphql");
 
-    private final Map<String, Pattern> compiledPatterns = new HashMap<>();
+    private final Map<String, Pattern> compiledPatterns = new ConcurrentHashMap<>();
     @Inject ObjectMapper objectMapper;
 
     @Override

--- a/src/main/java/io/cryostat/targets/TargetUpdateService.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateService.java
@@ -31,6 +31,7 @@ import io.quarkus.vertx.ConsumeEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.JobBuilder;
@@ -77,17 +78,20 @@ public class TargetUpdateService {
         scheduler.shutdown();
     }
 
-    @ConsumeEvent(Credential.CREDENTIALS_STORED)
+    @ConsumeEvent(value = Credential.CREDENTIALS_STORED, blocking = true)
+    @Transactional
     void onCredentialsStored(Credential credential) {
         updateTargetsForExpression(credential);
     }
 
-    @ConsumeEvent(Credential.CREDENTIALS_UPDATED)
+    @ConsumeEvent(value = Credential.CREDENTIALS_UPDATED, blocking = true)
+    @Transactional
     void onCredentialsUpdated(Credential credential) {
         updateTargetsForExpression(credential);
     }
 
-    @ConsumeEvent(Credential.CREDENTIALS_DELETED)
+    @ConsumeEvent(value = Credential.CREDENTIALS_DELETED, blocking = true)
+    @Transactional
     void onCredentialsDeleted(Credential credential) {
         updateTargetsForExpression(credential);
     }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -12,6 +12,7 @@ quarkus.http.cors.access-control-allow-credentials=true
 # quarkus.http.cors.methods=GET,PUT,POST,PATCH,OPTIONS
 # quarkus.http.cors.access-control-max-age=1s
 
+quarkus.log.level=ALL
 quarkus.hibernate-orm.log.sql=true
 
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #753

## Description of the change:
Ensures transaction context is active when processing credential deletions in particular situations.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. Check out PR
2. Apply this patch:
```patch
diff --git a/src/main/java/io/cryostat/discovery/Discovery.java b/src/main/java/io/cryostat/discovery/Discovery.java
index 508dbd55..0279cc46 100644
--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -215,6 +215,9 @@ public class Discovery {
                             remoteURI));
         }
 
+        if (true) {
+            throw new BadRequestException();
+        }
         if (agentTlsRequired && !callbackUri.getScheme().equals("https")) {
             throw new BadRequestException(
                     String.format(
```
3. Build PR
4. `./smoketest.bash -O -t quarkus-cryostat-agent`
5. Because of the patch above, the Agent instance should fail to register itself with Cryostat. Check Cryostat's logs when this happens. Before this PR, exceptions like in #753 will be seen. With this PR the logs should be clean when the Agent instance fails to register and tries to clean up its own credentials.
6. Alternatively, simply open the web UI and go to Security, then define a credential. Then try to delete it, and check the Cryostat logs immediately after. The same kind of stack trace should appear if this PR is not applied. Requires https://github.com/cryostatio/cryostat-web/pull/1513