### PR TITLE
feat(credential): set default encryption key

### DIFF
--- a/src/main/java/io/cryostat/credentials/Credential.java
+++ b/src/main/java/io/cryostat/credentials/Credential.java
@@ -71,16 +71,44 @@ public class Credential extends PanacheEntity {
     public MatchExpression matchExpression;
 
     @ColumnTransformer(
-            read = "pgp_sym_decrypt(username, current_setting('encrypt.key'))",
-            write = "pgp_sym_encrypt(?, current_setting('encrypt.key'))")
+            read =
+                    """
+                    pgp_sym_decrypt(username,
+                        coalesce(
+                            current_setting('encrypt.key', true),
+                            'default_key')
+                        )
+                    """,
+            write =
+                    """
+                    pgp_sym_encrypt(?,
+                        coalesce(
+                            current_setting('encrypt.key', true),
+                            'default_key')
+                        )
+                    """)
     @Column(updatable = false, columnDefinition = "bytea")
     @NotBlank
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String username;
 
     @ColumnTransformer(
-            read = "pgp_sym_decrypt(password, current_setting('encrypt.key'))",
-            write = "pgp_sym_encrypt(?, current_setting('encrypt.key'))")
+            read =
+                    """
+                    pgp_sym_decrypt(password,
+                        coalesce(
+                            current_setting('encrypt.key', true),
+                            'default_key')
+                        )
+                    """,
+            write =
+                    """
+                    pgp_sym_encrypt(?,
+                        coalesce(
+                            current_setting('encrypt.key', true),
+                            'default_key')
+                        )
+                    """)
     @Column(updatable = false, columnDefinition = "bytea")
     @NotBlank
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-operator/issues/1134

## Description of the change:
Uses a default value of `default_key` for the `pgcrypto` functions used in the `Credential` keyring table. Normally when deploying Cryostat with `cryostat-db`, the `encrypt.key` database configuration parameter should be set and this key will be used to symmetrically encrypt/decrypt the credentials in the keyring. However, in cases where it is not possible to set such configuration parameters and where relaxed data security may be acceptable, then Cryostat should be able to cope with the database not having an `encrypt.key` configuration parameter.
