### PR TITLE
feat(rules): allow patching of all rule fields

### DIFF
--- a/src/main/java/io/cryostat/rules/Rules.java
+++ b/src/main/java/io/cryostat/rules/Rules.java
@@ -164,15 +164,13 @@ public class Rules {
             throw new BadRequestException("Rule name cannot be updated");
         }
 
-        if (body.containsKey("enabled")) {
-            boolean enabled = body.getBoolean("enabled");
-            // order matters here, we want to clean before we disable
-            if (clean && !enabled) {
-                bus.send(Rule.RULE_ADDRESS + "?clean", rule);
-            }
-            rule.enabled = enabled;
+        // order matters here, we want to clean before we disable
+        if (clean) {
+            bus.send(Rule.RULE_ADDRESS + "?clean", rule);
         }
-
+        if (body.containsKey("enabled")) {
+            rule.enabled = body.getBoolean("enabled");
+        }
         if (body.containsKey("matchExpression")) {
             MatchExpression expr = new MatchExpression(body.getString("matchExpression"));
             expr.persist();

--- a/src/main/java/io/cryostat/rules/Rules.java
+++ b/src/main/java/io/cryostat/rules/Rules.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.cryostat.ConfigProperties;
@@ -159,13 +160,47 @@ public class Rules {
             throw new NotFoundException("Rule with name " + name + " not found");
         }
 
-        boolean enabled = body.getBoolean("enabled");
-        // order matters here, we want to clean before we disable
-        if (clean && !enabled) {
-            bus.send(Rule.RULE_ADDRESS + "?clean", rule);
+        if (!Objects.equals(body.getString("name"), name)) {
+            throw new BadRequestException("Rule name cannot be updated");
         }
 
-        rule.enabled = enabled;
+        if (body.containsKey("enabled")) {
+            boolean enabled = body.getBoolean("enabled");
+            // order matters here, we want to clean before we disable
+            if (clean && !enabled) {
+                bus.send(Rule.RULE_ADDRESS + "?clean", rule);
+            }
+            rule.enabled = enabled;
+        }
+
+        if (body.containsKey("matchExpression")) {
+            MatchExpression expr = new MatchExpression(body.getString("matchExpression"));
+            expr.persist();
+            rule.matchExpression = expr;
+        }
+        if (body.containsKey("description")) {
+            rule.description = body.getString("description");
+        }
+        if (body.containsKey("eventSpecifier")) {
+            rule.eventSpecifier = body.getString("eventSpecifier");
+        }
+        if (body.containsKey("archivalPeriodSeconds")) {
+            rule.archivalPeriodSeconds = body.getInteger("archivalPeriodSeconds");
+        }
+        if (body.containsKey("initialDelaySeconds")) {
+            rule.initialDelaySeconds = body.getInteger("initialDelaySeconds");
+        }
+        if (body.containsKey("preservedArchives")) {
+            rule.preservedArchives = body.getInteger("preservedArchives");
+        }
+        if (body.containsKey("maxAgeSeconds")) {
+            rule.maxAgeSeconds = body.getInteger("maxAgeSeconds");
+        }
+        if (body.containsKey("maxSizeBytes")) {
+            rule.maxSizeBytes = body.getInteger("maxSizeBytes");
+        }
+        // rule.metadata = TODO ;
+
         rule.persist();
 
         return rule;

--- a/src/main/java/io/cryostat/rules/Rules.java
+++ b/src/main/java/io/cryostat/rules/Rules.java
@@ -197,7 +197,9 @@ public class Rules {
         if (body.containsKey("maxSizeBytes")) {
             rule.maxSizeBytes = body.getInteger("maxSizeBytes");
         }
-        // rule.metadata = TODO ;
+        if (body.containsKey("metadata")) {
+            rule.metadata = body.getJsonObject("metadata").mapTo(Metadata.class);
+        }
 
         rule.persist();
 

--- a/src/test/java/io/cryostat/rules/RulesTest.java
+++ b/src/test/java/io/cryostat/rules/RulesTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import io.cryostat.AbstractTransactionalTestBase;
 
@@ -207,6 +209,7 @@ public class RulesTest extends AbstractTransactionalTestBase {
         copy.put("description", "new description");
         copy.put("eventSpecifier", "template=Profiling,type=TARGET");
         copy.put("matchExpression", EXPR_2);
+        copy.put("metadata", Map.of("labels", Map.of("foo", "bar")));
         given().log()
                 .all()
                 .body(copy.toString())
@@ -239,7 +242,12 @@ public class RulesTest extends AbstractTransactionalTestBase {
                         "[0].enabled", is(false),
                         "[0].description", equalTo("new description"),
                         "[0].eventSpecifier", equalTo("template=Profiling,type=TARGET"),
-                        "[0].matchExpression", equalTo(EXPR_2));
+                        "[0].matchExpression", equalTo(EXPR_2),
+                        "[0].metadata",
+                                equalTo(
+                                        Map.of(
+                                                "labels",
+                                                List.of(Map.of("key", "foo", "value", "bar")))));
 
         given().log()
                 .all()

--- a/src/test/java/io/cryostat/rules/RulesTest.java
+++ b/src/test/java/io/cryostat/rules/RulesTest.java
@@ -113,7 +113,7 @@ public class RulesTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    public void testUpdate() {
+    public void testUpdateEnabled() {
         var copy = rule.copy();
         copy.put("enabled", false);
         given().log()
@@ -149,7 +149,7 @@ public class RulesTest extends AbstractTransactionalTestBase {
 
         given().log()
                 .all()
-                .body(new JsonObject().put("enabled", true).toString())
+                .body(copy.copy().put("enabled", true).toString())
                 .contentType(ContentType.JSON)
                 .patch(RULE_NAME)
                 .then()
@@ -165,7 +165,7 @@ public class RulesTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    public void testUpdateWithClean() {
+    public void testUpdateEnabledWithClean() {
         given().log()
                 .all()
                 .body(rule.toString())
@@ -182,7 +182,7 @@ public class RulesTest extends AbstractTransactionalTestBase {
         given().log()
                 .all()
                 .queryParam("clean", true)
-                .body(new JsonObject().put("enabled", false).toString())
+                .body(rule.copy().put("enabled", false).toString())
                 .contentType(ContentType.JSON)
                 .patch(RULE_NAME)
                 .then()
@@ -198,6 +198,64 @@ public class RulesTest extends AbstractTransactionalTestBase {
 
         Mockito.verify(bus, Mockito.times(1))
                 .send(Mockito.eq(Rule.RULE_ADDRESS + "?clean"), Mockito.any(Rule.class));
+    }
+
+    @Test
+    public void testUpdate() {
+        var copy = rule.copy();
+        copy.put("enabled", false);
+        copy.put("description", "new description");
+        copy.put("eventSpecifier", "template=Profiling,type=TARGET");
+        copy.put("matchExpression", EXPR_2);
+        given().log()
+                .all()
+                .body(copy.toString())
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .log()
+                .all()
+                .and()
+                .assertThat()
+                .contentType(ContentType.JSON)
+                .statusCode(201)
+                .body(
+                        "id", notNullValue(),
+                        "name", is(RULE_NAME));
+
+        given().log()
+                .all()
+                .get()
+                .then()
+                .log()
+                .all()
+                .and()
+                .assertThat()
+                .contentType(ContentType.JSON)
+                .statusCode(200)
+                .body(
+                        "size()", is(1),
+                        "[0].name", is(RULE_NAME),
+                        "[0].enabled", is(false),
+                        "[0].description", equalTo("new description"),
+                        "[0].eventSpecifier", equalTo("template=Profiling,type=TARGET"),
+                        "[0].matchExpression", equalTo(EXPR_2));
+
+        given().log()
+                .all()
+                .body(copy.copy().put("enabled", true).toString())
+                .contentType(ContentType.JSON)
+                .patch(RULE_NAME)
+                .then()
+                .log()
+                .all()
+                .and()
+                .assertThat()
+                .contentType(ContentType.JSON)
+                .statusCode(200)
+                .body(
+                        "name", is(RULE_NAME),
+                        "enabled", is(true));
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/issues/1581

## Description of the change:
Allows more Automated Rule fields to be updated by the existing PATCH endpoint. Rule names cannot be modified this way but anything else can be.

## Motivation for the change:
Required for upcoming frontend feature to allow editing existing Rules or duplicating Rules.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
