### PR TITLE
fix(discovery): apply predicate to node queries

### DIFF
--- a/src/main/java/io/cryostat/discovery/DiscoveryNode.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryNode.java
@@ -144,7 +144,9 @@ public class DiscoveryNode extends PanacheEntity {
         return DiscoveryNode.<DiscoveryNode>find(
                         "#DiscoveryNode.byTypeWithName",
                         Parameters.with("nodeType", kind).and("name", name))
-                .firstResultOptional()
+                .stream()
+                .filter(predicate)
+                .findFirst()
                 .orElseGet(
                         () ->
                                 QuarkusTransaction.joiningExisting()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #870
See https://github.com/cryostatio/cryostat/pull/725#issuecomment-2863344308

## Description of the change:
Fixes a bug introduced in #870 refactoring where the new `DiscoveryNode.byTypeWithName` query and associated Java method are used improperly. This query is expected to return back a list of nodes that match the given node type and name, with an additional predicate function to filter the results further in cases where more than one result is expected. If there are no matching results then a new node is created, and an additional given customizer function is used to apply specific changes to that node (ex. so that it would match the query predicate). This logic was already used internally in the `KubeApi` discovery class, so it was generalized and extracted out.

But the bug introduced in #870 is simple and subtle: the query predicate was not actually applied. The method would simply query the database for nodes with the given type and name, then return the first result (or create a new node if there were no matches). In many cases this ends up working out just fine. However, in cases like the one in the linked discussion, if there are two discovery subtrees where there is some intermediate node with the same type and name, then the bug results in the "first" (I think this means lowest assigned database ID) result being returned with no other considerations. In this particular example this means the `ReplicaSet` and `Pod`s get attached to the wrong `Deployment`, since both namespaces contain nodes with the Deployment type and identical names.

## How to manually test:
1. Check out and build PR
2. Set up a Kubernetes cluster (ex. `kind create cluster` or `oc start`), create namespaces `apps1`, `apps2`, and `cryostat`
3. Set up sample applications in `apps1` and `apps2` namespaces. For example, use the cryostat-operator `make sample_app`. Make sure it is the same application deployed in each namespace, or at least that the applications have identically-named Deployments.
4. Use Helm chart to deploy within `cryostat` namespace:
```
helm install \
    --set core.image.repository=quay.io/$myusername/cryostat \
    --set core.image.tag=$myimagetag \
    --set core.discovery.kubernetes.enabled=true \
    --set core.discovery.kubernetes.namespaces='{apps1,apps2}' \
    cryostat ./charts/cryostat
```
5. Open Cryostat UI and go to Topology view, or query the API directly (`https --auth-type=bearer --auth=$(oc whoami -t) https://cryostat-cryostat-helm.apps-crc.testing/api/v4/discovery`) and inspect the response JSON. Verify that the applications are in distinct discovery subtrees with the last common ancestor being the `KubernetesApi` Realm node.

![image](https://github.com/user-attachments/assets/59650ee7-18dd-40bc-98f6-3c3a9e172fbd)
