### PR TITLE
fix(credentials): Persist matchExpression when creating credentials from files

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -11,6 +11,7 @@ services:
       - jmxtls_cfg:/truststore:U
       - templates:/opt/cryostat.d/templates.d:U
       - probes:/opt/cryostat.d/probes.d:U
+      - credentials:/opt/cryostat.d/credentials.d:U
     security_opt:
       - label:disable
     hostname: cryostat

--- a/src/main/java/io/cryostat/credentials/Credentials.java
+++ b/src/main/java/io/cryostat/credentials/Credentials.java
@@ -99,16 +99,13 @@ public class Credentials {
             Map<String, Object> params = new HashMap<String, Object>();
             params.put("username", credential.username);
             params.put("password", credential.password);
-            params.put("matchExpression", credential.matchExpression);
+            var matchExpressionExists =
+                    MatchExpression.find("script", credential.matchExpression.script).count() != 0;
             var exists =
-                    Credential.find(
-                                            "username = :username"
-                                                    + " and password = :password"
-                                                    + " and matchExpression = :matchExpression",
-                                            params)
+                    Credential.find("username = :username" + " and password = :password", params)
                                     .count()
                             != 0;
-            if (exists) {
+            if (exists && matchExpressionExists) {
                 logger.trace("Credential exists");
                 return;
             }

--- a/src/main/java/io/cryostat/credentials/Credentials.java
+++ b/src/main/java/io/cryostat/credentials/Credentials.java
@@ -69,7 +69,9 @@ public class Credentials {
 
     @Transactional
     void onStart(@Observes StartupEvent evt) {
+        logger.trace("Walking Credentials dir: " + dir.toString());
         if (!checkDir()) {
+            logger.warn("Failed to find credentials dir: " + dir.toString());
             return;
         }
         try {
@@ -90,8 +92,10 @@ public class Credentials {
     }
 
     private void createFromFile(java.nio.file.Path path) {
+        logger.trace("Creating credential from path: " + path.toString());
         try (var is = new BufferedInputStream(Files.newInputStream(path))) {
             var credential = mapper.readValue(is, Credential.class);
+            credential.matchExpression.persist();
             Map<String, Object> params = new HashMap<String, Object>();
             params.put("username", credential.username);
             params.put("password", credential.password);
@@ -105,6 +109,7 @@ public class Credentials {
                                     .count()
                             != 0;
             if (exists) {
+                logger.trace("Credential exists");
                 return;
             }
             credential.persist();


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat/issues/728

Fixes an issue found in https://github.com/cryostatio/cryostat-operator/pull/1089

While the matchExpression field in the Credential class is already marked as cascading (CascadeType.ALL) we reference it in the query to check whether the Credential we're creating already exists before the matchExpression is persisted. This fixes that by persisting it after it's created by the json mapper and adds some additional logging to the trace and warn levels.

To test:

- Create a directory 'credentials' and add a json credential file to it (credential.json)

{
    "username": "user",
    "password": "pass",
    "matchExpression": "false"
}

- Build the cryostat container (./mvnw package -Dquarkus.docker.buildx.platform=linux/amd64)
- Run smoketest (bash smoketest.bash -Op)
- Check the logs to see that the credential gets detected.
- Check the security view in the web UI to see that it was created and persisted.