### PR TITLE
fix(rules): correct error handling behaviour across component boundary

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -319,10 +319,6 @@ components:
         statusMessage:
           type: string
       type: object
-    Instant:
-      example: 2022-03-10T16:15:50Z
-      format: date-time
-      type: string
     JsonObject:
       items:
         properties:
@@ -397,8 +393,6 @@ components:
       type: object
     Metadata:
       properties:
-        expiry:
-          $ref: '#/components/schemas/Instant'
         labels:
           additionalProperties:
             type: string

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -122,8 +122,6 @@ type MemoryUtilization {
 }
 
 type Metadata {
-  "ISO-8601"
-  expiry: DateTime
   labels(
     "Get entry/entries for a certain key/s"
     key: [String]

--- a/src/main/java/io/cryostat/MessageCodecs.java
+++ b/src/main/java/io/cryostat/MessageCodecs.java
@@ -19,7 +19,7 @@ import io.cryostat.recordings.ActiveRecordings.LinkedRecordingDescriptor;
 
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.LocalEventBusCodec;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
@@ -28,6 +28,7 @@ public class MessageCodecs {
     @Inject EventBus bus;
 
     void onStart(@Observes StartupEvent evt) {
-        bus.registerDefaultCodec(LinkedRecordingDescriptor.class, new LocalEventBusCodec<>());
+        bus.getDelegate()
+                .registerDefaultCodec(LinkedRecordingDescriptor.class, new LocalEventBusCodec<>());
     }
 }

--- a/src/main/java/io/cryostat/discovery/JDPDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/JDPDiscovery.java
@@ -35,7 +35,7 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.ConsumeEvent;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Produces;

--- a/src/main/java/io/cryostat/events/S3TemplateService.java
+++ b/src/main/java/io/cryostat/events/S3TemplateService.java
@@ -50,7 +50,7 @@ import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
 import io.quarkus.runtime.StartupEvent;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;

--- a/src/main/java/io/cryostat/jmcagent/JMCAgentProbes.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgentProbes.java
@@ -32,7 +32,7 @@ import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
 import io.smallrye.common.annotation.Blocking;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DELETE;

--- a/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
+++ b/src/main/java/io/cryostat/jmcagent/S3ProbeTemplateService.java
@@ -34,7 +34,7 @@ import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
 import io.quarkus.runtime.StartupEvent;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;

--- a/src/main/java/io/cryostat/rules/RuleExecutor.java
+++ b/src/main/java/io/cryostat/rules/RuleExecutor.java
@@ -42,6 +42,7 @@ import io.cryostat.targets.Target.TargetDiscovery;
 
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -77,23 +78,23 @@ public class RuleExecutor {
 
     @ConsumeEvent(blocking = true)
     @Transactional
-    void onMessage(ActivationAttempt attempt) throws QuantityConversionException {
+    Uni<Void> onMessage(ActivationAttempt attempt) {
         Target attachedTarget = Target.<Target>find("id", attempt.target().id).singleResult();
-        recordingHelper
-                .getActiveRecording(
+        var priorRecording =
+                recordingHelper.getActiveRecording(
                         attachedTarget,
-                        r -> Objects.equals(r.name, attempt.rule().getRecordingName()))
-                .ifPresent(
-                        rec -> {
-                            try {
-                                recordingHelper
-                                        .stopRecording(rec)
-                                        .await()
-                                        .atMost(connectionFailedTimeout);
-                            } catch (Exception e) {
-                                logger.warn(e);
-                            }
-                        });
+                        r -> Objects.equals(r.name, attempt.rule().getRecordingName()));
+        if (priorRecording.isPresent()) {
+            try {
+                recordingHelper
+                        .stopRecording(priorRecording.get())
+                        .await()
+                        .atMost(connectionFailedTimeout);
+            } catch (Exception e) {
+                logger.warn(e);
+                return Uni.createFrom().failure(e);
+            }
+        }
 
         Pair<String, TemplateType> pair =
                 recordingHelper.parseEventSpecifier(attempt.rule().eventSpecifier);
@@ -103,20 +104,27 @@ public class RuleExecutor {
 
         var labels = new HashMap<>(attempt.rule().metadata.labels());
         labels.put("rule", attempt.rule().name);
-        ActiveRecording recording =
-                recordingHelper
-                        .startRecording(
-                                attachedTarget,
-                                RecordingReplace.STOPPED,
-                                template,
-                                createRecordingOptions(attempt.rule()),
-                                labels)
-                        .await()
-                        .atMost(Duration.ofSeconds(10));
+        try {
+            ActiveRecording recording =
+                    recordingHelper
+                            .startRecording(
+                                    attachedTarget,
+                                    RecordingReplace.STOPPED,
+                                    template,
+                                    createRecordingOptions(attempt.rule()),
+                                    labels)
+                            .await()
+                            .atMost(Duration.ofSeconds(10));
 
-        if (attempt.rule().isArchiver()) {
-            scheduleArchival(attempt.rule(), attachedTarget, recording);
+            if (attempt.rule().isArchiver()) {
+                scheduleArchival(attempt.rule(), attachedTarget, recording);
+            }
+        } catch (QuantityConversionException e) {
+            logger.error(e);
+            return Uni.createFrom().failure(e);
         }
+
+        return Uni.createFrom().nullItem();
     }
 
     @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY, blocking = true)

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -41,7 +41,7 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;

--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -79,7 +79,7 @@ public class RuleService {
                                     "Attempting to activate rule \"{0}\" for target {1} -"
                                             + " attempt #{2}",
                                     attempt.rule.name, attempt.target.connectUrl, attempt.attempts);
-                            bus.publish(RuleExecutor.class.getName(), attempt);
+                            bus.requestAndAwait(RuleExecutor.class.getName(), attempt);
                         } catch (InterruptedException ie) {
                             logger.trace(ie);
                             break;

--- a/src/test/java/itest/RulesPostFormIT.java
+++ b/src/test/java/itest/RulesPostFormIT.java
@@ -136,7 +136,6 @@ class RulesPostFormIT extends StandardSelfTest {
                                     new HashMap<>() {
                                         {
                                             put("labels", List.of());
-                                            put("expiry", null);
                                         }
                                     });
             MatcherAssert.assertThat(firstResponse.getRight(), Matchers.equalTo(expectedResponse));

--- a/src/test/java/itest/RulesPostJsonIT.java
+++ b/src/test/java/itest/RulesPostJsonIT.java
@@ -171,7 +171,6 @@ class RulesPostJsonIT extends StandardSelfTest {
                                     new HashMap<>() {
                                         {
                                             put("labels", List.of());
-                                            put("expiry", null);
                                         }
                                     });
             MatcherAssert.assertThat(


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #878
Related to https://github.com/cryostatio/cryostat/pull/732

## Description of the change:
In #732 the RuleService was split up and the RuleExecutor was extracted out as a separate component. These two communicate with each other over the EventBus. The error handling retry/backoff behaviour was left within the RuleService, and the RuleExecutor would simply throw uncaught exceptions if anything failed during eventbus message processing.

This change ensures that exceptions thrown during RuleExecutor processing are passed back to the RuleService so that the error handling logic can be correctly invoked in those cases, as well.

The particular exception noted in the linked issue is one where an assumed precondition of the RuleExecutor - that the activation attempt target exists - does not always actually hold. This might be because the target has been lost in the meantime, but also maybe because of a potential race condition between the discovery subsystem and the rule activation subsystem, where the discovery system has persisted the target node and emitted a notification, and the rule system is responding to the notification but cannot yet retrieve the target by database query because the discovery transaction has not been flushed.

## How to manually test:
1. Check out and build PR.
2. Deploy in a Kubernetes environment using the Helm chart or Operator.
```
helm install --set core.route.enabled=true --set authentication.openshift.enabled=true --set core.discovery.kubernetes.enabled=true --set core.discovery.kubernetes.namespaces='{cryostat,apps1,apps2}' --set db.pvc.enabled=true --set storage.pvc.enabled=true --set core.image.repository=quay.io/andrewazores/cryostat --set core.image.tag=rule-activation-1 cryostat ./charts/cryostat
```
3. Deploy some sample applications. If the application requires SSL/TLS certs or stored credentials ensure these are also set up.
5. Enable an Automated Rule that applies to the sample applications and/or Cryostat itself. The new Analysis rule would be a good candidate.
6. Ensure all targets have recording created due to rule activation.
7. Disable and clean rule. Ensure all targets have recording stopped.
8. Repeat steps 4-6 multiple times and ensure results are consistent.