### PR TITLE
feat(agent): implement config to disable Agent TLS verification

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -62,4 +62,5 @@ public class ConfigProperties {
     public static final String URI_RANGE = "cryostat.target.uri-range";
 
     public static final String AGENT_TLS_REQUIRED = "cryostat.agent.tls.required";
+    public static final String AGENT_TLS_VERIFY_HOST = "cryostat.agent.tls.verify-host";
 }

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -60,6 +60,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.codec.BodyCodec;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.ws.rs.ForbiddenException;
 import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.StringUtils;
@@ -72,7 +73,7 @@ public class AgentClient {
     public static final String NULL_CREDENTIALS = "No credentials found for agent";
 
     @ConfigProperty(name = ConfigProperties.AGENT_TLS_REQUIRED)
-    private boolean tlsEnabled;
+    private boolean tlsRequired;
 
     private final Target target;
     private final WebClient webClient;
@@ -446,10 +447,10 @@ public class AgentClient {
             HttpMethod mtd, String path, Buffer payload, BodyCodec<T> codec) {
         logger.debugv("{0} {1} {2}", mtd, getUri(), path);
 
-        if (tlsEnabled && !getUri().getScheme().equals("https")) {
+        if (tlsRequired && !getUri().getScheme().equals("https")) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Agent is configured with TLS enabled (%s) but the agent URI is not an"
+                            "Agent is configured with TLS required (%s) but the agent URI is not an"
                                     + " https connection.",
                             ConfigProperties.AGENT_TLS_REQUIRED));
         }
@@ -483,7 +484,11 @@ public class AgentClient {
     public static class Factory {
 
         @Inject ObjectMapper mapper;
-        @Inject WebClient webClient;
+
+        @Inject
+        @Named(TargetsModule.AGENT_CLIENT)
+        WebClient webClient;
+
         @Inject Logger logger;
 
         @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)

--- a/src/main/java/io/cryostat/targets/TargetsModule.java
+++ b/src/main/java/io/cryostat/targets/TargetsModule.java
@@ -15,23 +15,75 @@
  */
 package io.cryostat.targets;
 
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+import io.cryostat.ConfigProperties;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.libcryostat.sys.Environment;
 import io.cryostat.libcryostat.sys.FileSystem;
 
 import io.quarkus.arc.DefaultBean;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.TrustOptions;
+import io.vertx.mutiny.ext.web.client.WebClient;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 @Singleton
 public class TargetsModule {
 
+    static final String AGENT_CLIENT = "AGENT_CLIENT";
+
     @Produces
     @DefaultBean
     public JFRConnectionToolkit provideJfrConnectionToolkit() {
-        Logger log = LoggerFactory.getLogger(JFRConnectionToolkit.class);
+        var log = org.slf4j.LoggerFactory.getLogger(JFRConnectionToolkit.class);
         return new JFRConnectionToolkit(log::warn, new FileSystem(), new Environment());
+    }
+
+    @Produces
+    @Singleton
+    @Named(AGENT_CLIENT)
+    public WebClient provideAgentWebClient(
+            Vertx vertx,
+            @ConfigProperty(name = ConfigProperties.AGENT_TLS_VERIFY_HOST) boolean verifyHost,
+            Logger logger) {
+        logger.infov(
+                "Creating {0} WebClient {1}={2}",
+                AGENT_CLIENT, ConfigProperties.AGENT_TLS_VERIFY_HOST, verifyHost);
+        io.vertx.ext.web.client.WebClient delegate =
+                io.vertx.ext.web.client.WebClient.create(vertx);
+        WebClient wc = new WebClient(delegate);
+        SSLOptions opts = new SSLOptions();
+        if (!verifyHost) {
+            TrustOptions trust =
+                    TrustOptions.wrap(
+                            new X509TrustManager() {
+                                @Override
+                                public void checkClientTrusted(
+                                        X509Certificate[] chain, String authType)
+                                        throws CertificateException {}
+
+                                @Override
+                                public void checkServerTrusted(
+                                        X509Certificate[] chain, String authType)
+                                        throws CertificateException {}
+
+                                @Override
+                                public X509Certificate[] getAcceptedIssuers() {
+                                    return new X509Certificate[0];
+                                }
+                            });
+            opts.setTrustOptions(trust);
+        }
+        wc.updateSSLOptionsAndAwait(opts);
+        return wc;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,7 @@ cryostat.http.proxy.path=/
 cryostat.target.uri-range=PUBLIC
 
 cryostat.agent.tls.required=true
+cryostat.agent.tls.verify-host=true
 
 conf-dir=/opt/cryostat.d
 credentials-dir=${conf-dir}/credentials.d


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-operator/pull/1076

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
