### PR TITLE
fix(events): permit JFR Event Types without label attributes

### DIFF
--- a/src/main/java/io/cryostat/events/SerializableEventTypeInfo.java
+++ b/src/main/java/io/cryostat/events/SerializableEventTypeInfo.java
@@ -27,15 +27,17 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public record SerializableEventTypeInfo(
-        String name,
         String typeId,
+        String name,
         String description,
         String[] category,
         Map<String, SerializableOptionDescriptor> options) {
 
     public SerializableEventTypeInfo {
-        Objects.requireNonNull(name);
         Objects.requireNonNull(typeId);
+        if (name == null) {
+            name = "";
+        }
         if (description == null) {
             description = "";
         }
@@ -61,6 +63,6 @@ public record SerializableEventTypeInfo(
                     SerializableOptionDescriptor.fromOptionDescriptor(entry.getValue()));
         }
 
-        return new SerializableEventTypeInfo(name, typeId, description, category, options);
+        return new SerializableEventTypeInfo(typeId, name, description, category, options);
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/803
Depends on https://github.com/cryostatio/cryostat-core/pull/507

## Description of the change:
JFR events do not necessarily have the `label` attribute, which in the JMC API is called `name`. The OpenJDK built-in events all happen to have this attribute, but custom application or framework events may not, and notably GraalVM has at least one event type (`EveryChunkPeriodEvents`) which has no label.

## Motivation for the change:
Unlabelled JFR events would cause an NPE on `/api/v4/targets/{id}/events` query before this.

## How to manually test:
1. Combine with https://github.com/cryostatio/cryostat-core/pull/507 and https://github.com/cryostatio/test-applications/pull/34
2. `./mvnw -o clean package`
3. `./smoketest.bash -O -t quarkus-native`
4. Open Cryostat UI, go to Events. Select `jmxquarkus` target. Ensure that Event Types table populates. Ensure that a recording can be started, archived, automated-analysis'd, etc.
