### PR TITLE
chore(auth): deprecate oauth2 logout endpoint

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1562,13 +1562,17 @@ paths:
         - Health
   /api/v4/logout:
     post:
+      deprecated: true
       responses:
         "200":
           content:
             application/json:
               schema: {}
           description: OK
-      summary: OAuth2 sign out. Invalidate the current user session
+      summary: |
+        OAuth2 sign out. Invalidate the current user session.
+        Clients should directly visit the /oauth2/sign_out endpoint rather than relying on this endpoint
+        and its redirect response.
       tags:
         - Auth
   /api/v4/matchExpressions:

--- a/src/main/java/io/cryostat/security/Auth.java
+++ b/src/main/java/io/cryostat/security/Auth.java
@@ -36,7 +36,14 @@ public class Auth {
     @Path("/api/v4/logout")
     @PermitAll
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "OAuth2 sign out. Invalidate the current user session")
+    @Operation(
+            summary =
+                    """
+                    OAuth2 sign out. Invalidate the current user session.
+                    Clients should directly visit the /oauth2/sign_out endpoint rather than relying on this endpoint
+                    and its redirect response.
+                    """)
+    @Deprecated(since = "4.1", forRemoval = true)
     public RestResponse<Object> logout(@Context RoutingContext context) {
         return ResponseBuilder.create(RestResponse.Status.PERMANENT_REDIRECT)
                 .location(URI.create("/oauth2/sign_out"))


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat-web#1808
