### PR TITLE
fix(recordings): Delete file uploads when complete

### DIFF
--- a/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
+++ b/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
@@ -18,6 +18,7 @@ package io.cryostat.diagnostic;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -336,6 +337,13 @@ public class DiagnosticsHelper {
         bus.publish(
                 MessagingServer.class.getName(),
                 new Notification(event.category().category(), event.payload()));
+
+        try {
+            // Clean up temporary files
+            Files.delete(heapDump.filePath());
+        } catch (IOException ioe) {
+            log.warn(ioe);
+        }
         return dump;
     }
 

--- a/src/main/java/io/cryostat/events/EventTemplates.java
+++ b/src/main/java/io/cryostat/events/EventTemplates.java
@@ -16,6 +16,7 @@
 package io.cryostat.events;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -154,6 +155,9 @@ public class EventTemplates {
                     .build();
         } catch (InvalidEventTemplateException | InvalidXmlException e) {
             throw new BadRequestException(e);
+        } finally {
+            // Clean up temporary files
+            Files.delete(body.filePath());
         }
     }
 

--- a/src/main/java/io/cryostat/jmcagent/JMCAgentTemplates.java
+++ b/src/main/java/io/cryostat/jmcagent/JMCAgentTemplates.java
@@ -16,6 +16,7 @@
 package io.cryostat.jmcagent;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import io.cryostat.core.jmcagent.ProbeTemplate;
@@ -88,6 +89,11 @@ public class JMCAgentTemplates {
             throw new BadRequestException("Request must contain a 'probeTemplate' file upload");
         }
         var probeTemplate = service.addTemplate(body.filePath(), name);
+        try {
+            Files.delete(body.filePath());
+        } catch (IOException ioe) {
+            logger.warn(ioe);
+        }
         return ResponseBuilder.<ProbeTemplate>created(
                         uriInfo.getAbsolutePathBuilder().path(probeTemplate.getFileName()).build())
                 .entity(probeTemplate)

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -264,6 +265,12 @@ public class ArchivedRecordings {
         var archivedRecording = recordingHelper.uploadArchivedRecording(jvmId, recording, metadata);
         logger.trace("Upload complete");
 
+        // Clean up the recording file after uploading
+        try {
+            Files.delete(recording.filePath());
+        } catch (IOException ioe) {
+            logger.warn(ioe);
+        }
         return Map.of(
                 "name",
                 archivedRecording.name(),

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
@@ -1360,6 +1361,12 @@ public class RecordingHelper {
         bus.publish(
                 MessagingServer.class.getName(),
                 new Notification(event.category().category(), event.payload()));
+        // Clean up the recording file after uploading
+        try {
+            Files.delete(recording.filePath());
+        } catch (IOException ioe) {
+            logger.warn(ioe);
+        }
         return archivedRecording;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/cryostatio/cryostat/issues/1046

Currently there are several instances where files uploaded to cryostat aren't cleaned up once they're no longer needed. This PR addresses that. Cleans up temporary files from file uploads, similar to what is done on the agent side for heap dumps.  Thread Dumps are returned from the agent as a string so there are no temporary files to clean up there.

## How to manually test:
1. Build this PR, deploy it in the environment of your choice (I tested it via the operator in a crc cluster)
2. Test each action (uploading a recording manually, uploading through the agent, uploading an event template, triggering a heap dump)
3. Check the cryostat container's fileystem, make sure the temporary files are cleaned up