### PR TITLE
fix(dockerfile): remove system property binding quarkus.http.host to 0.0.0.0

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -647,7 +647,7 @@ info:
     name: Apache 2.0
     url: https://github.com/cryostatio/cryostat/blob/main/LICENSE
   title: Cryostat API
-  version: 4.0.1-snapshot
+  version: 4.0.2-snapshot
 openapi: 3.0.3
 paths:
   /api/beta/diagnostics/targets/{targetId}/gc:

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -85,7 +85,8 @@ EXPOSE 8181
 USER 185
 LABEL io.cryostat.component=cryostat
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV QUARKUS_HTTP_HOST=0.0.0.0
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 ENTRYPOINT [ "/deployments/app/entrypoint.bash", "/opt/jboss/container/java/run/run-java.sh" ]


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #952
See https://github.com/cryostatio/cryostat-operator/pull/1138
See https://github.com/cryostatio/cryostat-helm/pull/257

## Description of the change:
Removes the `-Dquarkus.http.host=0.0.0.0` system property present in the default `JAVA_OPTS_APPEND` environment variable, and sets this as a `QUARKUS_HTTP_HOST=0.0.0.0` environment variable instead.

## Motivation for the change:
1. Setting it as an environment variable is easier to manage, since the variable is a single key-value pair. The system property within `JAVA_OPTS_APPEND` is part of multiple key-value pairs, and more easily (accidentally) overridden.
2. Worse, the system property may not be accidentally overridden - it may be an accidental override. Quarkus (via smallrye-config) will use system properties before environment variables when determining config properties. If `JAVA_OPTS_APPEND` is not overridden, then this `-Dquarkus.http.host` system property will be present, and Quarkus will use its value even if the final deployment does specify a `QUARKUS_HTTP_HOST` environment variable.