### PR TITLE
feat(automated-analysis): include label for grouping target-analysis recordings

### DIFF
--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -58,6 +58,9 @@ import org.jboss.resteasy.reactive.RestResponse;
 @Path("")
 public class Reports {
 
+    private static final String TARGET_ANALYSIS_LABEL_KEY = "source";
+    private static final String TARGET_ANALYSIS_LABEL_VALUE = "target-analysis";
+
     @ConfigProperty(name = ConfigProperties.REPORTS_STORAGE_CACHE_ENABLED)
     boolean storageCacheEnabled;
 
@@ -138,7 +141,11 @@ public class Reports {
                 (v) -> {
                     helper.createSnapshot(
                                     target,
-                                    Map.of(AnalysisReportAggregator.AUTOANALYZE_LABEL, "true"))
+                                    Map.of(
+                                            AnalysisReportAggregator.AUTOANALYZE_LABEL,
+                                            "true",
+                                            TARGET_ANALYSIS_LABEL_KEY,
+                                            TARGET_ANALYSIS_LABEL_VALUE))
                             .subscribe()
                             .with(
                                     recording -> {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #859
Related to #892

## Description of the change:
Adds an additional label to snapshot recordings created by `POST /api/v4.1/targets/{targetId}/reports` requests.

## Motivation for the change:
The label will be copied to the archived version of the snapshot. Later, when the user is done looking at the automated analyses results and doesn't want/need the archived recordings anymore, the label makes it quick and easy to select the recordings which were created by target automated analysis for deletion.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O`, optionally add `-r` or `-t quarkus-cryostat-agent`
3. Wait for everything to come up and open UI
4. Select Cryostat itself as the target, or select another target and start some recording. Wait some time for data to be collected.
5. Go to Recordings > Active Recordings, click Analyze, then click the icon to perform analysis. Wait some time and repeat once or more times.
6. Go to Recordings > Archived Recordings and verify that the archived recordings have a `source=target-analysis` label. Clicking on the label should select all of the recordings with that label. Verify that these can be batch deleted.
7. Repeat steps 4-6, but using the Archives > All Archives and Archives > All Targets views, which should exhibit the same behaviour.
