### PR TITLE
fix(health): apply timeout to connected service health checks

### DIFF
--- a/src/main/java/io/cryostat/ConfigProperties.java
+++ b/src/main/java/io/cryostat/ConfigProperties.java
@@ -56,6 +56,8 @@ public class ConfigProperties {
     public static final String CONNECTIONS_FAILED_TIMEOUT = "cryostat.connections.failed-timeout";
     public static final String CONNECTIONS_UPLOAD_TIMEOUT = "cryostat.connections.upload-timeout";
 
+    public static final String CONNECTIONS_HEALTH_TIMEOUT =
+            "cryostat.services.health-check.timeout";
     public static final String REPORTS_FILTER = "cryostat.services.reports.filter";
     public static final String REPORTS_SIDECAR_URL = "quarkus.rest-client.reports.url";
     public static final String REPORTS_USE_PRESIGNED_TRANSFER =

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ cryostat.connections.ttl=10s
 cryostat.connections.failed-backoff=2s
 cryostat.connections.failed-timeout=30s
 cryostat.connections.upload-timeout=30m
+cryostat.services.health-check.timeout=5s
 quarkus.cache.enabled=true
 cryostat.services.reports.memory-cache.enabled=true
 quarkus.cache.caffeine.matchexpressions.maximum-size=512


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1165

## Description of the change:
Applies a short 5 second timeout to connected service (ex. jfr-datasource, cryostat-reports) health checks which are included as part of Cryostat's overall `GET /health` endpoint. Previously there was no timeout applied here, so Cryostat could wait indefinitely for a response, which would also mean the original client making the `GET /health` request could wait indefinitely for a response unless it had its own timeout. If the connected services do not respond to a health check quickly enough, Cryostat should simply consider those connections unhealthy and report them as unavailable.