### PR TITLE
ci(cache): set cache download timeout

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -95,6 +95,7 @@ jobs:
     needs: [checkout-branch]
     runs-on: ubuntu-latest
     env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
       deps-cache-name: cache-yarn
       build-cache-name: cache-webpack
     name: Build and test
@@ -195,6 +196,8 @@ jobs:
   update-schemas:
     needs: [checkout-branch]
     runs-on: ubuntu-latest
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
     outputs:
       OPENAPI_STATUS: ${{ steps.schema-update.outputs.openapi_status }}
       OPENAPI_DIFF_FILE: ${{ steps.schema-update.outputs.openapi_diff_file }}

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -49,6 +49,7 @@ jobs:
     env:
       IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
       frontend-cache-name: cache-yarn
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
     permissions:
       packages: write
       contents: read
@@ -136,6 +137,8 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:
@@ -206,6 +209,7 @@ jobs:
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     env:
       CI_ARCH: ${{ matrix.arch }}
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
     steps:
     - uses: DamianReeves/write-file-action@v1.3
       with:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #972

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
