### PR TITLE
fix(diagnostics): use longer timeout for slow operations

### DIFF
--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -97,6 +97,8 @@ public class LongRunningRequestGenerator {
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_UPLOAD_TIMEOUT)
     Duration uploadFailedTimeout;
 
+    public LongRunningRequestGenerator() {}
+
     @ConsumeEvent(value = THREAD_DUMP_ADDRESS, blocking = true)
     @Transactional
     public void onMessage(ThreadDumpRequest request) {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/1131

## Description of the change:
Changes the heap dump and thread dump operations from using the connection failure timeout (default 30 seconds) to the upload failure timeout (default 30 **minutes**), since these operations - especially heap dumps - are expected to take more time in real scenarios.
