### PR TITLE
ci(github): disable ryuk

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -9,6 +9,9 @@ on:
     types:
       - created
 
+env:
+  TESTCONTAINERS_RYUK_DISABLED: true
+
 jobs:
   check-before-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -19,6 +19,7 @@ env:
   CI_USER: cryostat+bot
   CI_REGISTRY: quay.io/cryostat
   CI_IMG: quay.io/cryostat/cryostat
+  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   get-pom-properties:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Disable testcontainers ryuk in CI. The quay.io image in use is not multiarch and fails to start in arm64 CI. ryuk is used to reap containers after the test run, but we don't need that in CI since the job will end and the runner will exit anyway.
