### PR TITLE
test(agent): agent discovery test

### DIFF
--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -9,7 +9,6 @@ services:
       - "9977"
     environment:
       JAVA_OPTS_APPEND: >-
-        -Dquarkus.http.host=0.0.0.0
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=trace
         -javaagent:/deployments/app/cryostat-agent.jar
@@ -21,6 +20,7 @@ services:
         -Dcom.sun.management.jmxremote.authenticate=false
         -Dcom.sun.management.jmxremote.ssl=false
         -Dcom.sun.management.jmxremote.local.only=false
+      QUAKRUS_HTTP_HOST: 0.0.0.0
       QUARKUS_HTTP_PORT: 10010
       ORG_ACME_CRYOSTATSERVICE_ENABLED: "false"
       CRYOSTAT_AGENT_APP_NAME: quarkus-cryostat-agent

--- a/compose/sample_apps/quarkus-petclinic.yml
+++ b/compose/sample_apps/quarkus-petclinic.yml
@@ -13,7 +13,6 @@ services:
       io.cryostat.jmxPort: "11223"
     environment:
       JAVA_OPTS_APPEND: >-
-        -Dquarkus.http.host=0.0.0.0
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dcom.sun.management.jmxremote.autodiscovery=false
         -Dcom.sun.management.jmxremote
@@ -23,6 +22,7 @@ services:
         -Dcom.sun.management.jmxremote.authenticate=false
         -Dcom.sun.management.jmxremote.ssl=false
         -Dcom.sun.management.jmxremote.local.only=false
+      QUARKUS_HTTP_HOST: 0.0.0.0
       QUARKUS_HTTP_PORT: 10011
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://quarkus-petclinic-db:5432/petclinic
     restart: always

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <com.mycila.license.maven.plugin.version>5.0.0</com.mycila.license.maven.plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
+    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <failsafe-plugin.version>3.5.3</failsafe-plugin.version>
     <failsafe.rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</failsafe.rerunFailingTestsCount>
   </properties>
@@ -472,6 +473,7 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+          <skipTests>${skip.surefire.tests}</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,8 @@
                 <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <maven.home>${maven.home}</maven.home>
+                <quarkus.test.network-alias>cryostat</quarkus.test.network-alias>
+                <quarkus.test.arg-line>--network-alias=${quarkus.test.network-alias}</quarkus.test.arg-line>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -91,7 +91,8 @@ USER 185
 EXPOSE 8181
 LABEL io.cryostat.component=cryostat
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV QUARKUS_HTTP_HOST=0.0.0.0
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 ENTRYPOINT [ "/deployments/app/entrypoint.bash", "/opt/jboss/container/java/run/run-java.sh" ]

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,7 +5,7 @@ cryostat.discovery.podman.enabled=true
 cryostat.discovery.docker.enabled=true
 cryostat.discovery.kubernetes.enabled=true
 
-quarkus.test.env.JAVA_OPTS_APPEND=-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
+quarkus.test.env.JAVA_OPTS_APPEND=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
 quarkus.http.test-timeout=60s
 
 cryostat.agent.tls.required=false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -6,7 +6,6 @@ cryostat.discovery.docker.enabled=true
 cryostat.discovery.kubernetes.enabled=true
 
 quarkus.test.env.JAVA_OPTS_APPEND=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false
-quarkus.http.test-timeout=60s
 
 cryostat.agent.tls.required=false
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -109,6 +109,7 @@ quarkus.http.filter.static.header.Cache-Control=max-age=31536000
 quarkus.http.filter.static.matches=/static/.+
 quarkus.http.filter.static.methods=GET
 quarkus.http.filter.static.order=1
+quarkus.http.test-timeout=60s
 
 # FIXME since Quarkus 3.20 / S3 SDK 2.30.36 leaving this enabled results in junk 'chunk-signature' data
 # being inserted to PutObjectRequests when the object storage instance is SeaweedFS/cryostat-storage

--- a/src/test/java/io/cryostat/resources/AgentApplicationResource.java
+++ b/src/test/java/io/cryostat/resources/AgentApplicationResource.java
@@ -111,9 +111,7 @@ public class AgentApplicationResource
                 "quarkus.http.proxy.proxy-address-forwarding", "true",
                 "quarkus.http.proxy.allow-x-forwarded", "true",
                 "quarkus.http.proxy.enable-forwarded-host", "true",
-                "quarkus.http.proxy.enable-forwarded-prefix", "true",
-                "quarkus.http.access-log.pattern", "long",
-                "quarkus.http.access-log.enabled", "true");
+                "quarkus.http.proxy.enable-forwarded-prefix", "true");
     }
 
     @Override

--- a/src/test/java/io/cryostat/resources/AgentApplicationResource.java
+++ b/src/test/java/io/cryostat/resources/AgentApplicationResource.java
@@ -105,7 +105,6 @@ public class AgentApplicationResource
         container.start();
 
         return Map.of(
-                "quarkus.test.arg-line", "--network-alias=cryostat",
                 "cryostat.agent.tls.required", "false",
                 "cryostat.http.proxy.host", ALIAS,
                 "cryostat.http.proxy.port", Integer.toString(cryostatPort.get()),

--- a/src/test/java/io/cryostat/resources/AuthProxyContainer.java
+++ b/src/test/java/io/cryostat/resources/AuthProxyContainer.java
@@ -50,7 +50,7 @@ upstreamConfig:
   upstreams:
     - id: cryostat
       path: /
-      uri: http://cryostat:CRYOSTAT_PORT
+      uri: http://CRYOSTAT_HOST:CRYOSTAT_PORT
 providers:
   - id: dummy
     name: Unused - Sign In Below
@@ -71,6 +71,12 @@ providers:
                         ALPHA_CONFIG
                                 .replaceAll("AUTHPROXY_HOST", "0.0.0.0")
                                 .replaceAll("AUTHPROXY_PORT", Integer.toString(PORT))
+                                .replaceAll(
+                                        "CRYOSTAT_HOST",
+                                        Optional.ofNullable(
+                                                        System.getProperty(
+                                                                "quarkus.test.network-alias"))
+                                                .orElse("cryostat"))
                                 .replaceAll("CRYOSTAT_PORT", Integer.toString(cryostatPort))),
                 CFG_FILE_PATH);
         waitingFor(Wait.forLogMessage(".*OAuthProxy configured.*", 1));

--- a/src/test/java/io/cryostat/resources/S3StorageBucketedMetadataResource.java
+++ b/src/test/java/io/cryostat/resources/S3StorageBucketedMetadataResource.java
@@ -41,7 +41,7 @@ public class S3StorageBucketedMetadataResource
                     "CRYOSTAT_SECRET_KEY", "secret_key",
                     "CRYOSTAT_BUCKETS",
                             "archivedrecordings,archivedreports,eventtemplates,probes,metadata");
-    private static final Logger logger = Logger.getLogger(S3StorageResource.class);
+    private static final Logger logger = Logger.getLogger(S3StorageBucketedMetadataResource.class);
     private Optional<String> containerNetworkId;
     private GenericContainer<?> container;
 

--- a/src/test/java/io/cryostat/resources/S3StorageObjectMetadataResource.java
+++ b/src/test/java/io/cryostat/resources/S3StorageObjectMetadataResource.java
@@ -41,7 +41,7 @@ public class S3StorageObjectMetadataResource
                     "CRYOSTAT_SECRET_KEY", "secret_key",
                     "CRYOSTAT_BUCKETS",
                             "archivedrecordings,archivedreports,eventtemplates,probes,metadata");
-    private static final Logger logger = Logger.getLogger(S3StorageResource.class);
+    private static final Logger logger = Logger.getLogger(S3StorageObjectMetadataResource.class);
     private Optional<String> containerNetworkId;
     private GenericContainer<?> container;
 

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -66,7 +66,7 @@ public class AgentDiscoveryIT extends HttpClientTest {
                             obj.getString("connectUrl"),
                             Matchers.equalTo(
                                     String.format(
-                                            "http://%s:%d/",
+                                            "http://%s:%d",
                                             AgentApplicationResource.ALIAS,
                                             AgentApplicationResource.PORT)));
 

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -32,7 +32,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import itest.bases.HttpClientTest;
 import junit.framework.AssertionFailedError;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
@@ -51,7 +50,7 @@ public class AgentDiscoveryIT extends HttpClientTest {
     public static boolean enabled() {
         String arch = Optional.ofNullable(System.getenv("CI_ARCH")).orElse("").trim();
         boolean ci = Boolean.valueOf(System.getenv("CI"));
-        return !ci || (ci && (StringUtils.isBlank(arch) || "amd64".equalsIgnoreCase(arch)));
+        return !ci || (ci && "amd64".equalsIgnoreCase(arch));
     }
 
     @Test

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -26,8 +26,9 @@ import io.cryostat.resources.AgentApplicationResource;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.json.JsonObject;
+import itest.bases.HttpClientTest;
 import junit.framework.AssertionFailedError;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -35,12 +36,12 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@QuarkusTest
+@QuarkusIntegrationTest
 @QuarkusTestResource(value = AgentApplicationResource.class, restrictToAnnotatedClass = true)
 @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
-public class AgentDiscoveryTest {
+public class AgentDiscoveryIT extends HttpClientTest {
 
-    static final Logger logger = Logger.getLogger(AgentDiscoveryTest.class);
+    static final Logger logger = Logger.getLogger(AgentDiscoveryIT.class);
     static final Duration TIMEOUT = Duration.ofSeconds(60);
 
     @Test

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -16,6 +16,7 @@
 package itest;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -31,22 +32,26 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import itest.bases.HttpClientTest;
 import junit.framework.AssertionFailedError;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
-
-// import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = AgentApplicationResource.class, restrictToAnnotatedClass = true)
 @QuarkusTestResource(value = S3StorageResource.class)
-// @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^$")
-// @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^amd64|AMD64$")
+@EnabledIf("enabled")
 public class AgentDiscoveryIT extends HttpClientTest {
 
     static final Logger logger = Logger.getLogger(AgentDiscoveryIT.class);
     static final Duration TIMEOUT = Duration.ofSeconds(60);
+
+    public static boolean enabled() {
+        String arch = Optional.ofNullable(System.getenv("CI_ARCH")).orElse("").trim();
+        return StringUtils.isBlank(arch) || "amd64".equalsIgnoreCase(arch);
+    }
 
     @Test
     void shouldDiscoverTarget() throws InterruptedException, TimeoutException, ExecutionException {

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -50,7 +50,8 @@ public class AgentDiscoveryIT extends HttpClientTest {
 
     public static boolean enabled() {
         String arch = Optional.ofNullable(System.getenv("CI_ARCH")).orElse("").trim();
-        return StringUtils.isBlank(arch) || "amd64".equalsIgnoreCase(arch);
+        boolean ci = Boolean.valueOf(System.getenv("CI"));
+        return !ci || (ci && (StringUtils.isBlank(arch) || "amd64".equalsIgnoreCase(arch)));
     }
 
     @Test

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import io.cryostat.resources.AgentApplicationResource;
+import io.cryostat.resources.S3StorageResource;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = AgentApplicationResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = S3StorageResource.class)
 // @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^$")
 // @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^amd64|AMD64$")
 public class AgentDiscoveryIT extends HttpClientTest {

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -19,6 +19,7 @@ import static io.restassured.RestAssured.given;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -51,9 +52,10 @@ public class AgentDiscoveryIT extends HttpClientTest {
         while (true) {
             var resp = given().when().get("/api/v4/targets").then().extract();
             if (HttpStatusCodeIdentifier.isSuccessCode(resp.statusCode())) {
-                List<JsonObject> result = resp.body().jsonPath().getList("$");
+                List<Map<String, Object>> result = resp.body().jsonPath().getList("$");
                 if (result.size() == 1) {
-                    JsonObject obj = result.get(0);
+                    Map<String, Object> rawObj = result.get(0);
+                    JsonObject obj = new JsonObject(rawObj);
                     MatcherAssert.assertThat(
                             obj.getString("alias"),
                             Matchers.equalTo(AgentApplicationResource.ALIAS));

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -59,8 +59,7 @@ public class AgentDiscoveryIT extends HttpClientTest {
             if (HttpStatusCodeIdentifier.isSuccessCode(resp.statusCode())) {
                 List<Map<String, Object>> result = resp.body().jsonPath().getList("$");
                 if (result.size() == 1) {
-                    Map<String, Object> rawObj = result.get(0);
-                    JsonObject obj = new JsonObject(rawObj);
+                    JsonObject obj = new JsonObject(result.get(0));
                     MatcherAssert.assertThat(
                             obj.getString("alias"),
                             Matchers.equalTo(AgentApplicationResource.ALIAS));

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -39,7 +39,12 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = AgentApplicationResource.class, restrictToAnnotatedClass = true)
-@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+@EnabledIfEnvironmentVariable(
+        named = "CI",
+        matches = "true",
+        disabledReason =
+                "Runs well in CI under Docker, but not locally under Podman due to testcontainers"
+                        + " 'Broken Pipe' IOException")
 public class AgentDiscoveryIT extends HttpClientTest {
 
     static final Logger logger = Logger.getLogger(AgentDiscoveryIT.class);

--- a/src/test/java/itest/AgentDiscoveryIT.java
+++ b/src/test/java/itest/AgentDiscoveryIT.java
@@ -34,12 +34,13 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+// import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = AgentApplicationResource.class, restrictToAnnotatedClass = true)
-@EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^$")
-@EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^amd64|AMD64$")
+// @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^$")
+// @EnabledIfEnvironmentVariable(named = "CI_ARCH", matches = "^amd64|AMD64$")
 public class AgentDiscoveryIT extends HttpClientTest {
 
     static final Logger logger = Logger.getLogger(AgentDiscoveryIT.class);

--- a/src/test/java/itest/CustomTargetsTest.java
+++ b/src/test/java/itest/CustomTargetsTest.java
@@ -155,6 +155,13 @@ public class CustomTargetsTest extends StandardSelfTest {
                             try {
                                 return expectNotification(
                                                 "TargetJvmDiscovery",
+                                                o ->
+                                                        "FOUND"
+                                                                .equals(
+                                                                        o.getJsonObject("message")
+                                                                                .getJsonObject(
+                                                                                        "event")
+                                                                                .getString("kind")),
                                                 REQUEST_TIMEOUT_SECONDS,
                                                 TimeUnit.SECONDS)
                                         .get();

--- a/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
+++ b/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
@@ -114,7 +114,7 @@ public class RecordingWorkflowBucketedMetadataTest extends StandardSelfTest {
                     recordingInfo.getString("name"), Matchers.equalTo(TEST_RECORDING_NAME));
             MatcherAssert.assertThat(recordingInfo.getString("state"), Matchers.equalTo("RUNNING"));
 
-            Thread.sleep(2_000L); // wait some time to save a portion of the recording
+            Thread.sleep(15_000L); // wait some time to save a portion of the recording
 
             // save a copy of the partial recording dump
             MultiMap saveHeaders = MultiMap.caseInsensitiveMultiMap();
@@ -194,7 +194,7 @@ public class RecordingWorkflowBucketedMetadataTest extends StandardSelfTest {
                     Matchers.matchesRegex(
                             TARGET_ALIAS + "_" + TEST_RECORDING_NAME + "_[\\d]{8}T[\\d]{6}Z.jfr"));
             String savedDownloadUrl = recordingInfo.getString("downloadUrl");
-            Thread.sleep(3_000L); // wait for the dump to complete
+            Thread.sleep(20_000L); // wait for the dump to complete
 
             // verify the in-memory recording list has not changed, except recording is now stopped
             CompletableFuture<JsonArray> listRespFuture5 = new CompletableFuture<>();

--- a/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
+++ b/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
@@ -80,7 +80,7 @@ public class RecordingWorkflowBucketedMetadataTest extends StandardSelfTest {
             // create an in-memory recording
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
             form.add("recordingName", TEST_RECORDING_NAME);
-            form.add("duration", "5");
+            form.add("duration", "30");
             form.add("events", "template=ALL");
             webClient
                     .extensions()
@@ -216,7 +216,8 @@ public class RecordingWorkflowBucketedMetadataTest extends StandardSelfTest {
             MatcherAssert.assertThat(
                     recordingInfo.getString("name"), Matchers.equalTo(TEST_RECORDING_NAME));
             MatcherAssert.assertThat(recordingInfo.getString("state"), Matchers.equalTo("STOPPED"));
-            MatcherAssert.assertThat(recordingInfo.getInteger("duration"), Matchers.equalTo(5_000));
+            MatcherAssert.assertThat(
+                    recordingInfo.getInteger("duration"), Matchers.equalTo(30_000));
 
             // verify in-memory and saved recordings can be downloaded successfully and yield
             // non-empty recording binaries containing events, and that

--- a/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
+++ b/src/test/java/itest/RecordingWorkflowBucketedMetadataTest.java
@@ -48,7 +48,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@QuarkusTestResource(S3StorageBucketedMetadataResource.class)
+@QuarkusTestResource(
+        value = S3StorageBucketedMetadataResource.class,
+        restrictToAnnotatedClass = true)
 public class RecordingWorkflowBucketedMetadataTest extends StandardSelfTest {
 
     private final ExecutorService worker = ForkJoinPool.commonPool();

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -78,7 +78,7 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             // create an in-memory recording
             MultiMap form = MultiMap.caseInsensitiveMultiMap();
             form.add("recordingName", TEST_RECORDING_NAME);
-            form.add("duration", "5");
+            form.add("duration", "30");
             form.add("events", "template=ALL");
             webClient
                     .extensions()
@@ -214,7 +214,8 @@ public class RecordingWorkflowTest extends StandardSelfTest {
             MatcherAssert.assertThat(
                     recordingInfo.getString("name"), Matchers.equalTo(TEST_RECORDING_NAME));
             MatcherAssert.assertThat(recordingInfo.getString("state"), Matchers.equalTo("STOPPED"));
-            MatcherAssert.assertThat(recordingInfo.getInteger("duration"), Matchers.equalTo(5_000));
+            MatcherAssert.assertThat(
+                    recordingInfo.getInteger("duration"), Matchers.equalTo(30_000));
 
             // verify in-memory and saved recordings can be downloaded successfully and yield
             // non-empty recording binaries containing events, and that

--- a/src/test/java/itest/RecordingWorkflowTest.java
+++ b/src/test/java/itest/RecordingWorkflowTest.java
@@ -112,7 +112,7 @@ public class RecordingWorkflowTest extends StandardSelfTest {
                     recordingInfo.getString("name"), Matchers.equalTo(TEST_RECORDING_NAME));
             MatcherAssert.assertThat(recordingInfo.getString("state"), Matchers.equalTo("RUNNING"));
 
-            Thread.sleep(2_000L); // wait some time to save a portion of the recording
+            Thread.sleep(20_000L); // wait some time to save a portion of the recording
 
             // save a copy of the partial recording dump
             MultiMap saveHeaders = MultiMap.caseInsensitiveMultiMap();
@@ -192,7 +192,7 @@ public class RecordingWorkflowTest extends StandardSelfTest {
                     Matchers.matchesRegex(
                             TARGET_ALIAS + "_" + TEST_RECORDING_NAME + "_[\\d]{8}T[\\d]{6}Z.jfr"));
             String savedDownloadUrl = recordingInfo.getString("downloadUrl");
-            Thread.sleep(3_000L); // wait for the dump to complete
+            Thread.sleep(15_000L); // wait for the dump to complete
 
             // verify the in-memory recording list has not changed, except recording is now stopped
             CompletableFuture<JsonArray> listRespFuture5 = new CompletableFuture<>();


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #759

## Description of the change:
1. Fixes up the agent discovery integration test, which tests the integration of Cryostat + oauth2_proxy + cryostat-agent by simply ensuring that an agent instance is able to register with Cryostat via the proxy, and that the agent eventually becomes discoverable and listed in Cryostat's API. A key part of this is the `--network-alias` to `quarkus.test.arg-line` change from the resource class into `pom.xml`, which reinstates the configuration so that the Cryostat container under test is resolvable by the hostname `cryostat` within the test network. This test is disabled in PR CI because of the ["Broken pipe"](https://github.com/cryostatio/cryostat/pull/767) issue, but it should run in push CI when PRs get merged. It should also run locally in ex. `mvn clean verify` runs.
2. Does some other cleanup that I noticed while troubleshooting the problem above. For example, changing `-Dquarkus.http.host` system properties to `QUARKUS_HTTP_HOST` environment variables just to be more consistent.
3. Increases a test recording duration and timeout to improve test reliability in slow CI environment.