### PR TITLE
test(storage): deploy cryostat-storage instead of localstack

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -130,8 +130,6 @@ jobs:
           [[registry]]
           location = "docker.io"
           blocked = true
-    - name: install qemu
-      run: dnf install -y qemu
     - run: git submodule init && git submodule update
     - name: Cache yarn packages
       uses: actions/cache@v4

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -29,7 +29,5 @@ quarkus.datasource.devservices.username=quarkus
 quarkus.datasource.devservices.password=quarkus
 quarkus.datasource.devservices.db-name=quarkus
 
-quarkus.aws.devservices.localstack.image-name=quay.io/hazelcast_cloud/localstack:4.1.1
-quarkus.s3.devservices.enabled=true
-quarkus.s3.devservices.buckets=archivedrecordings,archivedreports,eventtemplates,probes
+quarkus.s3.devservices.enabled=false
 # !!!

--- a/src/test/java/io/cryostat/AbstractTestBase.java
+++ b/src/test/java/io/cryostat/AbstractTestBase.java
@@ -19,8 +19,10 @@ import static io.restassured.RestAssured.given;
 
 import java.time.Duration;
 
+import io.cryostat.resources.S3StorageResource;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.restassured.http.ContentType;
 import jakarta.inject.Inject;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 
+@QuarkusTestResource(S3StorageResource.class)
 public abstract class AbstractTestBase {
 
     public static final String SELF_JMX_URL = "service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi";


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
