### PR TITLE
chore(quay): switch more images to quay.io alternatives

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -112,6 +112,30 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.testcontainers.properties
+        write-mode: overwrite
+        contents: |
+          docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+          ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+          ryuk.container.privileged=true
+          testcontainers.reuse.enable=false
+          tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.config/containers/registries.conf.d/999-block-docker-io.conf
+        write-mode: overwrite
+        contents: |
+          [[registry]]
+          location = "docker.io"
+          blocked = true
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: /etc/hosts
+        write-mode: append
+        contents: |
+          0.0.0.0 docker.io index.docker.io
     - run: git submodule init && git submodule update
     - name: Cache yarn packages
       uses: actions/cache@v4

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -52,6 +52,30 @@ jobs:
       packages: write
       contents: read
     steps:
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.testcontainers.properties
+        write-mode: overwrite
+        contents: |
+          docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+          ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+          ryuk.container.privileged=true
+          testcontainers.reuse.enable=false
+          tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.config/containers/registries.conf.d/999-block-docker-io.conf
+        write-mode: overwrite
+        contents: |
+          [[registry]]
+          location = "docker.io"
+          blocked = true
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: /etc/hosts
+        write-mode: append
+        contents: |
+          0.0.0.0 docker.io index.docker.io
     - name: Add CRIU PPA
       run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
     - name: Install podman 4
@@ -118,6 +142,30 @@ jobs:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.testcontainers.properties
+        write-mode: overwrite
+        contents: |
+          docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+          ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+          ryuk.container.privileged=true
+          testcontainers.reuse.enable=false
+          tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.config/containers/registries.conf.d/999-block-docker-io.conf
+        write-mode: overwrite
+        contents: |
+          [[registry]]
+          location = "docker.io"
+          blocked = true
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: /etc/hosts
+        write-mode: append
+        contents: |
+          0.0.0.0 docker.io index.docker.io
     - name: Install podman 4
       run: |
         sudo apt update
@@ -167,6 +215,30 @@ jobs:
     env:
       CI_ARCH: ${{ matrix.arch }}
     steps:
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.testcontainers.properties
+        write-mode: overwrite
+        contents: |
+          docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+          ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+          ryuk.container.privileged=true
+          testcontainers.reuse.enable=false
+          tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.config/containers/registries.conf.d/999-block-docker-io.conf
+        write-mode: overwrite
+        contents: |
+          [[registry]]
+          location = "docker.io"
+          blocked = true
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: /etc/hosts
+        write-mode: append
+        contents: |
+          0.0.0.0 docker.io index.docker.io
     - uses: actions/checkout@v4
       with:
         submodules: true
@@ -206,6 +278,30 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [get-pom-properties, build-images, unit-test, integration-test]
     steps:
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.testcontainers.properties
+        write-mode: overwrite
+        contents: |
+          docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+          ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+          ryuk.container.privileged=true
+          testcontainers.reuse.enable=false
+          tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: $HOME/.config/containers/registries.conf.d/999-block-docker-io.conf
+        write-mode: overwrite
+        contents: |
+          [[registry]]
+          location = "docker.io"
+          blocked = true
+    - uses: DamianReeves/write-file-action@v1.3
+      with:
+        path: /etc/hosts
+        write-mode: append
+        contents: |
+          0.0.0.0 docker.io index.docker.io
     - name: Add CRIU PPA
       run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
     - name: Install podman 4

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
 
 `$HOME/.testcontainers.properties`
 ```properties
-ryuk.container.privileged=true
 docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+ryuk.container.privileged=true
 testcontainers.reuse.enable=false
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
 ```properties
 docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
 ryuk.container.image=quay.io/infinispan-test/ryuk\:0.8.1
+tinyimage.container.image=registry.access.redhat.com/ubi9/ubi-micro
 ryuk.container.privileged=true
 testcontainers.reuse.enable=false
 ```

--- a/compose/s3-localstack.yml
+++ b/compose/s3-localstack.yml
@@ -15,7 +15,7 @@ services:
       AWS_ACCESS_KEY_ID: unused
       AWS_SECRET_ACCESS_KEY: unused
   s3:
-    image: ${LOCALSTACK_IMAGE:-docker.io/localstack/localstack:stable}
+    image: ${LOCALSTACK_IMAGE:-quay.io/hazelcast_cloud/localstack:4.1.1}
     hostname: s3
     expose:
       - "4566"

--- a/compose/s3-minio.yml
+++ b/compose/s3-minio.yml
@@ -15,7 +15,7 @@ services:
       AWS_ACCESS_KEY_ID: minioroot
       AWS_SECRET_ACCESS_KEY: minioroot
   s3:
-    image: ${MINIO_IMAGE:-docker.io/minio/minio:latest}
+    image: ${MINIO_IMAGE:-quay.io/minio/minio:latest}
     hostname: s3
     expose:
       - "9000"

--- a/compose/sample_apps/opensearch.yml
+++ b/compose/sample_apps/opensearch.yml
@@ -1,6 +1,6 @@
 services:
   opensearch-node:
-    image: docker.io/opensearchproject/opensearch:latest
+    image: quay.io/openstack.kolla/opensearch:2024.1-rocky-9
     hostname: opensearch-node
     environment:
       discovery.type: single-node
@@ -23,7 +23,7 @@ services:
       # - "9600" # Performance Analyzer
 
   opensearch-dashboards:
-    image: docker.io/opensearchproject/opensearch-dashboards:latest
+    image: quay.io/openstack.kolla/opensearch-dashboards:2024.1-rocky-9
     hostname: opensearch-dashboards
     ports:
       - 5601:5601

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -36,9 +36,9 @@ quarkus.datasource.devservices.db-name=quarkus
 # !!!
 
 quarkus.s3.devservices.enabled=true
-quarkus.s3.devservices.buckets=archivedrecordings
+quarkus.s3.devservices.buckets=archivedrecordings,archivedreports,eventtemplates,probes
 # FIXME the following overrides should not be required, but currently seem to help with testcontainers reliability
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:2.1.0
+quarkus.aws.devservices.localstack.image-name=quay.io/hazelcast_cloud/localstack:4.1.1
 quarkus.aws.devservices.localstack.container-properties.START_WEB=0
 quarkus.aws.devservices.localstack.container-properties.SERVICES=s3
 quarkus.aws.devservices.localstack.container-properties.EAGER_SERVICE_LOADING=1

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -26,6 +26,7 @@ quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db
 quarkus.flyway.clean-at-start=true
 
 # !!! prod databases must set this configuration parameter some other way via a secret !!!
+quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db:latest
 quarkus.datasource.devservices.container-env.PG_ENCRYPT_KEY=examplekey
 quarkus.datasource.devservices.container-env.POSTGRESQL_USER=quarkus
 quarkus.datasource.devservices.container-env.POSTGRESQL_PASSWORD=quarkus

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -28,5 +28,7 @@ quarkus.datasource.devservices.username=quarkus
 quarkus.datasource.devservices.password=quarkus
 quarkus.datasource.devservices.db-name=quarkus
 
-quarkus.s3.devservices.enabled=false
+quarkus.aws.devservices.localstack.image-name=quay.io/hazelcast_cloud/localstack:4.1.1
+quarkus.s3.devservices.enabled=true
+quarkus.s3.devservices.buckets=archivedrecordings,archivedreports,eventtemplates,probes
 # !!!

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -20,6 +20,7 @@ cryostat.services.reports.memory-cache.enabled=false
 cryostat.services.reports.storage-cache.enabled=false
 
 # !!! prod databases must set this configuration parameter some other way via a secret !!!
+quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db:latest
 quarkus.datasource.devservices.container-env.PG_ENCRYPT_KEY=examplekey
 quarkus.datasource.devservices.container-env.POSTGRESQL_USER=quarkus
 quarkus.datasource.devservices.container-env.POSTGRESQL_PASSWORD=quarkus


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
