### PR TITLE
feat(diagnostics): Add endpoints and storage handling for heap dumps

### DIFF
--- a/smoketest.bash
+++ b/smoketest.bash
@@ -17,7 +17,7 @@ PULL_IMAGES=${PULL_IMAGES:-true}
 KEEP_VOLUMES=${KEEP_VOLUMES:-false}
 OPEN_TABS=${OPEN_TABS:-false}
 
-PRECREATE_BUCKETS=${PRECREATE_BUCKETS:-archivedrecordings,archivedreports,eventtemplates,probes}
+PRECREATE_BUCKETS=${PRECREATE_BUCKETS:-archivedrecordings,archivedreports,eventtemplates,probes,heapdumps}
 
 LOG_LEVEL=0
 CRYOSTAT_HTTP_HOST=${CRYOSTAT_HTTP_HOST:-cryostat}

--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -28,6 +28,9 @@ public class ConfigProperties {
             "storage.buckets.event-templates.name";
     public static final String AWS_BUCKET_NAME_PROBE_TEMPLATES =
             "storage.buckets.probe-templates.name";
+    public static final String AWS_BUCKET_NAME_HEAP_DUMPS = "storage.buckets.heap-dumps.name";
+    public static final String AWS_METADATA_PREFIX_THREAD_DUMPS =
+            "storage.metadata.prefix.thread-dumps";
     public static final String AWS_METADATA_PREFIX_RECORDINGS =
             "storage.metadata.prefix.recordings";
     public static final String AWS_METADATA_PREFIX_EVENT_TEMPLATES =
@@ -63,6 +66,9 @@ public class ConfigProperties {
     public static final String STORAGE_EXT_URL = "storage-ext.url";
     public static final String STORAGE_PRESIGNED_DOWNLOADS_ENABLED =
             "storage.presigned-downloads.enabled";
+
+    public static final String STORAGE_METADATA_HEAP_DUMPS_STORAGE_MODE =
+            "storage.metadata.heap-dumps.storage-mode";
 
     public static final String CUSTOM_TEMPLATES_DIR = "templates-dir";
     public static final String PRESET_TEMPLATES_DIR = "preset-templates-dir";

--- a/src/main/java/io/cryostat/diagnostic/BucketedDiagnosticsMetadataService.java
+++ b/src/main/java/io/cryostat/diagnostic/BucketedDiagnosticsMetadataService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.diagnostic;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.cryostat.ConfigProperties;
+import io.cryostat.StorageBuckets;
+import io.cryostat.diagnostic.Diagnostics.HeapDump;
+import io.cryostat.recordings.ArchivedRecordingMetadataService;
+import io.cryostat.util.CRUDService;
+import io.cryostat.util.HttpMimeType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ApplicationScoped
+@LookupIfProperty(
+        name = ConfigProperties.STORAGE_METADATA_THREAD_DUMPS_STORAGE_MODE,
+        stringValue = ArchivedRecordingMetadataService.METADATA_STORAGE_MODE_BUCKET)
+public class BucketedDiagnosticsMetadataService
+        implements CRUDService<String, HeapDump, HeapDump> {
+
+    @ConfigProperty(name = ConfigProperties.STORAGE_METADATA_THREAD_DUMPS_STORAGE_MODE)
+    String storageMode;
+
+    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_METADATA)
+    String bucket;
+
+    @ConfigProperty(name = ConfigProperties.AWS_METADATA_PREFIX_THREAD_DUMPS)
+    String prefix;
+
+    @Inject S3Client storage;
+    @Inject StorageBuckets buckets;
+
+    @Inject ObjectMapper mapper;
+
+    @Inject Logger logger;
+
+    void onStart(@Observes StartupEvent evt) {
+        if (!ArchivedRecordingMetadataService.METADATA_STORAGE_MODE_BUCKET.equals(storageMode)) {
+            return;
+        }
+        buckets.createIfNecessary(bucket);
+    }
+
+    @Override
+    public List<HeapDump> list() throws IOException {
+        var builder = ListObjectsV2Request.builder().bucket(bucket).prefix(prefix);
+        var objs = storage.listObjectsV2(builder.build()).contents();
+        return objs.stream()
+                .map(
+                        t -> {
+                            // TODO this entails a remote file read over the network and then some
+                            // minor processing of the received file. More time will be spent
+                            // retrieving the data than processing it, so this should be
+                            // parallelized.
+                            try {
+                                return read(t.key()).orElseThrow();
+                            } catch (IOException e) {
+                                logger.error(e);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    @Override
+    public void create(String k, HeapDump threadDump) throws IOException {
+        storage.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(prefix(k))
+                        .contentType(HttpMimeType.PLAINTEXT.mime())
+                        .build(),
+                RequestBody.fromBytes(mapper.writeValueAsBytes(threadDump)));
+    }
+
+    @Override
+    public Optional<HeapDump> read(String k) throws IOException {
+        try (var stream =
+                new BufferedInputStream(
+                        storage.getObject(
+                                GetObjectRequest.builder()
+                                        .bucket(bucket)
+                                        .key(prefix(k))
+                                        .build()))) {
+            return Optional.of(mapper.readValue(stream, HeapDump.class));
+        }
+    }
+
+    @Override
+    public void delete(String k) throws IOException {
+        storage.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(prefix(k)).build());
+    }
+
+    private String prefix(String key) {
+        return String.format("%s/%s", prefix, key);
+    }
+}

--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -15,21 +15,86 @@
  */
 package io.cryostat.diagnostic;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.cryostat.ConfigProperties;
+import io.cryostat.Producers;
+import io.cryostat.recordings.ActiveRecordings.Metadata;
+import io.cryostat.recordings.LongRunningRequestGenerator;
+import io.cryostat.recordings.LongRunningRequestGenerator.HeapDumpRequest;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
+import io.cryostat.util.HttpMimeType;
 
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.Identifier;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Path("/api/beta/diagnostics/targets/{targetId}")
 public class Diagnostics {
 
     @Inject TargetConnectionManager targetConnectionManager;
+    @Inject S3Client storage;
+    @Inject S3Presigner presigner;
+    @Inject Logger log;
+    @Inject LongRunningRequestGenerator generator;
+
+    @Inject
+    @Identifier(Producers.BASE64_URL)
+    Base64 base64Url;
+
+    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_HEAP_DUMPS)
+    String bucket;
+
+    @ConfigProperty(name = ConfigProperties.STORAGE_PRESIGNED_DOWNLOADS_ENABLED)
+    boolean presignedDownloadsEnabled;
+
+    @ConfigProperty(name = ConfigProperties.STORAGE_EXT_URL)
+    Optional<String> externalStorageUrl;
+
+    @Inject EventBus bus;
+    @Inject DiagnosticsHelper helper;
 
     @Path("/gc")
     @RolesAllowed("write")
@@ -48,5 +113,150 @@ public class Diagnostics {
                 conn ->
                         conn.invokeMBeanOperation(
                                 "java.lang:type=Memory", "gc", null, null, Void.class));
+    }
+
+    @Path("/heapdump")
+    @RolesAllowed("write")
+    @POST
+    @Operation(
+        summary = "Initiates a heap dump on the specified target",
+        description = 
+            """
+            Request the remote target to perform a heap dump.                
+            """)
+    public String heapDump(HttpServerResponse response, @RestPath long targetId) {
+        log.tracev("Initiating heap dump for target: {0}", targetId);
+        HeapDumpRequest request =
+                new HeapDumpRequest(UUID.randomUUID().toString(), targetId);
+        response.endHandler(
+                (e) -> bus.publish(LongRunningRequestGenerator.HEAP_DUMP_REQUEST_ADDRESS, request));
+        return request.id();
+    }
+
+    @Path("heapdump/upload/{jvmId}")
+    @RolesAllowed("read")
+    @Blocking
+    @POST
+    public void uploadHeapDump(@RestPath String jvmId,
+        @Parameter(required = true) @RestForm("heapDump") FileUpload heapDump,
+        @Parameter(required = false) @RestForm("labels") JsonObject rawLabels
+        ) {
+        log.tracev("Received heap dump upload request for target: {0}", jvmId);
+        jvmId = jvmId.strip();
+                Map<String, String> labels = new HashMap<>();
+        if (rawLabels != null) {
+            rawLabels.getMap().forEach((k, v) -> labels.put(k, v.toString()));
+        }
+        labels.put("jvmId", jvmId);
+        Metadata metadata = new Metadata(labels);
+        doUpload(heapDump, metadata, jvmId);
+    }
+
+    @Blocking
+    Map<String,Object> doUpload(FileUpload heapDump, Metadata metadata, String jvmId) {
+        var dump = helper.addHeapDump(jvmId, heapDump, metadata);
+        return Map.of(
+                "name",
+                dump.uuid());
+                // TODO: labels support
+                //"metadata",
+                //dump.metadata().labels());
+    }
+
+    @Path("/heapdump")
+    @RolesAllowed("read")
+    @Blocking
+    @GET
+    public List<HeapDump> getHeapDumps(@RestPath long targetId) {
+        log.tracev("Fetching heap dumps for target: {0}", targetId);
+        return helper.getHeapDumps(targetId);
+    }
+
+    @DELETE
+    @Blocking
+    @Path("/heapdump/{heapDumpId}")
+    @RolesAllowed("write")
+    public void deleteHeapDump(@RestPath String heapDumpId, @RestPath long targetId) {
+        try {
+            log.tracev("Deleting thread dump with ID: {0}", heapDumpId);
+            helper.deleteHeapDump(heapDumpId, targetId);
+        } catch (NoSuchKeyException e) {
+            throw new NotFoundException(e);
+        } catch (BadRequestException e) {
+            throw e;
+        }
+    }
+
+    @Path("/heapdump/download/{encodedKey}")
+    @RolesAllowed("read")
+    @Blocking
+    @GET
+    public RestResponse<Object> handleStorageDownload(
+            @RestPath String encodedKey, @RestQuery String query) throws URISyntaxException {
+        Pair<String, String> decodedKey = helper.decodedKey(encodedKey);
+        log.tracev("Handling download Request for key: {0}", decodedKey);
+        log.tracev("Handling download Request for query: {0}", query);
+        String key = helper.heapDumpKey(decodedKey);
+        try {
+            storage.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build())
+                    .sdkHttpResponse();
+        } catch (NoSuchKeyException e) {
+            throw new NotFoundException(e);
+        }
+
+        if (!presignedDownloadsEnabled) {
+            return ResponseBuilder.ok()
+                    .header(
+                            HttpHeaders.CONTENT_DISPOSITION,
+                            String.format("attachment; filename=\"%s\"", decodedKey.getValue()))
+                    .header(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime())
+                    .entity(helper.getHeapDumpStream(encodedKey))
+                    .build();
+        }
+
+        log.tracev("Handling presigned download request for {0}", decodedKey);
+        GetObjectRequest getRequest = GetObjectRequest.builder().bucket(bucket).key(key).build();
+        GetObjectPresignRequest presignRequest =
+                GetObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(1))
+                        .getObjectRequest(getRequest)
+                        .build();
+        PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
+        URI uri = presignedRequest.url().toURI();
+        if (externalStorageUrl.isPresent()) {
+            String extUrl = externalStorageUrl.get();
+            if (StringUtils.isNotBlank(extUrl)) {
+                URI extUri = new URI(extUrl);
+                uri =
+                        new URI(
+                                extUri.getScheme(),
+                                extUri.getAuthority(),
+                                URI.create(String.format("%s/%s", extUri.getPath(), uri.getPath()))
+                                        .normalize()
+                                        .getPath(),
+                                uri.getQuery(),
+                                uri.getFragment());
+            }
+        }
+        ResponseBuilder<Object> response =
+                ResponseBuilder.create(RestResponse.Status.PERMANENT_REDIRECT);
+        if (StringUtils.isNotBlank(query)) {
+            response =
+                    response.header(
+                            HttpHeaders.CONTENT_DISPOSITION,
+                            String.format(
+                                    "attachment; filename=\"%s\"",
+                                    new String(base64Url.decode(query), StandardCharsets.UTF_8)));
+        }
+        return response.location(uri).build();
+    }
+
+    public record HeapDump(String jvmId, String downloadUrl, String uuid, long lastModified) {
+
+        public HeapDump {
+            Objects.requireNonNull(jvmId);
+            Objects.requireNonNull(downloadUrl);
+            Objects.requireNonNull(uuid);
+        }
     }
 }

--- a/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
+++ b/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.diagnostic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import io.cryostat.ConfigProperties;
+import io.cryostat.Producers;
+import io.cryostat.StorageBuckets;
+import io.cryostat.diagnostic.Diagnostics.HeapDump;
+import io.cryostat.libcryostat.sys.Clock;
+import io.cryostat.recordings.ActiveRecordings.Metadata;
+import io.cryostat.recordings.ArchivedRecordingMetadataService.StorageMode;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+import io.cryostat.ws.MessagingServer;
+import io.cryostat.ws.Notification;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.common.annotation.Identifier;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@ApplicationScoped
+public class DiagnosticsHelper {
+    
+    @ConfigProperty(name = ConfigProperties.AWS_BUCKET_NAME_HEAP_DUMPS)
+    String heapDumpBucket;
+
+    @ConfigProperty(name = ConfigProperties.STORAGE_METADATA_STORAGE_MODE)
+    String storageMode;
+
+    @Inject
+    @Identifier(Producers.BASE64_URL)
+    Base64 base64Url;
+
+    @Inject S3Client storage;
+    @Inject Logger log;
+    @Inject Clock clock;
+
+    @Inject Instance<BucketedDiagnosticsMetadataService> metadataService;
+
+    private static final String DUMP_HEAP = "dumpHeap";
+    private static final String HOTSPOT_DIAGNOSTIC_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
+    static final String HEAP_DUMP_REQUESTED = "HeapDumpRequested";
+    static final String HEAP_DUMP_DELETED = "HeapDumpDeleted";
+    static final String HEAP_DUMP_UPLOADED = "HeapDumpUploaded";
+
+    @Inject EventBus bus;
+    @Inject TargetConnectionManager targetConnectionManager;
+    @Inject StorageBuckets buckets;
+
+    void onStart(@Observes StartupEvent evt) {
+        log.tracev("Creating heap dump bucket: {0}", heapDumpBucket);
+        buckets.createIfNecessary(heapDumpBucket);
+    }
+
+    public void dumpHeap(long targetId) {
+        log.tracev(
+                "Heap Dump request received for Target: {0}", targetId);
+        Object[] params = new Object[1];
+        String[] signature = new String[] {String[].class.getName()};
+        // Heap Dump Retrieval is handled by a separate endpoint
+        targetConnectionManager.executeConnectedTask(
+                Target.getTargetById(targetId),
+                conn -> conn.invokeMBeanOperation(
+                    HOTSPOT_DIAGNOSTIC_BEAN_NAME, DUMP_HEAP, params, signature, String.class)
+                );
+    }
+
+    public void deleteHeapDump(String heapDumpID, long targetId)
+            throws BadRequestException, NoSuchKeyException {
+        String jvmId = Target.getTargetById(targetId).jvmId;
+        String key = heapDumpKey(jvmId, heapDumpID);
+        if (Objects.isNull(jvmId)) {
+            log.errorv("TargetId {0} failed to resolve to a jvmId", targetId);
+            throw new BadRequestException();
+        } else {
+            storage.headObject(HeadObjectRequest.builder()
+                .bucket(heapDumpBucket).key(key).build());
+            storage.deleteObject(DeleteObjectRequest.builder()
+                .bucket(heapDumpBucket).key(key).build());
+        }
+    }
+
+    public List<HeapDump> getHeapDumps(long targetId) {
+        return listHeapDumps(targetId).stream()
+                .map(
+                        item -> {
+                            try {
+                                return convertObject(item);
+                            } catch (Exception e) {
+                                log.error(e);
+                                return null;
+                            }
+                        })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private HeapDump convertObject(S3Object object) throws Exception {
+        String jvmId = object.key().split("/")[0];
+        String uuid = object.key().split("/")[1];
+        return new HeapDump(
+                jvmId, heapDumpDownloadUrl(jvmId, uuid), uuid, object.lastModified().toEpochMilli());
+    }
+
+    public HeapDump addHeapDump(String jvmId, FileUpload heapDump, Metadata metadata) {
+        String filename = heapDump.fileName().strip();
+        if (StringUtils.isBlank(filename)) {
+            throw new BadRequestException();
+        }
+        if (!filename.endsWith(".hprof")) {
+            filename = filename + ".hprof";
+        }
+        log.tracev("Putting Heap dump into storage with key: {0}", heapDumpKey(jvmId, filename));
+        var reqBuilder =
+                PutObjectRequest.builder()
+                        .bucket(heapDumpBucket)
+                        .key(heapDumpKey(jvmId, filename))
+                        // FIXME: Is this correct?
+                        .contentType(MediaType.TEXT_PLAIN);
+        switch (storageMode(storageMode)) {
+            case StorageMode.TAGGING:
+                // TODO: label support
+                /*reqBuilder =
+                        reqBuilder.tagging(createMetadataTagging(new Metadata(labels)));*/
+                break;
+            case StorageMode.METADATA:
+                break;
+            case StorageMode.BUCKET:
+                try {
+                    metadataService
+                            .get()
+                            .create(
+                                    heapDumpKey(jvmId, filename),
+                                    new HeapDump(
+                                            jvmId,
+                                            heapDumpDownloadUrl(jvmId, filename),
+                                            filename,
+                                            clock.now().getEpochSecond()));
+                    break;
+                } catch (IOException ioe) {
+                    log.warnv("Exception thrown while adding thread dump to storage: {0}", ioe);
+                }
+            default:
+                throw new IllegalStateException();
+        }
+        storage.putObject(reqBuilder.build(), RequestBody.fromFile(heapDump.filePath()));
+        var dump = new HeapDump(jvmId, heapDumpDownloadUrl(jvmId, filename), filename, clock.now().getEpochSecond());
+        var target = Target.getTargetByJvmId(jvmId);
+        bus.publish(
+            MessagingServer.class.getName(),
+            new Notification(HEAP_DUMP_UPLOADED, Map.of("targetId", target.get().id, "filename", filename)));
+        return dump;
+    }
+
+    public String heapDumpDownloadUrl(String jvmId, String filename) {
+        return String.format(
+                "/api/beta/diagnostics/heapdump/download/%s", encodedKey(jvmId, filename));
+    }
+
+    public String encodedKey(String jvmId, String uuid) {
+        Objects.requireNonNull(jvmId);
+        Objects.requireNonNull(uuid);
+        return base64Url.encodeAsString(
+                (heapDumpKey(jvmId, uuid)).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String heapDumpKey(String jvmId, String uuid) {
+        return (jvmId + "/" + uuid).strip();
+    }
+
+    public String heapDumpKey(Pair<String, String> pair) {
+        return heapDumpKey(pair.getKey(), pair.getValue());
+    }
+
+    public InputStream getHeapDumpStream(String jvmId, String threadDumpID) {
+        return getHeapDumpStream(encodedKey(jvmId, threadDumpID));
+    }
+
+    public InputStream getHeapDumpStream(String encodedKey) {
+        Pair<String, String> decodedKey = decodedKey(encodedKey);
+        var key = heapDumpKey(decodedKey);
+
+        GetObjectRequest getRequest = GetObjectRequest.builder().bucket(heapDumpBucket).key(key).build();
+
+        return storage.getObject(getRequest);
+    }
+
+    public Pair<String, String> decodedKey(String encodedKey) {
+        String key = new String(base64Url.decode(encodedKey), StandardCharsets.UTF_8);
+        String[] parts = key.split("/");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException();
+        }
+        return Pair.of(parts[0], parts[1]);
+    }
+
+        public List<S3Object> listHeapDumps(long targetId) {
+        var builder = ListObjectsV2Request.builder().bucket(heapDumpBucket);
+        String jvmId = Target.getTargetById(targetId).jvmId;
+        if (Objects.isNull(jvmId)) {
+            log.errorv("TargetId {0} failed to resolve to a jvmId", targetId);
+        }
+        if (StringUtils.isNotBlank(jvmId)) {
+            builder = builder.prefix(jvmId);
+        }
+        return storage.listObjectsV2(builder.build()).contents();
+    }
+
+    public static StorageMode storageMode(String name) {
+        return Arrays.asList(StorageMode.values()).stream()
+                .filter(s -> s.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -37,7 +37,7 @@ quarkus.datasource.devservices.db-name=quarkus
 # !!!
 
 quarkus.s3.devservices.enabled=true
-quarkus.s3.devservices.buckets=archivedrecordings,archivedreports,eventtemplates,probes
+quarkus.s3.devservices.buckets=archivedrecordings,archivedreports,eventtemplates,probes,heapdumps
 # FIXME the following overrides should not be required, but currently seem to help with testcontainers reliability
 quarkus.aws.devservices.localstack.image-name=quay.io/hazelcast_cloud/localstack:4.1.1
 quarkus.aws.devservices.localstack.container-properties.START_WEB=0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -120,13 +120,16 @@ storage.presigned-downloads.enabled=false
 storage.metadata.storage-mode=tagging
 storage.metadata.archives.storage-mode=${storage.metadata.storage-mode}
 storage.metadata.event-templates.storage-mode=${storage.metadata.storage-mode}
+storage.metadata.heap-dumps.storage-mode=${storage.metadata.storage-mode}
 storage.buckets.creation-retry.period=10s
 storage.buckets.archives.name=archivedrecordings
 storage.buckets.event-templates.name=eventtemplates
 storage.buckets.probe-templates.name=probes
+storage.buckets.heap-dumps.name=heapdumps
 storage.buckets.metadata.name=metadata
 storage.metadata.prefix.recordings=${storage.buckets.archives.name}
 storage.metadata.prefix.event-templates=${storage.buckets.event-templates.name}
+storage.metadata.prefix.heap-dumps=${storage.buckets.heap-dumps.name}
 
 quarkus.quinoa.build-dir=dist
 quarkus.quinoa.enable-spa-routing=true


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat/issues/134 

Adds an initial implementation for performing a heap dump (POST /heapdump), as well as endpoints for storage interactions (delete, list, upload)

Opening as draft for now, subject to change as frontend is implemented and other parts are changed.

TODO list:
- Tests
- support for labels, similar to recordings (upload endpoint currently takes labels but doesn't do anything with them yet)
- Refactoring once https://github.com/cryostatio/cryostat/pull/894 is merged