### PR TITLE
fix(labels): Fix archived recording filter

### DIFF
--- a/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
@@ -120,7 +120,7 @@ public class ArchivedRecordings {
                     n ->
                             sourceTarget == null
                                     || Objects.equals(
-                                            r.metadata().labels().get("connectUrl"), sourceTarget);
+                                            r.metadata().labels().get("jvmId"), sourceTarget);
             Predicate<ArchivedRecording> matchesLabels =
                     n ->
                             labels == null


### PR DESCRIPTION
Related to: [#<issue number>](https://github.com/cryostatio/cryostat-web/issues/1842)

## Description of the change:
Changes the sourceTarget filter to match the jvmId in labels rather than connectUrl. This brings it in line with the frontend which uses sourceTarget to filter/match by the directory's jvm ID. (https://github.com/cryostatio/cryostat-web/blob/20e9651b0e7a64a85ff56b627bcb6f7d508d944c/src/app/Shared/Services/Api.service.tsx#L569)

## How to manually test:

- Check out and build this PR as well as https://github.com/cryostatio/cryostat-web/pull/1861
- Run a smoketest, attempt to add labels to a recording in the all archives view
- Verify it works as expected and generates the expected network traffic