### PR TITLE
chore(quarkus): upgrade to Quarkus 3.20 LTS

### DIFF
--- a/compose/cryostat.yml
+++ b/compose/cryostat.yml
@@ -28,7 +28,6 @@ services:
       CRYOSTAT_DISCOVERY_DOCKER_ENABLED: ${CRYOSTAT_DISCOVERY_DOCKER_ENABLED:-true}
       CRYOSTAT_AGENT_TLS_REQUIRED: ${ENFORCE_AGENT_TLS:-false}
       JAVA_OPTS_APPEND: >-
-        -XX:+FlightRecorder
         -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m
         -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
         -Dcom.sun.management.jmxremote.autodiscovery=true

--- a/compose/cryostat_docker.yml
+++ b/compose/cryostat_docker.yml
@@ -33,7 +33,6 @@ services:
       CRYOSTAT_DISCOVERY_DOCKER_ENABLED: "true"
       CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
       JAVA_OPTS_APPEND: >-
-        -XX:+FlightRecorder
         -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m
         -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
         -Dcom.sun.management.jmxremote.autodiscovery=true

--- a/compose/cryostat_k8s.yml
+++ b/compose/cryostat_k8s.yml
@@ -19,7 +19,7 @@ services:
     environment:
       CRYOSTAT_DISCOVERY_PODMAN_ENABLED: "false"
       CRYOSTAT_DISCOVERY_JDP_ENABLED: "true"
-      JAVA_OPTS_APPEND: "-XX:+FlightRecorder -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
+      JAVA_OPTS_APPEND: "-XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     restart: always
     healthcheck:
       test: curl --fail http://localhost:8181/health/liveness || exit 1

--- a/compose/sample_apps/quarkus-native.yml
+++ b/compose/sample_apps/quarkus-native.yml
@@ -12,7 +12,6 @@ services:
       QUARKUS_HTTP_PORT: 8760
       QUARKUS_HTTP_HOST: 0.0.0.0
     command: >-
-        -XX:+FlightRecorder
         -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m
         -Dcom.sun.management.jmxremote.port=8761
         -Dcom.sun.management.jmxremote.authenticate=false

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
           </execution>
         </executions>
         <configuration>
-          <jvmArgs>-Dcryostat.discovery.jdp.enabled=true -Dcryostat.discovery.podman.enabled=true -XX:+FlightRecorder -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false</jvmArgs>
+          <jvmArgs>-Dcryostat.discovery.jdp.enabled=true -Dcryostat.discovery.podman.enabled=true -XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false</jvmArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
     <org.testcontainers.bom.version>1.21.1</org.testcontainers.bom.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.15.5</quarkus.platform.version>
+    <quarkus.platform.version>3.20.1</quarkus.platform.version>
     <quarkus-quinoa.version>2.5.4</quarkus-quinoa.version>
-    <org.hibernate.orm.hibernate.jfr.version>6.6.7.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match this version? -->
+    <org.hibernate.orm.hibernate.jfr.version>6.6.13.Final</org.hibernate.orm.hibernate.jfr.version><!-- TODO is there some way to grab the Hibernate version used by Quarkus to match this version? -->
     <org.codehaus.mojo.build.helper.plugin.version>3.6.1</org.codehaus.mojo.build.helper.plugin.version>
     <org.codehaus.mojo.exec.plugin.version>3.5.1</org.codehaus.mojo.exec.plugin.version>
     <assembly-plugin.version>3.7.1</assembly-plugin.version>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -10,8 +10,6 @@ quarkus.http.test-timeout=60s
 
 cryostat.agent.tls.required=false
 
-quarkus.datasource.devservices.enabled=true
-quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db
 quarkus.hibernate-orm.log.sql=true
 quarkus.flyway.clean-at-start=true
 
@@ -20,6 +18,7 @@ cryostat.services.reports.memory-cache.enabled=false
 cryostat.services.reports.storage-cache.enabled=false
 
 # !!! prod databases must set this configuration parameter some other way via a secret !!!
+quarkus.datasource.devservices.enabled=true
 quarkus.datasource.devservices.image-name=quay.io/cryostat/cryostat-db:latest
 quarkus.datasource.devservices.container-env.PG_ENCRYPT_KEY=examplekey
 quarkus.datasource.devservices.container-env.POSTGRESQL_USER=quarkus

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,9 @@ quarkus.http.filter.static.matches=/static/.+
 quarkus.http.filter.static.methods=GET
 quarkus.http.filter.static.order=1
 
+# FIXME since Quarkus 3.20 leaving this enabled results in junk 'chunk-signature' data being inserted to PutObjectRequests
+quarkus.s3.chunked-encoding=false
+
 quarkus.s3.sync-client.type=apache
 storage-ext.url=
 storage.presigned-downloads.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -130,6 +130,9 @@ quarkus.quinoa.package-manager-command.dev=start:dev
 
 quarkus.scheduler.start-mode=forced
 
+# FIXME since Quarkus 3.20 the pom.xml cryostat.imageVersionLower property substitution trick does not work
+quarkus.application.version=4.1.0-snapshot
+
 quarkus.application.name=cryostat
 quarkus.container-image.build=true
 quarkus.container-image.push=false

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -15,6 +15,7 @@
  */
 package itest;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,7 @@ import itest.bases.StandardSelfTest;
 import itest.util.ITestCleanupFailedException;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import org.apache.commons.io.HexDump;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -223,13 +225,25 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             Path inMemoryDownloadPath =
                     downloadFile(inMemoryDownloadUrl, TEST_RECORDING_NAME, ".jfr")
                             .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            MatcherAssert.assertThat(
+                    inMemoryDownloadPath.toFile().length(), Matchers.greaterThan(0L));
 
             Path savedDownloadPath =
                     downloadFile(savedDownloadUrl, TEST_RECORDING_NAME + "_saved", ".jfr")
                             .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            MatcherAssert.assertThat(
-                    inMemoryDownloadPath.toFile().length(), Matchers.greaterThan(0L));
             MatcherAssert.assertThat(savedDownloadPath.toFile().length(), Matchers.greaterThan(0L));
+
+            System.out.println(
+                    String.format(
+                            "inMemoryDownload %s (%d bytes):",
+                            inMemoryDownloadPath, inMemoryDownloadPath.toFile().length()));
+            HexDump.dump(Files.readAllBytes(inMemoryDownloadPath), 0, System.out, 0);
+            System.out.print("\n\n----------------\n\n");
+            System.out.println(
+                    String.format(
+                            "savedDownload %s (%d bytes):",
+                            savedDownloadPath, savedDownloadPath.toFile().length()));
+            HexDump.dump(Files.readAllBytes(savedDownloadPath), 0, System.out, 0);
 
             List<RecordedEvent> inMemoryEvents = RecordingFile.readAllEvents(inMemoryDownloadPath);
             List<RecordedEvent> savedEvents = RecordingFile.readAllEvents(savedDownloadPath);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/778

Related to https://github.com/quarkusio/quarkus/issues/48257
Related to https://github.com/seaweedfs/seaweedfs/issues/6847

The linked Quarkus bug breaks the `cryostat.imageVersionLower`/`quarkus.application.version` build step, which is a minor annoyance and can be worked around.

The linked SeaweedFS bug may actually be an AWS SDK bug tied to the Quarkus version upgrade - still investigating this. There is an available workaround by disabling chunked encoding on the S3 client, which I think is not ideal for performance and reliability reasons. This means this bug is also related to https://github.com/cryostatio/cryostat-helm/issues/246 / https://github.com/cryostatio/cryostat-operator/issues/959 , since it may be necessary for users to enable or disable chunked encoding depending on which S3 provider they hook up to.
