### PR TITLE
fix(api): Location header points to correct API version path

### DIFF
--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -180,7 +180,7 @@ public class Reports {
         return Response.ok(jobId, MediaType.TEXT_PLAIN)
                 .status(Response.Status.ACCEPTED)
                 .location(
-                        UriBuilder.fromUri(String.format("/api/v4/targets/%d/reports", targetId))
+                        UriBuilder.fromUri(String.format("/api/v4.1/targets/%d/reports", targetId))
                                 .build())
                 .build();
     }

--- a/src/test/java/io/cryostat/reports/ReportsTest.java
+++ b/src/test/java/io/cryostat/reports/ReportsTest.java
@@ -118,7 +118,7 @@ public class ReportsTest extends AbstractTransactionalTestBase {
                             .header(
                                     "Location",
                                     String.format(
-                                            "http://localhost:8081/api/v4/targets/%d/reports",
+                                            "http://localhost:8081/api/v4.1/targets/%d/reports",
                                             targetId))
                             .and()
                             .extract()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat-web#1589
Related to #842

## Description of the change:
Corrects a `Location` response header that points to `api/v4` when it should be `api/v4.1`. The `cryostat-web` client does not actually use this `Location` header, but it should still be corrected.
