### PR TITLE
test(storage): configurable cryostat-storage container tag

### DIFF
--- a/src/test/java/io/cryostat/resources/S3StorageResource.java
+++ b/src/test/java/io/cryostat/resources/S3StorageResource.java
@@ -30,7 +30,7 @@ public class S3StorageResource
         implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
     protected static int S3_PORT = 8333;
-    protected static final String IMAGE_NAME = "quay.io/cryostat/cryostat-storage:latest";
+    protected static final String IMAGE_NAME = "quay.io/cryostat/cryostat-storage:STORAGE_VERSION";
     protected static final Map<String, String> envMap =
             Map.of(
                     "DATA_DIR", "/tmp",
@@ -46,8 +46,16 @@ public class S3StorageResource
 
     @Override
     public Map<String, String> start() {
+        String storageVersion =
+                Optional.ofNullable(
+                                System.getProperty(
+                                        "cryostat-storage.version",
+                                        System.getenv("CRYOSTAT_STORAGE_VERSION")))
+                        .orElse("latest");
         container =
-                new GenericContainer<>(DockerImageName.parse(IMAGE_NAME))
+                new GenericContainer<>(
+                                DockerImageName.parse(
+                                        IMAGE_NAME.replace("STORAGE_VERSION", storageVersion)))
                         .withExposedPorts(S3_PORT)
                         .withEnv(envMap)
                         .withTmpFs(Map.of("/data", "rw"))


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1198

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
