### PR TITLE
test(smoketest): ensure removal of credentials volume

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -277,6 +277,8 @@ cleanup() {
     ${container_engine} volume rm templates || true
     ${container_engine} rm probes_helper || true
     ${container_engine} volume rm probes || true
+    ${container_engine} rm credentials_helper || true
+    ${container_engine} volume rm credentials || true
     truncate -s 0 "${HOSTSFILE}"
     for i in "${PIDS[@]}"; do
         kill -0 "${i}" && kill "${i}"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #857

## Description of the change:
Ensure the `credentials` volume and `_helper` container are cleaned up so that subsequent re-runs have a clean slate.
