### PR TITLE
chore(connection): remove TargetConnectionManager locking structures

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -40,7 +40,6 @@ public class ConfigProperties {
     public static final String CONTAINERS_REQUEST_TIMEOUT =
             "cryostat.discovery.containers.request-timeout";
 
-    public static final String CONNECTIONS_MAX_OPEN = "cryostat.connections.max-open";
     public static final String CONNECTIONS_TTL = "cryostat.connections.ttl";
     public static final String CONNECTIONS_FAILED_BACKOFF = "cryostat.connections.failed-backoff";
     public static final String CONNECTIONS_FAILED_TIMEOUT = "cryostat.connections.failed-timeout";

--- a/src/main/java/io/cryostat/events/TargetEventTemplates.java
+++ b/src/main/java/io/cryostat/events/TargetEventTemplates.java
@@ -24,7 +24,6 @@ import io.cryostat.core.templates.TemplateService;
 import io.cryostat.libcryostat.templates.Template;
 import io.cryostat.libcryostat.templates.TemplateType;
 import io.cryostat.targets.Target;
-import io.cryostat.targets.TargetConnectionManager;
 
 import io.smallrye.common.annotation.Blocking;
 import jakarta.annotation.security.RolesAllowed;
@@ -54,7 +53,6 @@ public class TargetEventTemplates {
     @Inject TargetTemplateService.Factory targetTemplateServiceFactory;
     @Inject S3TemplateService customTemplateService;
     @Inject PresetTemplateService presetTemplateService;
-    @Inject TargetConnectionManager connectionManager;
     @Inject Logger logger;
 
     @GET

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -25,7 +25,6 @@ import org.openjdk.jmc.flightrecorder.configuration.IRecordingDescriptor;
 import io.cryostat.recordings.ActiveRecordings.LinkedRecordingDescriptor;
 import io.cryostat.recordings.ActiveRecordings.Metadata;
 import io.cryostat.targets.Target;
-import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
@@ -160,7 +159,6 @@ public class ActiveRecording extends PanacheEntity {
 
         @Inject Logger logger;
         @Inject EventBus bus;
-        @Inject TargetConnectionManager connectionManager;
         @Inject RecordingHelper recordingHelper;
 
         @PostPersist

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -361,8 +361,7 @@ public class RecordingHelper {
             RecordingOptions options,
             Map<String, String> rawLabels)
             throws QuantityConversionException {
-        return QuarkusTransaction.joiningExisting()
-                .call(() -> startRecordingImpl(target, replace, template, options, rawLabels));
+        return startRecordingImpl(target, replace, template, options, rawLabels);
     }
 
     private Uni<ActiveRecording> startRecordingImpl(
@@ -377,9 +376,12 @@ public class RecordingHelper {
                 connectionManager.executeConnectedTask(
                         target,
                         conn ->
-                                getDescriptorByName(conn, recordingName)
-                                        .map(this::mapState)
-                                        .orElse(null));
+                                QuarkusTransaction.joiningExisting()
+                                        .call(
+                                                () ->
+                                                        getDescriptorByName(conn, recordingName)
+                                                                .map(this::mapState)
+                                                                .orElse(null)));
         boolean restart = previousState == null || shouldRestartRecording(replace, previousState);
         if (!restart) {
             throw new EntityExistsException("Recording", recordingName);

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -130,7 +130,7 @@ public class TargetConnectionManager {
 
         Caffeine<URI, JFRConnection> cacheBuilder =
                 Caffeine.newBuilder()
-                        .executor(executor)
+                        .executor(virtualThreadPool)
                         .scheduler(Scheduler.systemScheduler())
                         .removalListener(this::closeConnection);
         if (ttl.isNegative()) {

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -20,12 +20,10 @@ import java.net.URI;
 import java.rmi.ConnectIOException;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 
@@ -95,7 +93,6 @@ public class TargetConnectionManager {
     private final Logger logger;
 
     private final AsyncLoadingCache<URI, JFRConnection> connections;
-    private final Map<URI, Object> targetLocks;
     private final Optional<Semaphore> semaphore;
 
     private final Duration failedBackoff;
@@ -124,7 +121,6 @@ public class TargetConnectionManager {
         this.failedBackoff = failedBackoff;
         this.failedTimeout = failedTimeout;
 
-        this.targetLocks = new ConcurrentHashMap<>();
         if (maxOpen > 0) {
             this.semaphore = Optional.of(new Semaphore(maxOpen, true));
         } else {
@@ -203,15 +199,7 @@ public class TargetConnectionManager {
                 Uni.createFrom()
                         .completionStage(connections.get(target.connectUrl))
                         .onItem()
-                        .transform(
-                                Unchecked.function(
-                                        conn -> {
-                                            synchronized (
-                                                    targetLocks.computeIfAbsent(
-                                                            target.connectUrl, k -> new Object())) {
-                                                return task.execute(conn);
-                                            }
-                                        })));
+                        .transform(Unchecked.function(task::execute)));
     }
 
     public <T> T executeConnectedTask(Target target, ConnectedTask<T> task) {
@@ -292,7 +280,6 @@ public class TargetConnectionManager {
             evt.begin();
             try {
                 connection.close();
-                targetLocks.remove(connectUrl);
             } catch (JFRJMXConnection.ConnectionFailureException e) {
                 evt.setExceptionThrown(true);
             } catch (Exception e) {

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -46,7 +45,6 @@ import io.cryostat.expressions.MatchExpressionEvaluator;
 import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target.EventKind;
 import io.cryostat.targets.Target.TargetDiscovery;
-import io.cryostat.util.URIUtil;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
@@ -108,14 +106,12 @@ public class TargetConnectionManager {
             MatchExpressionEvaluator matchExpressionEvaluator,
             CredentialsFinder credentialsFinder,
             AgentConnection.Factory agentConnectionFactory,
-            URIUtil uriUtil,
             @ConfigProperty(name = ConfigProperties.CONNECTIONS_MAX_OPEN) int maxOpen,
             @ConfigProperty(name = ConfigProperties.CONNECTIONS_TTL) Duration ttl,
             @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_BACKOFF)
                     Duration failedBackoff,
             @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
                     Duration failedTimeout,
-            Executor executor,
             Logger logger) {
         FlightRecorder.register(TargetConnectionOpened.class);
         FlightRecorder.register(TargetConnectionClosed.class);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,6 @@ kubernetes.service.host=
 
 quarkus.test.integration-test-profile=test
 
-cryostat.connections.max-open=0
 cryostat.connections.ttl=10s
 cryostat.connections.failed-backoff=2s
 cryostat.connections.failed-timeout=30s

--- a/src/test/java/io/cryostat/recordings/ActiveRecordingsTest.java
+++ b/src/test/java/io/cryostat/recordings/ActiveRecordingsTest.java
@@ -250,6 +250,8 @@ public class ActiveRecordingsTest extends AbstractTransactionalTestBase {
                         .log()
                         .all()
                         .and()
+                        .assertThat()
+                        .statusCode(201)
                         .extract()
                         .body()
                         .jsonPath()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #967

## Description of the change:
Removes thread locking structures and maximum open connections logic from the TargetConnectionManager.

## Motivation for the change:
See #967

## How to manually test:
1. Check out and build PR
2. `./smoktest.bash -O -r -t quarkus-cryostat-agent,wildfly-28`
3. Click around the UI, wait for agent instances to push harvested recordings, etc. and make sure everything is still working the same as usual.
