### PR TITLE
fix(config): handle symlinks in declarative config loading

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -62,4 +62,7 @@ public class ConfigProperties {
     public static final String URI_RANGE = "cryostat.target.uri-range";
 
     public static final String AGENT_TLS_REQUIRED = "cryostat.agent.tls.required";
+
+    public static final String DECLARATIVE_CONFIG_RESOLVE_SYMLINKS =
+            "cryostat.declarative-configuration.symlinks.resolve";
 }

--- a/src/main/java/io/cryostat/DeclarativeConfiguration.java
+++ b/src/main/java/io/cryostat/DeclarativeConfiguration.java
@@ -56,7 +56,8 @@ public class DeclarativeConfiguration {
         if (resolveSymlinks) {
             // attempt to resolve symlinks, which will be deduplicated later
             paths =
-                    paths.map(
+                    paths.filter(Files::isRegularFile)
+                            .map(
                                     p -> {
                                         try {
                                             return p.toRealPath();

--- a/src/main/java/io/cryostat/DeclarativeConfiguration.java
+++ b/src/main/java/io/cryostat/DeclarativeConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class DeclarativeConfiguration {
+
+    @Inject Logger logger;
+
+    @ConfigProperty(name = ConfigProperties.DECLARATIVE_CONFIG_RESOLVE_SYMLINKS)
+    boolean resolveSymlinks;
+
+    public SortedSet<Path> walk(Path dir) throws IOException {
+        logger.debugv("Walking directory {0}", dir);
+        if (!Files.exists(dir)) {
+            return Collections.emptySortedSet();
+        }
+        if (!Files.isDirectory(dir)) {
+            throw new IOException(String.format("Location %s is not a directory", dir));
+        }
+        if (!Files.isReadable(dir)) {
+            throw new IOException(String.format("Location %s is not readable", dir));
+        }
+        if (!Files.isExecutable(dir)) {
+            throw new IOException(String.format("Location %s is not executable", dir));
+        }
+        Stream<Path> paths = Files.walk(dir).filter(Files::isReadable);
+        if (resolveSymlinks) {
+            // attempt to resolve symlinks, which will be deduplicated later
+            paths =
+                    paths.map(
+                                    p -> {
+                                        try {
+                                            return p.toRealPath();
+                                        } catch (IOException e) {
+                                            logger.error(e);
+                                            return null;
+                                        }
+                                    })
+                            .filter(Objects::nonNull);
+        } else {
+            // filter out and ignore symlinks entirely
+            paths = paths.filter(f -> Files.isRegularFile(f, LinkOption.NOFOLLOW_LINKS));
+        }
+        paths =
+                paths.map(Path::normalize)
+                        .peek(p -> logger.tracev("found declarative configuration file {0}", p));
+        return new TreeSet<>(paths.toList());
+    }
+}

--- a/src/main/java/io/cryostat/events/S3TemplateService.java
+++ b/src/main/java/io/cryostat/events/S3TemplateService.java
@@ -39,6 +39,7 @@ import org.openjdk.jmc.flightrecorder.configuration.model.xml.XMLTagInstance;
 import org.openjdk.jmc.flightrecorder.configuration.model.xml.XMLValidationResult;
 
 import io.cryostat.ConfigProperties;
+import io.cryostat.DeclarativeConfiguration;
 import io.cryostat.Producers;
 import io.cryostat.StorageBuckets;
 import io.cryostat.core.FlightRecorderException;
@@ -85,6 +86,7 @@ public class S3TemplateService implements MutableTemplateService {
     @ConfigProperty(name = ConfigProperties.CUSTOM_TEMPLATES_DIR)
     Path dir;
 
+    @Inject DeclarativeConfiguration declarativeConfiguration;
     @Inject S3Client storage;
     @Inject StorageBuckets storageBuckets;
 
@@ -98,13 +100,9 @@ public class S3TemplateService implements MutableTemplateService {
 
     void onStart(@Observes StartupEvent evt) {
         storageBuckets.createIfNecessary(bucket);
-        if (!checkDir()) {
-            return;
-        }
         try {
-            Files.walk(dir)
-                    .filter(Files::isRegularFile)
-                    .filter(Files::isReadable)
+            declarativeConfiguration
+                    .walk(dir)
                     .forEach(
                             p -> {
                                 try (var is = Files.newInputStream(p)) {

--- a/src/main/java/io/cryostat/security/TrustStore.java
+++ b/src/main/java/io/cryostat/security/TrustStore.java
@@ -15,12 +15,12 @@
  */
 package io.cryostat.security;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
 import io.cryostat.ConfigProperties;
+import io.cryostat.DeclarativeConfiguration;
 
 import io.smallrye.common.annotation.Blocking;
 import jakarta.inject.Inject;
@@ -37,6 +37,7 @@ public class TrustStore {
     @ConfigProperty(name = ConfigProperties.SSL_TRUSTSTORE_DIR)
     java.nio.file.Path trustStoreDir;
 
+    @Inject DeclarativeConfiguration declarativeConfiguration;
     @Inject Logger logger;
 
     @Blocking
@@ -51,10 +52,8 @@ public class TrustStore {
         if (!accessible) {
             return List.of();
         }
-        return Files.walk(trustStoreDir)
-                .map(java.nio.file.Path::toFile)
-                .filter(File::isFile)
-                .map(File::getPath)
+        return declarativeConfiguration.walk(trustStoreDir).stream()
+                .map(java.nio.file.Path::toString)
                 .toList();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,6 +52,8 @@ cryostat.target.uri-range=PUBLIC
 
 cryostat.agent.tls.required=true
 
+cryostat.declarative-configuration.symlinks.resolve=true
+
 conf-dir=/opt/cryostat.d
 credentials-dir=${conf-dir}/credentials.d
 rules-dir=${conf-dir}/rules.d


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/718
See also #912
Fixes #916

## Description of the change:
Refactors to extract a shared utility class across various components that have the common "declarative configuration" concept, ie. directories that can be mounted to the Cryostat container allowing the user to define resources without needing to deploy Cryostat and go through the API (ex. Automated Rules as JSON files). The shared utility adds some additional logic for handling of symbolic links.

## Motivation for the change:
The symbolic link handling addition deals with the case where Kubernetes Secrets and ConfigMaps are mounted to Cryostat by the Operator or Helm Chart. The actual filesystem layout after this happens ends up with the regular file as well as a symlink pointing to the file. We don't want to double-load resources from the symlinks.

There is a remaining issue that can still happen here, which is really just #912. If the Cryostat container comes up, reads a Stored Credential from declarative configuration, and persists that to the database, we are OK. If the Cryostat container is then restarted for any reason then it will come up, read the same Stored Credential declarative configuration *again*, and *persist it again* successfully. This will lead to *M x N* Stored Credentials being created in the long run, where *M* is the number of container restarts and *N* is the number of files in the stored credentials configuration directory. #912 would allow us to properly detect duplicates when (or just before) persisting expressions and credentials and avoid this problem.

## How to manually test:
1. Check out and build PR, or use my image
2. Set up a k8s/OpenShift cluster
3. Deploy:

`credential1`:
```json
{
    "username": "user",
    "password": "pass",
    "matchExpression": "false"
}
```
`oc create secret generic credential1 --from-file=credential.json`

`fib-tls`:
https://github.com/cryostatio/test-applications/blob/main/vertx-fib/src/main/extras/app/resources/vertx-fib-demo.cer
`oc create secret generic fib-tls --from-file=./vertx-fib-demo.cer`

```
$ helm install \
    --set core.debug.log.level=trace \
    --set core.image.repository=quay.io/andrewazores/cryostat \
    --set core.image.tag=decl-cfg-symlink-2 \
    --set core.route.enabled=true \
    --set core.config.credentials.secretNames='{credential1}' \
    --set core.config.tlsTruststore.secretNames='{fib-tls}' \
    cryostat ./charts/cryostat
```

4. Wait for Deployment ready, then open Cryostat UI. Go to Security. One TLS cert should be listed in the custom truststore, and one `false` Match Expression/Stored Credential should appear.
