### PR TITLE
ci(github): re-enable qemu for single-arch testcontainers

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -130,6 +130,8 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
+    - name: install qemu
+      run: dnf install -y qemu
     - run: git submodule init && git submodule update
     - name: Cache yarn packages
       uses: actions/cache@v4
@@ -155,9 +157,9 @@ jobs:
         yarn install && yarn yarn:frzinstall
         cd -
     - name: Add CRIU PPA
-      run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
+      run: sudo add-apt-repository ppa:criu/ppa
     - name: Ensure podman 4+ and podman-docker installed
-      run: sudo apt update && sudo apt -y satisfy "podman (>= 4.0), podman-docker"
+      run: sudo apt update && sudo apt -y satisfy "podman (>= 4.0), podman-docker, qemu-user-static"
     - name: Start Podman API
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -71,11 +71,11 @@ jobs:
           location = "docker.io"
           blocked = true
     - name: Add CRIU PPA
-      run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
-    - name: Install podman 4
+      run: sudo add-apt-repository ppa:criu/ppa
+    - name: Install podman 4 and qemu
       run: |
         sudo apt update
-        sudo apt -y satisfy "podman (>= 4.0)"
+        sudo apt -y satisfy "podman (>= 4.0), qemu-user-static"
     - uses: actions/checkout@v4
       with:
         submodules: true
@@ -154,10 +154,10 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - name: Install podman 4
+    - name: Install podman 4 and qemu
       run: |
         sudo apt update
-        sudo apt -y satisfy "podman (>= 4.0)"
+        sudo apt -y satisfy "podman (>= 4.0), qemu-user-static"
     - uses: actions/checkout@v4
       with:
         submodules: true
@@ -279,11 +279,11 @@ jobs:
           location = "docker.io"
           blocked = true
     - name: Add CRIU PPA
-      run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
-    - name: Install podman 4
+      run: sudo add-apt-repository ppa:criu/ppa
+    - name: Install podman 4 and qemu
       run: |
         sudo apt update
-        sudo apt -y satisfy "podman (>= 4.0)"
+        sudo apt -y satisfy "podman (>= 4.0), qemu-user-static"
     - name: Download container tarballs
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
