### PR TITLE
fix(discovery): handle k8s IPv6 EndpointSlices

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -37,6 +37,8 @@ public class ConfigProperties {
             "storage.metadata.prefix.event-templates";
 
     public static final String DISCOVERY_IPV6_ENABLED = "cryostat.discovery.ipv6-enabled";
+    public static final String DISCOVERY_IPV4_DNS_TRANSFORM_ENABLED =
+            "cryostat.discovery.kubernetes.ipv4.dns-transform.enabled";
     public static final String CONTAINERS_POLL_PERIOD = "cryostat.discovery.containers.poll-period";
     public static final String CONTAINERS_REQUEST_TIMEOUT =
             "cryostat.discovery.containers.request-timeout";

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -36,6 +36,7 @@ public class ConfigProperties {
     public static final String AWS_METADATA_PREFIX_EVENT_TEMPLATES =
             "storage.metadata.prefix.event-templates";
 
+    public static final String DISCOVERY_IPV6_ENABLED = "cryostat.discovery.ipv6-enabled";
     public static final String CONTAINERS_POLL_PERIOD = "cryostat.discovery.containers.poll-period";
     public static final String CONTAINERS_REQUEST_TIMEOUT =
             "cryostat.discovery.containers.request-timeout";

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -313,9 +313,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 if (ref == null) {
                     continue;
                 }
-                logger.infov(
-                        "discovered EndpointSlice: {0} {1} port {2}",
-                        slice.getAddressType(), addr, port);
                 switch (slice.getAddressType().toLowerCase()) {
                     case "ipv6":
                         addr = String.format("[%s]", addr);
@@ -741,9 +738,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                 "",
                                 0,
                                 "/jndi/rmi://" + addr + ':' + port.getPort() + "/jmxrmi");
-                logger.infov(
-                        "mapping TargetTuple {0} to Target with addr {1} and JMX URL {2}",
-                        this, addr, jmxUrl);
                 URI connectUrl = URI.create(jmxUrl.toString());
 
                 Target target = new Target();

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -110,6 +110,9 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConfigProperty(name = ConfigProperties.DISCOVERY_IPV6_ENABLED)
     boolean ipv6Enabled;
 
+    @ConfigProperty(name = ConfigProperties.DISCOVERY_IPV4_DNS_TRANSFORM_ENABLED)
+    boolean ipv4TransformEnabled;
+
     @ConfigProperty(name = "cryostat.discovery.kubernetes.port-names")
     Optional<List<String>> jmxPortNames;
 
@@ -317,8 +320,15 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     case "ipv6":
                         addr = String.format("[%s]", addr);
                         break;
-                    case "IPv4":
-                    case "FQDN":
+                    case "ipv4":
+                        if (ipv4TransformEnabled) {
+                            addr =
+                                    String.format(
+                                            "%s.%s.pod",
+                                            addr.replaceAll("\\.", "-"), ref.getNamespace());
+                        }
+                        break;
+                    case "fqdn":
                     // fall-through
                     default:
                         // no-op

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -323,6 +323,8 @@ public class TargetConnectionManager {
                             () -> connections.synchronous().invalidate(connectUrl)));
         } catch (Exception e) {
             evt.setExceptionThrown(true);
+            logger.error(e);
+            e.printStackTrace();
             throw e;
         } finally {
             evt.end();

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -324,7 +324,6 @@ public class TargetConnectionManager {
         } catch (Exception e) {
             evt.setExceptionThrown(true);
             logger.error(e);
-            e.printStackTrace();
             throw e;
         } finally {
             evt.end();

--- a/src/main/java/io/cryostat/targets/TargetsModule.java
+++ b/src/main/java/io/cryostat/targets/TargetsModule.java
@@ -22,8 +22,7 @@ import io.cryostat.libcryostat.sys.FileSystem;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 @Singleton
 public class TargetsModule {
@@ -31,7 +30,7 @@ public class TargetsModule {
     @Produces
     @DefaultBean
     public JFRConnectionToolkit provideJfrConnectionToolkit() {
-        Logger log = LoggerFactory.getLogger(JFRConnectionToolkit.class);
+        Logger log = Logger.getLogger(JFRConnectionToolkit.class);
         return new JFRConnectionToolkit(log::warn, new FileSystem(), new Environment());
     }
 }

--- a/src/main/java/io/cryostat/util/URIRange.java
+++ b/src/main/java/io/cryostat/util/URIRange.java
@@ -56,21 +56,16 @@ public enum URIRange {
             return predicate.test(address);
         } catch (UnknownHostException uhe) {
             log.errorv(uhe, "Failed to resolve host: {0}", hostname);
-            uhe.printStackTrace();
             return false;
         }
     }
 
     public boolean validate(String hostname) {
-        log.infov("URIRange {0} validating {1}", name(), hostname);
-        new Exception().printStackTrace();
         List<URIRange> ranges =
                 List.of(values()).stream()
                         .filter(r -> r.ordinal() <= this.ordinal())
                         .collect(Collectors.toList());
-        boolean valid = ranges.stream().anyMatch(range -> range.fn.test(hostname));
-        log.infov("URIRange {0} validated {1} = {2}", name(), hostname, valid);
-        return valid;
+        return ranges.stream().anyMatch(range -> range.fn.test(hostname));
     }
 
     public static URIRange fromString(String s) {

--- a/src/main/java/io/cryostat/util/URIUtil.java
+++ b/src/main/java/io/cryostat/util/URIUtil.java
@@ -66,8 +66,8 @@ public class URIUtil {
     }
 
     boolean validateJmxServiceURL(JMXServiceURL jmxUrl) {
-        String hostname = ipv6Compat(ConnectionToolkit.getHostName(jmxUrl));
-        return URIRange.fromString(uriRange).validate(hostname);
+        return URIRange.fromString(uriRange)
+                .validate(ipv6Compat(ConnectionToolkit.getHostName(jmxUrl)));
     }
 
     private static String ipv6Compat(String s) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.flyway.migrate-at-start=true
 quarkus.flyway.validate-migration-naming=true
 
 quarkus.naming.enable-jndi=true
+cryostat.discovery.ipv6-enabled=false
 cryostat.discovery.jdp.enabled=false
 cryostat.discovery.containers.poll-period=10s
 cryostat.discovery.containers.request-timeout=2s

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.flyway.validate-migration-naming=true
 
 quarkus.naming.enable-jndi=true
 cryostat.discovery.ipv6-enabled=false
+cryostat.discovery.kubernetes.ipv4.dns-transform.enabled=true
 cryostat.discovery.jdp.enabled=false
 cryostat.discovery.containers.poll-period=10s
 cryostat.discovery.containers.request-timeout=2s


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #964

## Description of the change:
1. Adds a boolean config property (defaults to `true`) to apply a DNS name transformation to EndpointSlice addresses which are IPv4. Rather than using the simple direct IPv4 `1.2.3.4 `address as the hostname, the transformation changes this to the k8s DNS `1-2-3-4.$namespace.pod` hostname. This seems to be useful for at least some network stacks, ex. in `kind`.
2. Adds handling for IPv6 addresses, where the URL containing an IPv6 address as the hostname must enclose the address in square brackets. ~~This doesn't actually fix IPv6 connectivity issues at the moment - connection failures further down in JMC code or even (apparently) in JDK RMI code occur. For that reason, this also:~~
3. Adds a boolean config property to disable IPv6 handling in k8s discovery. EndpointSlices that advertise IPv6 addresses will simply be skipped if this is enabled. This would apply to `dualstack` clusters, where individual Pods/Services might have either or both IPv4/IPv6 addresses. This way, the IPv6 can be ignored and IPv4 used instead.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  ipFamily: ipv6
```

1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
