### PR TITLE
fix(sql): set DiscoveryNode sequence increment to 50

### DIFF
--- a/src/main/resources/db/migration/V4.0.3__cryostat.sql
+++ b/src/main/resources/db/migration/V4.0.3__cryostat.sql
@@ -1,0 +1,1 @@
+alter sequence DiscoveryNode_SEQ increment by 50;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #870

## Description of the change:
Sets the DiscoveryNode ID increment to 50.

## Motivation for the change:
Sets the increment, which is the default used by Hibernate. Without this change, the original 4.0 Flyway script setup has a bug where Hibernate is expecting increments of 50, but the table/sequence is set up to increment by 1s. This results in ConstraintViolationExceptions once enough records are created.
