### PR TITLE
perf(rules): use worker pool to perform Rule execution

### DIFF
--- a/src/main/java/io/cryostat/rules/RuleService.java
+++ b/src/main/java/io/cryostat/rules/RuleService.java
@@ -76,6 +76,7 @@ public class RuleService {
     private final BlockingQueue<ActivationAttempt> activations =
             new PriorityBlockingQueue<>(255, Comparator.comparing(t -> t.attempts.get()));
     private final ExecutorService activator = Executors.newSingleThreadExecutor();
+    private final ExecutorService workers = Executors.newVirtualThreadPerTaskExecutor();
 
     void onStart(@Observes StartupEvent ev) {
         logger.trace("RuleService started");
@@ -101,8 +102,7 @@ public class RuleService {
                             break;
                         }
                         final ActivationAttempt fAttempt = attempt;
-                        Infrastructure.getDefaultWorkerPool()
-                                .submit(() -> fireAttemptExecution(fAttempt));
+                        workers.submit(() -> fireAttemptExecution(fAttempt));
                     }
                 });
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1154

## Description of the change:
Use single threaded "activator" executor in RuleService to handle startup job of activating Rules against Targets, and then to process dispatch of ActivationAttempt queue. Activator only takes elements from queue and then fires an actual execution job to be processed on a "worker" pool, which uses virtual threads, rather than directly handling processing itself.

## Motivation for the change:
Allows concurrent/parallel activation of Rules against targets. Prior to this change Rule activation would only happen serially, so if there are many discovered targets and if connections to each target are a bit slow, then Rule overall activation could take significant time. Importantly, if a discovered target is not connectable at all and would produce a connection timeout, performing these activations concurrently on different virtual threads rather than serially on a single thread allows the possible activations to take place without needing to wait for the impossible activations to time out.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O -t quarkus-cryostat-agent,vertx-fib-demo`
3. Check that rule activation works as normal, but quicker than before.
