### PR TITLE
test(smoketest): add quarkus-petclinic sample

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -4,7 +4,7 @@ services:
       resources:
         limits:
           cpus: "2"
-          memory: 512m
+          memory: 1024m
     image: ${CRYOSTAT_IMAGE:-quay.io/cryostat/cryostat:latest}
     volumes:
       - ${XDG_RUNTIME_DIR}/podman/podman.sock:/run/user/1000/podman/podman.sock:Z

--- a/compose/sample_apps/quarkus-petclinic.yml
+++ b/compose/sample_apps/quarkus-petclinic.yml
@@ -1,0 +1,53 @@
+services:
+  quarkus-petclinic:
+    image: ${QUARKUS_PETCLINIC_IMAGE:-quay.io/redhat-java-monitoring/quarkus-petclinic:latest}
+    hostname: quarkus-petclinic
+    depends_on:
+      quarkus-petclinic-db:
+        condition: service_healthy
+    ports:
+      - "10011:10011"
+    labels:
+      io.cryostat.discovery: "true"
+      io.cryostat.jmxHost: "quarkus-petclinic"
+      io.cryostat.jmxPort: "11223"
+    environment:
+      JAVA_OPTS_APPEND: >-
+        -Dquarkus.http.host=0.0.0.0
+        -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+        -Dcom.sun.management.jmxremote.autodiscovery=false
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=11223
+        -Dcom.sun.management.jmxremote.rmi.port=11223
+        -Djava.rmi.server.hostname=quarkus-petclinic
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Dcom.sun.management.jmxremote.local.only=false
+      QUARKUS_HTTP_PORT: 10011
+      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://quarkus-petclinic-db:5432/petclinic
+    restart: always
+    healthcheck:
+      test: curl --fail http://localhost:10010 || exit 1
+      interval: 10s
+      retries: 3
+      start_period: 30s
+      timeout: 5s
+
+  quarkus-petclinic-db:
+    image: "postgres:14"
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 128m
+    environment:
+      - POSTGRES_USER=developer
+      - POSTGRES_PASSWORD=developer
+      - POSTGRES_DB=petclinic
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --dbname $$POSTGRES_DB --username $$POSTGRES_USER"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Depends on https://github.com/cryostatio/test-applications/pull/32

## Description of the change:
Adds a more complex sample application for testing.

## Motivation for the change:
This sample application is more interactive than many of the others, and this one includes `quarkus-jfr` and `hibernate-jfr` so can be used as a test for the functionalities integrating those event templates and automated rules.

See https://github.com/cryostatio/cryostat/pull/750
See https://github.com/cryostatio/cryostat/pull/733

## How to manually test:
1. Check out PR
2. `./smoketest.bash -Ot quarkus-petclinic`. If https://github.com/cryostatio/test-applications/pull/32 isn't merged yet, check out that PR and `cd quarkus-petclinic ; TAGS=latest ./build.bash` to build it locally first.
3. Wait for everything to come up. Open `https://localhost:8443` Cryostat UI. Open `http://localhost:10011` petclinic UI.
4. In Cryostat UI, ensure petclinic sample is discovered. Go to Event Types and ensure that hibernate events are registered. quarkus-jfr events should also be registered but this doesn't always seem to happen eagerly.
5. Go to Automated Rules and enable the hibernate rule. Ensure that a recording is created on the petclinic.
6. Go to Recordings and manually create a recording using the quarkus preset event template on the petclinic.
7. Go to petclinic UI and click around for a while.
8. Go back to Cryostat UI and download one of the active recordings. `jfr summary myfile.jfr | grep -e 'quarkus\|hibernate'` should return lots of results.