### PR TITLE
ci(github): remove privileged step

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -130,12 +130,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - uses: DamianReeves/write-file-action@v1.3
-      with:
-        path: /etc/hosts
-        write-mode: append
-        contents: |
-          0.0.0.0 docker.io index.docker.io
     - run: git submodule init && git submodule update
     - name: Cache yarn packages
       uses: actions/cache@v4

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -70,12 +70,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - uses: DamianReeves/write-file-action@v1.3
-      with:
-        path: /etc/hosts
-        write-mode: append
-        contents: |
-          0.0.0.0 docker.io index.docker.io
     - name: Add CRIU PPA
       run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
     - name: Install podman 4
@@ -160,12 +154,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - uses: DamianReeves/write-file-action@v1.3
-      with:
-        path: /etc/hosts
-        write-mode: append
-        contents: |
-          0.0.0.0 docker.io index.docker.io
     - name: Install podman 4
       run: |
         sudo apt update
@@ -233,12 +221,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - uses: DamianReeves/write-file-action@v1.3
-      with:
-        path: /etc/hosts
-        write-mode: append
-        contents: |
-          0.0.0.0 docker.io index.docker.io
     - uses: actions/checkout@v4
       with:
         submodules: true
@@ -296,12 +278,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - uses: DamianReeves/write-file-action@v1.3
-      with:
-        path: /etc/hosts
-        write-mode: append
-        contents: |
-          0.0.0.0 docker.io index.docker.io
     - name: Add CRIU PPA
       run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
     - name: Install podman 4


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
