### PR TITLE
fix(notifications): Restore missing notification when archiving recordings

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -18,6 +18,7 @@ package io.cryostat.recordings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -913,6 +914,28 @@ public class RecordingHelper {
             // Amazon S3 couldn't be contacted for a response, or the client
             // couldn't parse the response from Amazon S3.
             throw e;
+        }
+        if (expiry == null) {
+            ArchivedRecording archivedRecording =
+                    new ArchivedRecording(
+                            recording.target.jvmId,
+                            filename,
+                            downloadUrl(recording.target.jvmId, filename),
+                            reportUrl(recording.target.jvmId, filename),
+                            recording.metadata,
+                            accum,
+                            now.getEpochSecond());
+
+            URI connectUrl = recording.target.connectUrl;
+
+            var event =
+                    new ArchivedRecordingEvent(
+                            ActiveRecordings.RecordingEventCategory.ARCHIVED_CREATED,
+                            ArchivedRecordingEvent.Payload.of(connectUrl, archivedRecording));
+            bus.publish(event.category().category(), event.payload().recording());
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(event.category().category(), event.payload()));
         }
         return new ArchivedRecording(
                 recording.target.jvmId,


### PR DESCRIPTION
Fixes #781 

During the development of the long running api framework this notification got removed as it was causing problems with the implementation at that time. After iterating more and finishing the implementation of the framework I missed adding this back. This adds it back, fixing 781 and making automated rules archiving behave as expected in the UI.

![notifs](https://github.com/user-attachments/assets/5cade030-0970-40e7-9140-256b7289ac68)
