### PR TITLE
fix(notifications): Fix notification String constants

### DIFF
--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -48,9 +48,9 @@ public class LongRunningRequestGenerator {
     public static final String ACTIVE_REPORT_ADDRESS =
             "io.cryostat.recordings.ArchiveRequestGenerator.ActiveReportRequest";
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
-    private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailed";
+    private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailure";
     private static final String GRAFANA_UPLOAD_SUCCESS = "GrafanaUploadSuccess";
-    private static final String GRAFANA_UPLOAD_FAIL = "GrafanaUploadFailed";
+    private static final String GRAFANA_UPLOAD_FAIL = "GrafanaUploadFailure";
     private static final String REPORT_SUCCESS = "ReportSuccess";
     private static final String REPORT_FAILURE = "ReportFailure";
 


### PR DESCRIPTION
Fixes: [#761](https://github.com/cryostatio/cryostat/issues/761)

## Description of the change:
Fixes the notification category for ArchiveRecordingFailure and GrafanaUploadFailure to bring them in line with what the web frontend expects.

## How to manually test:
1. Run cryostat via ./mvnw quarkus:dev or smoketest
2. Fail to archive a recording (Can induce this by throwing an exception at the start of the try/catch in LongRunningRequestGenerator.java (line 71 for archive, 90, 107 for grafana))
3. Observe that the notifications are emitted.
