### PR TITLE
ci(github): use explicit path for runner home

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -114,7 +114,7 @@ jobs:
         cache: 'maven'
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.testcontainers.properties
+        path: /home/runner/.testcontainers.properties
         write-mode: overwrite
         contents: |
           docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
@@ -124,7 +124,7 @@ jobs:
           testcontainers.reuse.enable=false
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.config/containers/registries.conf.d/999-block-docker-io.conf
+        path: /home/runner/.config/containers/registries.conf.d/999-block-docker-io.conf
         write-mode: overwrite
         contents: |
           [[registry]]

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.testcontainers.properties
+        path: /home/runner/.testcontainers.properties
         write-mode: overwrite
         contents: |
           docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
@@ -64,7 +64,7 @@ jobs:
           testcontainers.reuse.enable=false
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.config/containers/registries.conf.d/999-block-docker-io.conf
+        path: /home/runner/.config/containers/registries.conf.d/999-block-docker-io.conf
         write-mode: overwrite
         contents: |
           [[registry]]
@@ -138,7 +138,7 @@ jobs:
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.testcontainers.properties
+        path: /home/runner/.testcontainers.properties
         write-mode: overwrite
         contents: |
           docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
@@ -148,7 +148,7 @@ jobs:
           testcontainers.reuse.enable=false
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.config/containers/registries.conf.d/999-block-docker-io.conf
+        path: /home/runner/.config/containers/registries.conf.d/999-block-docker-io.conf
         write-mode: overwrite
         contents: |
           [[registry]]
@@ -205,7 +205,7 @@ jobs:
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.testcontainers.properties
+        path: /home/runner/.testcontainers.properties
         write-mode: overwrite
         contents: |
           docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
@@ -215,7 +215,7 @@ jobs:
           testcontainers.reuse.enable=false
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.config/containers/registries.conf.d/999-block-docker-io.conf
+        path: /home/runner/.config/containers/registries.conf.d/999-block-docker-io.conf
         write-mode: overwrite
         contents: |
           [[registry]]
@@ -262,7 +262,7 @@ jobs:
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.testcontainers.properties
+        path: /home/runner/.testcontainers.properties
         write-mode: overwrite
         contents: |
           docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
@@ -272,7 +272,7 @@ jobs:
           testcontainers.reuse.enable=false
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: ~/.config/containers/registries.conf.d/999-block-docker-io.conf
+        path: /home/runner/.config/containers/registries.conf.d/999-block-docker-io.conf
         write-mode: overwrite
         contents: |
           [[registry]]


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
