### PR TITLE
feat(agent): cheaper endpoint for keyring credential check

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -976,8 +976,12 @@ paths:
               type: object
         required: true
       responses:
-        "201":
-          description: Created
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Credential'
+          description: OK
         "400":
           description: Bad Request
       summary: Check if a Credential already exists with an identical MatchExpression script.

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -202,10 +202,12 @@ public class Discovery {
             summary =
                     "Check if a Credential already exists with an identical MatchExpression"
                             + " script.")
-    public RestResponse<Void> checkCredentialByScript(@RestForm String script) {
-        var exists = Credential.count("matchExpression.script", script) > 0;
-        return RestResponse.status(
-                exists ? RestResponse.Status.NO_CONTENT : RestResponse.Status.NOT_FOUND);
+    public RestResponse<Credential> checkCredentialExists(@RestForm String script) {
+        var result = Credential.find("matchExpression.script", script);
+        if (result.count() == 0) {
+            return RestResponse.notFound();
+        }
+        return RestResponse.ok(result.firstResult());
     }
 
     @Transactional


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1075

## Description of the change:
Adds a new API endpoint which is intended for the Agent to use to check whether its credentials are present in Cryostat's keyring.

## Motivation for the change:
The Agent currently uses `GET /api/v4/credentials` for this purpose. That is a relatively expensive API call because it entails querying for all M stored credentials and all N targets, then for each M\*N evaluating if the credential's match expression applies to the target. This was originally intended only for the UI's Security view and its stored credentials table, which should not be a very frequently visited view, so its relative heaviness was not a problem. However, since the Agent now also uses it as a hacky check to determine if there is already a stored credential which matches what it would submit for itself (by using the same match expression), the endpoint is called much more frequently - whenever an Agent instance is registering with Cryostat. Since each Agent is a target and adds a credential, the M*N complexity scales up quickly with each new Agent instance, so the heaviness of the endpoint starts to matter and in larger deployments can cause Agents to fail to register because the endpoint takes too long to respond.

This new endpoint allows clients (Agents) to POST a form containing a `script` field. Cryostat simply queries the database for a simple join of credentials to match expressions and selects for identical scripts. If there are no results then the response is an HTTP 404. If there are results then the response is an HTTP 200 and the first (probably only) result is sent as the response body. This requires only M queries (instead of M*N - no need to query all targets), does the join on the database side, and does not require match expression evaluation, so it will be a much lighter operation.

## How to manually test:
0. Check out https://github.com/cryostatio/cryostat-agent/pull/726 and `./mvnw install`, then rebuild the https://github.com/cryostatio/test-applications/blob/main/quarkus-agent locally to include the new Agent
1. Check out and build this PR
2. `./smoketest.bash -O -t quarkus-cryostat-agent`
3. Open UI > Topology and ensure Agent successfully registers. Wait ~10 minutes and ensure Agent does not lose registration or become re-discovered.
4. (optional) use Cryostat Operator to deploy updated Cryostat, deploy updated sample application, and test scaling up the sample application deployment to a large number of replicas
