### PR TITLE
fix(api): Fix location header for archived report generation

### DIFF
--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -103,11 +103,7 @@ public class Reports {
         return Response.ok(request.getId(), MediaType.TEXT_PLAIN)
                 .status(202)
                 .location(
-                        UriBuilder.fromUri(
-                                        String.format(
-                                                "/api/v4/targets/%d/reports/%d",
-                                                pair.getLeft(), pair.getRight()))
-                                .build())
+                        UriBuilder.fromUri(String.format("/api/v4/reports/%s", encodedKey)).build())
                 .build();
     }
 
@@ -129,7 +125,9 @@ public class Reports {
 
         // Check if we've already cached a result for this report, return it if so
         if (reportsService.keyExists(recording)) {
-            return Response.ok(reportsService.reportFor(recording).await().atMost(timeout))
+            return Response.ok(
+                            reportsService.reportFor(recording).await().atMost(timeout),
+                            MediaType.APPLICATION_JSON)
                     .status(200)
                     .build();
         }

--- a/src/test/java/io/cryostat/reports/ReportsTest.java
+++ b/src/test/java/io/cryostat/reports/ReportsTest.java
@@ -113,7 +113,17 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                 .assertThat()
                 .statusCode(202)
                 .contentType(ContentType.TEXT)
-                .body(Matchers.any(String.class));
+                .body(Matchers.any(String.class))
+                .assertThat()
+                // 202 Indicates report generation is in progress and sends an intermediate
+                // response.
+                // Verify we get a location header from a 202.
+                .header(
+                        "Location",
+                        "http://localhost:8081/api/v4/targets/"
+                                + targetId
+                                + "/reports/"
+                                + remoteId);
 
         given().log()
                 .all()
@@ -165,7 +175,12 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                 .assertThat()
                 .statusCode(202)
                 .contentType(ContentType.TEXT)
-                .body(Matchers.any(String.class));
+                .body(Matchers.any(String.class))
+                .assertThat()
+                // 202 Indicates report generation is in progress and sends an intermediate
+                // response.
+                // Verify we get a location header from a 202.
+                .header("Location", "http://localhost:8081" + reportUrl);
 
         given().log()
                 .all()

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -192,7 +192,6 @@ public class RecordingWorkflowTest extends StandardSelfTest {
                     Matchers.matchesRegex(
                             TARGET_ALIAS + "_" + TEST_RECORDING_NAME + "_[\\d]{8}T[\\d]{6}Z.jfr"));
             String savedDownloadUrl = recordingInfo.getString("downloadUrl");
-
             Thread.sleep(3_000L); // wait for the dump to complete
 
             // verify the in-memory recording list has not changed, except recording is now stopped
@@ -250,6 +249,7 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             MatcherAssert.assertThat(
                     reportResponse.statusCode(),
                     Matchers.both(Matchers.greaterThanOrEqualTo(200)).and(Matchers.lessThan(300)));
+            MatcherAssert.assertThat(reportResponse.getHeader("Location"), Matchers.notNullValue());
             MatcherAssert.assertThat(reportResponse.bodyAsString(), Matchers.notNullValue());
 
             // Check that report generation concludes


### PR DESCRIPTION
Fixes #762

Hi,

This addresses https://github.com/cryostatio/cryostat/issues/762 . The location header that was returned with the request when the cache missed and the report needed to be generated was incorrect, this caused the following sequence of events to happen:

- Client sends report generation request
- Server sees that the report isn't in the cache, kicks off report generation and tries to return an intermediate response to the client
- Location Header on the last step was incorrect causing an exception which returned a 400 to the client despite report generation proceeding as expected.
-  Subsequent requests succeeded because at that point the report was cached.

This fixes the location header and adds a missing content type header to active report generation.
