### PR TITLE
fix(db): use text constraints, not limited size data types

### DIFF
--- a/src/main/resources/db/migration/V4.0.0__cryostat.sql
+++ b/src/main/resources/db/migration/V4.0.0__cryostat.sql
@@ -19,7 +19,7 @@
         maxAge bigint not null,
         maxSize bigint not null,
         metadata jsonb,
-        name varchar(255),
+        name text check (char_length(name) < 64),
         remoteId bigint not null,
         startTime bigint not null,
         state smallint check (state between 0 and 4),
@@ -40,8 +40,8 @@
     create table DiscoveryNode (
         id bigint not null,
         labels jsonb,
-        name varchar(255) not null,
-        nodeType varchar(255) not null,
+        name text not null check (char_length(name) < 255),
+        nodeType text not null check (char_length(nodeType) < 255),
         parentNode bigint,
         primary key (id)
     );
@@ -49,7 +49,7 @@
     create table DiscoveryPlugin (
         id uuid not null,
         builtin boolean not null,
-        callback varchar(255) unique,
+        callback text unique,
         credential_id bigint unique,
         realm_id bigint not null unique,
         primary key (id)
@@ -57,20 +57,20 @@
 
     create table MatchExpression (
         id bigint not null,
-        script varchar(255) not null,
+        script text not null check (char_length(script) < 1024),
         primary key (id)
     );
 
     create table Rule (
         id bigint not null,
         archivalPeriodSeconds integer not null,
-        description varchar(255),
+        description text check (char_length(description) < 1024),
         enabled boolean not null,
-        eventSpecifier varchar(255) not null,
+        eventSpecifier text not null check (char_length(eventSpecifier) < 255),
         initialDelaySeconds integer not null,
         maxAgeSeconds integer not null,
         maxSizeBytes integer not null,
-        name varchar(255) unique,
+        name text unique check (char_length(name) < 255),
         preservedArchives integer not null,
         matchExpression bigint unique,
         primary key (id)
@@ -78,10 +78,10 @@
 
     create table Target (
         id bigint not null,
-        alias varchar(255),
+        alias text check (char_length(alias) < 255),
         annotations jsonb,
         connectUrl bytea unique,
-        jvmId varchar(255),
+        jvmId text check (char_length(jvmId) < 255),
         labels jsonb,
         discoveryNode bigint unique,
         primary key (id)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #667

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
