### PR TITLE
test(storage): deploy cryostat-storage rather than localstack

### DIFF
--- a/src/test/java/itest/CustomEventTemplateTest.java
+++ b/src/test/java/itest/CustomEventTemplateTest.java
@@ -15,6 +15,9 @@
  */
 package itest;
 
+import io.cryostat.resources.S3StorageResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.buffer.Buffer;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@QuarkusTestResource(S3StorageResource.class)
 @DisabledOnIntegrationTest("classpath resources are not loadable in integration test")
 public class CustomEventTemplateTest extends StandardSelfTest {
 

--- a/src/test/java/itest/GraphQLTest.java
+++ b/src/test/java/itest/GraphQLTest.java
@@ -41,10 +41,12 @@ import java.util.stream.Collectors;
 
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.RootNode;
+import io.cryostat.resources.S3StorageResource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -65,6 +67,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
+@QuarkusTestResource(S3StorageResource.class)
 @TestMethodOrder(OrderAnnotation.class)
 class GraphQLTest extends StandardSelfTest {
 

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.cryostat.resources.LocalStackResource;
+import io.cryostat.resources.S3StorageResource;
 import io.cryostat.util.HttpMimeType;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(LocalStackResource.class)
+@QuarkusTestResource(S3StorageResource.class)
 public class RecordingWorkflowTest extends StandardSelfTest {
 
     private final ExecutorService worker = ForkJoinPool.commonPool();

--- a/src/test/java/itest/ReportGenerationTest.java
+++ b/src/test/java/itest/ReportGenerationTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import io.cryostat.resources.LocalStackResource;
+import io.cryostat.resources.S3StorageResource;
 import io.cryostat.util.HttpMimeType;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(LocalStackResource.class)
+@QuarkusTestResource(S3StorageResource.class)
 public class ReportGenerationTest extends StandardSelfTest {
 
     private final ExecutorService worker = ForkJoinPool.commonPool();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #759

## Description of the change:
Sets up the tests (unit and integration) to deploy `cryostat-storage` rather than `localstack` as the S3 storage instance.

## Motivation for the change:
This allows us to have some level of automated integration testing between Cryostat and our SeaweedFS soft fork to ensure things are working as expected.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
