### PR TITLE
feat(async-profiler): initial support for cryostat-agent integration

### DIFF
--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -13,6 +13,7 @@ services:
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar
         -javaagent:/deployments/app/jmc-agent.jar
+        -javaagent:/deployments/app/async-profiler.jar
         -Dcom.sun.management.jmxremote.autodiscovery=false
         -Dcom.sun.management.jmxremote
         -Dcom.sun.management.jmxremote.port=22222

--- a/schema-generator/dependency-reduced-pom.xml
+++ b/schema-generator/dependency-reduced-pom.xml
@@ -10,14 +10,14 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.1</version>
+        <version>3.15.0</version>
         <configuration>
           <release>21</release>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -28,7 +28,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -103,7 +103,7 @@
   </build>
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
-    <com.diffplug.spotless.maven.plugin.version>3.1.0</com.diffplug.spotless.maven.plugin.version>
+    <com.diffplug.spotless.maven.plugin.version>3.2.1</com.diffplug.spotless.maven.plugin.version>
     <maven.compiler.source>21</maven.compiler.source>
     <com.mycila.license.maven.plugin.version>5.0.0</com.mycila.license.maven.plugin.version>
     <maven.compiler.target>21</maven.compiler.target>

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -104,7 +104,7 @@ components:
       type: object
     AsyncProfile:
       properties:
-        endtime:
+        duration:
           format: int64
           type: integer
         id:
@@ -112,7 +112,7 @@ components:
         size:
           format: int64
           type: integer
-        starttime:
+        startTime:
           format: int64
           type: integer
       type: object

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -109,6 +109,9 @@ components:
           type: integer
         id:
           type: string
+        size:
+          format: int64
+          type: integer
         starttime:
           format: int64
           type: integer

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -102,6 +102,30 @@ components:
             $ref: '#/components/schemas/ThreadDump'
           type: array
       type: object
+    AsyncProfile:
+      properties:
+        endtime:
+          format: int64
+          type: integer
+        id:
+          type: string
+        starttime:
+          format: int64
+          type: integer
+      type: object
+    AsyncProfilerStatus:
+      properties:
+        availableEvents:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+        currentProfile:
+          $ref: '#/components/schemas/StartProfileRequest'
+        status:
+          $ref: '#/components/schemas/ProfilerStatus'
+      type: object
     AuthResponse:
       properties:
         username:
@@ -524,6 +548,12 @@ components:
         xml:
           type: string
       type: object
+    ProfilerStatus:
+      enum:
+        - STOPPED
+        - RUNNING
+        - UNKNOWN
+      type: string
     RecordingState:
       enum:
         - NEW
@@ -651,6 +681,21 @@ components:
           $ref: '#/components/schemas/Date'
         triggerCondition:
           type: string
+      type: object
+    StartProfileRequest:
+      properties:
+        duration:
+          format: int64
+          type: integer
+        events:
+          items:
+            type: string
+          type: array
+        id:
+          type: string
+        startTime:
+          format: int64
+          type: integer
       type: object
     Suggestion:
       properties:
@@ -1243,6 +1288,116 @@ paths:
       summary: Upload a JFR binary file to archives, associated with a particular target
       tags:
         - Archived Recordings
+  /api/beta/targets/{targetId}/async-profiler:
+    get:
+      parameters:
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/AsyncProfile'
+                type: array
+          description: OK
+      summary: List existing async-profiler profiles on the specified target
+      tags:
+        - Async Profiler
+    post:
+      parameters:
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartProfileRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: OK
+        "400":
+          description: Bad Request
+      summary: Create a new async-profiler profile on the specified target
+      tags:
+        - Async Profiler
+  /api/beta/targets/{targetId}/async-profiler/status:
+    get:
+      parameters:
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncProfilerStatus'
+          description: OK
+      summary: Get specified target's async-profiler status
+      tags:
+        - Async Profiler
+  /api/beta/targets/{targetId}/async-profiler/{profileId}:
+    delete:
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "204":
+          description: No Content
+      summary: Delete an async-profiler profile from the specified target
+      tags:
+        - Async Profiler
+    get:
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: OK
+      summary: Download an async-profiler binary file in JFR format
+      tags:
+        - Async Profiler
   /api/beta/targets/{targetId}/smart_triggers:
     get:
       parameters:

--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.asyncprofiler;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+import io.cryostat.targets.AgentClient.AsyncProfilerStatus;
+import io.cryostat.targets.AgentClient.ProfilerStatus;
+import io.cryostat.targets.AgentClient.StartProfileRequest;
+import io.cryostat.targets.AgentConnection;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+import io.cryostat.util.HttpMimeType;
+import io.cryostat.ws.MessagingServer;
+import io.cryostat.ws.Notification;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.runtime.ShutdownEvent;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+
+@Path("/api/beta/targets/{targetId}/async-profiler")
+public class AsyncProfiler {
+
+    public static final String ASYNC_PROFILER_CREATED = "AsyncProfilerCreated";
+    public static final String ASYNC_PROFILER_STOPPED = "AsyncProfilerStopped";
+    public static final String ASYNC_PROFILER_DELETED = "AsyncProfilerDeleted";
+
+    public enum AsyncProfilerEventCategory {
+        CREATED(ASYNC_PROFILER_CREATED),
+        STOPPED(ASYNC_PROFILER_STOPPED),
+        DELETED(ASYNC_PROFILER_DELETED),
+        ;
+
+        private final String category;
+
+        private AsyncProfilerEventCategory(String category) {
+            this.category = category;
+        }
+
+        public String category() {
+            return category;
+        }
+    }
+
+    @Inject TargetConnectionManager tcm;
+    @Inject Scheduler scheduler;
+    @Inject EventBus bus;
+    @Inject Logger logger;
+
+    void onStop(@Observes ShutdownEvent evt) throws SchedulerException {
+        scheduler.shutdown();
+    }
+
+    @POST
+    @Blocking
+    @Transactional
+    @RolesAllowed("write")
+    @Operation(summary = "Create a new async-profiler profile on the specified target")
+    public Uni<String> create(@RestPath long targetId, StartProfileRequest req) {
+        Target target = Target.find("id", targetId).singleResult();
+        Duration duration = Duration.ofSeconds(req.duration());
+
+        return executeUni(target, conn -> conn.dumpAsyncProfile(req.events(), duration))
+                .invoke(
+                        (id) -> {
+                            JobKey key =
+                                    new JobKey(Long.toString(target.id), "async-profiler-update");
+                            JobDetail job =
+                                    JobBuilder.newJob(AsyncProfilerUpdateJob.class)
+                                            .withIdentity(key)
+                                            .usingJobData("id", id)
+                                            .usingJobData("targetId", target.id)
+                                            .usingJobData("duration", req.duration())
+                                            .build();
+                            Trigger trigger =
+                                    TriggerBuilder.newTrigger()
+                                            .withIdentity(
+                                                    job.getKey().getName(), job.getKey().getGroup())
+                                            // TODO make configurable
+                                            .startAt(
+                                                    Date.from(
+                                                            Instant.now()
+                                                                    .plus(duration)
+                                                                    .plusSeconds(2)))
+                                            // TODO make configurable
+                                            .withSchedule(
+                                                    SimpleScheduleBuilder.simpleSchedule()
+                                                            .withIntervalInSeconds(2)
+                                                            .withMisfireHandlingInstructionNextWithExistingCount()
+                                                            .withRepeatCount(5))
+                                            .build();
+                            try {
+                                if (!scheduler.checkExists(trigger.getKey())) {
+                                    scheduler.scheduleJob(job, trigger);
+                                }
+                            } catch (SchedulerException se) {
+                                logger.error(se);
+                            }
+
+                            var payload = AsyncProfilerEvent.Payload.of(target, id, duration);
+                            notify(
+                                    new AsyncProfilerEvent(
+                                            AsyncProfiler.AsyncProfilerEventCategory.CREATED,
+                                            payload));
+                        });
+    }
+
+    @GET
+    @Path("/{profileId}")
+    @Blocking
+    @RolesAllowed("read")
+    @Operation(summary = "Download an async-profiler binary file in JFR format")
+    public RestResponse<InputStream> get(@RestPath long targetId, @RestPath String profileId)
+            throws Exception {
+        Target target = Target.find("id", targetId).singleResult();
+        return ResponseBuilder.<InputStream>ok()
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        String.format(
+                                "attachment; filename=\"%s_%s.asprof.jfr\"",
+                                target.alias, profileId))
+                .header(HttpHeaders.CONTENT_TYPE, HttpMimeType.OCTET_STREAM.mime())
+                .entity(execute(target, conn -> conn.streamAsyncProfile(profileId)))
+                .build();
+    }
+
+    @GET
+    @Path("/status")
+    @Blocking
+    @RolesAllowed("read")
+    @Operation(summary = "Get specified target's async-profiler status")
+    public Uni<AsyncProfilerStatus> getStatus(@RestPath long targetId) throws Exception {
+        Target target = Target.find("id", targetId).singleResult();
+        return executeUni(target, conn -> conn.asyncProfilerStatus());
+    }
+
+    @GET
+    @Blocking
+    @Transactional
+    @RolesAllowed("read")
+    @Operation(summary = "List existing async-profiler profiles on the specified target")
+    public Uni<List<String>> list(@RestPath long targetId) throws Exception {
+        Target target = Target.find("id", targetId).singleResult();
+        return executeUni(target, AgentConnection::listAsyncProfiles);
+    }
+
+    @DELETE
+    @Transactional
+    @Blocking
+    @Path("/{profileId}")
+    @RolesAllowed("write")
+    @Operation(summary = "Delete an async-profiler profile from the specified target")
+    public Uni<Void> delete(@RestPath long targetId, @RestPath String profileId) throws Exception {
+        Target target = Target.find("id", targetId).singleResult();
+        return executeUni(target, conn -> conn.deleteAsyncProfile(profileId))
+                .invoke(
+                        () -> {
+                            var payload = AsyncProfilerEvent.Payload.of(target, profileId, 0);
+                            notify(
+                                    new AsyncProfilerEvent(
+                                            AsyncProfiler.AsyncProfilerEventCategory.DELETED,
+                                            payload));
+                        })
+                .map(v -> null);
+    }
+
+    private <T> Uni<T> executeUni(Target target, AgentConnectedTask<T> task) {
+        if (!target.isAgent()) {
+            throw new BadRequestException();
+        }
+        return tcm.executeConnectedTaskUni(
+                target,
+                conn -> {
+                    if (!(conn instanceof AgentConnection)) {
+                        throw new InternalServerErrorException();
+                    }
+                    return task.execute((AgentConnection) conn);
+                });
+    }
+
+    private <T> T execute(Target target, AgentConnectedTask<T> task) {
+        if (!target.isAgent()) {
+            throw new BadRequestException();
+        }
+        return tcm.executeConnectedTask(
+                target,
+                conn -> {
+                    if (!(conn instanceof AgentConnection)) {
+                        throw new InternalServerErrorException();
+                    }
+                    return task.execute((AgentConnection) conn);
+                });
+    }
+
+    private void notify(AsyncProfilerEvent event) {
+        bus.publish(
+                MessagingServer.class.getName(),
+                new Notification(event.category().category(), event.payload()));
+    }
+
+    interface AgentConnectedTask<T> {
+        T execute(AgentConnection connection) throws Exception;
+    }
+
+    public record AsyncProfilerEvent(
+            AsyncProfiler.AsyncProfilerEventCategory category, Payload payload) {
+        public AsyncProfilerEvent {
+            Objects.requireNonNull(category);
+            Objects.requireNonNull(payload);
+        }
+
+        public record Payload(Target target, String id, long duration) {
+            public Payload {
+                Objects.requireNonNull(target);
+                Objects.requireNonNull(id);
+                Objects.requireNonNull(duration);
+            }
+
+            public static Payload of(Target target, String id, Duration duration) {
+                return new Payload(target, id, duration.toSeconds());
+            }
+
+            public static Payload of(Target target, String id, long duration) {
+                return new Payload(target, id, duration);
+            }
+        }
+    }
+
+    @DisallowConcurrentExecution
+    static class AsyncProfilerUpdateJob implements Job {
+
+        @Inject EventBus bus;
+        @Inject Scheduler scheduler;
+        @Inject TargetConnectionManager tcm;
+        @Inject Logger logger;
+
+        @Override
+        public void execute(JobExecutionContext context) throws JobExecutionException {
+            Target target =
+                    QuarkusTransaction.joiningExisting()
+                            .call(
+                                    () ->
+                                            Target.find(
+                                                            "id",
+                                                            context.getMergedJobDataMap()
+                                                                    .getLong("targetId"))
+                                                    .singleResult());
+            String id = context.getMergedJobDataMap().getString("id");
+            long duration = context.getMergedJobDataMap().getLong("duration");
+            tcm.executeConnectedTaskUni(
+                            target, conn -> ((AgentConnection) conn).asyncProfilerStatus())
+                    .subscribe()
+                    .with(
+                            s -> {
+                                if (s.status().equals(ProfilerStatus.STOPPED)) {
+                                    var payload =
+                                            AsyncProfilerEvent.Payload.of(target, id, duration);
+                                    notify(
+                                            new AsyncProfilerEvent(
+                                                    AsyncProfiler.AsyncProfilerEventCategory
+                                                            .STOPPED,
+                                                    payload));
+                                    cancelJob(context);
+                                }
+                            },
+                            t -> {
+                                logger.error(t);
+                                cancelJob(context);
+                            });
+        }
+
+        void cancelJob(JobExecutionContext context) {
+            try {
+                scheduler.deleteJob(context.getTrigger().getJobKey());
+            } catch (SchedulerException se) {
+                logger.error(se);
+            }
+        }
+
+        void notify(AsyncProfilerEvent event) {
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(event.category().category(), event.payload()));
+        }
+    }
+}

--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -130,7 +130,7 @@ public class AsyncProfiler {
                                                     Date.from(
                                                             Instant.now()
                                                                     .plus(duration)
-                                                                    .plusSeconds(2)))
+                                                                    .plusSeconds(1)))
                                             // TODO make configurable
                                             .withSchedule(
                                                     SimpleScheduleBuilder.simpleSchedule()

--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
+import io.cryostat.targets.AgentClient.AsyncProfile;
 import io.cryostat.targets.AgentClient.AsyncProfilerStatus;
 import io.cryostat.targets.AgentClient.ProfilerStatus;
 import io.cryostat.targets.AgentClient.StartProfileRequest;
@@ -187,7 +188,7 @@ public class AsyncProfiler {
     @Transactional
     @RolesAllowed("read")
     @Operation(summary = "List existing async-profiler profiles on the specified target")
-    public Uni<List<String>> list(@RestPath long targetId) throws Exception {
+    public Uni<List<AsyncProfile>> list(@RestPath long targetId) throws Exception {
         Target target = Target.find("id", targetId).singleResult();
         return executeUni(target, AgentConnection::listAsyncProfiles);
     }

--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -180,7 +180,7 @@ public class AsyncProfiler {
     @Operation(summary = "Get specified target's async-profiler status")
     public Uni<AsyncProfilerStatus> getStatus(@RestPath long targetId) throws Exception {
         Target target = Target.find("id", targetId).singleResult();
-        return executeUni(target, conn -> conn.asyncProfilerStatus());
+        return executeUni(target, AgentConnection::asyncProfilerStatus);
     }
 
     @GET

--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -33,6 +33,7 @@ import io.cryostat.util.HttpMimeType;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.runtime.ShutdownEvent;
 import io.smallrye.common.annotation.Blocking;
@@ -251,6 +252,7 @@ public class AsyncProfiler {
         T execute(AgentConnection connection) throws Exception;
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public record AsyncProfilerEvent(
             AsyncProfiler.AsyncProfilerEventCategory category, Payload payload) {
         public AsyncProfilerEvent {

--- a/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/ContainerDiscovery.java
@@ -364,7 +364,7 @@ public abstract class ContainerDiscovery {
     }
 
     @DisallowConcurrentExecution
-    private static class ContainersQueryJob implements Job {
+    static class ContainersQueryJob implements Job {
 
         @ConfigProperty(name = ConfigProperties.CONTAINERS_REQUEST_TIMEOUT)
         Duration requestTimeout;

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -662,7 +662,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     @DisallowConcurrentExecution
-    private static class EndpointsResyncJob implements Job {
+    static class EndpointsResyncJob implements Job {
         @Inject Logger logger;
         @Inject EventBus bus;
 

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -55,6 +55,7 @@ import io.cryostat.util.HttpStatusCodeIdentifier;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
@@ -826,6 +827,7 @@ public class AgentClient {
 
     static record SmartTriggerRequest(String definitions) {}
 
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public static record StartProfileRequest(
             String id, long startTime, List<String> events, long duration) {
         public StartProfileRequest(List<String> events, Duration duration) {
@@ -845,6 +847,7 @@ public class AgentClient {
 
     public static record AsyncProfile(String id, long startTime, long duration, long size) {}
 
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public static record AsyncProfilerStatus(
             StartProfileRequest currentProfile,
             ProfilerStatus status,

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -826,9 +826,10 @@ public class AgentClient {
 
     static record SmartTriggerRequest(String definitions) {}
 
-    public static record StartProfileRequest(List<String> events, long duration) {
+    public static record StartProfileRequest(
+            String id, long startTime, List<String> events, long duration) {
         public StartProfileRequest(List<String> events, Duration duration) {
-            this(events, duration.toSeconds());
+            this(null, 0, events, duration.toSeconds());
         }
 
         public StartProfileRequest {
@@ -843,7 +844,9 @@ public class AgentClient {
     }
 
     public static record AsyncProfilerStatus(
-            ProfilerStatus status, Map<String, List<String>> availableEvents) {}
+            StartProfileRequest currentProfile,
+            ProfilerStatus status,
+            Map<String, List<String>> availableEvents) {}
 
     public enum ProfilerStatus {
         STOPPED,

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -523,7 +523,6 @@ public class AgentClient {
     }
 
     Uni<AsyncProfilerStatus> asyncProfilerStatus() {
-        // FIXME async-profiler interaction should happen via MBean invoke
         return agentRestClient
                 .asyncProfilerStatus()
                 .map(
@@ -537,7 +536,6 @@ public class AgentClient {
     }
 
     Uni<String> dumpAsyncProfile(StartProfileRequest req) {
-        // FIXME async-profiler interaction should happen via MBean invoke
         return agentRestClient
                 .dumpAsyncProfiler(req)
                 .map(
@@ -567,7 +565,6 @@ public class AgentClient {
     }
 
     Uni<List<String>> listAsyncProfiles() {
-        // FIXME async-profiler interaction should happen via MBean invoke
         return agentRestClient
                 .listAsyncProfiler()
                 .map(
@@ -582,7 +579,6 @@ public class AgentClient {
     }
 
     Uni<Boolean> deleteAsyncProfile(String id) {
-        // FIXME async-profiler interaction should happen via MBean invoke
         return agentRestClient
                 .deleteAsyncProfiler(id)
                 .map(
@@ -591,7 +587,6 @@ public class AgentClient {
     }
 
     Uni<InputStream> streamAsyncProfile(String id) {
-        // FIXME async-profiler interaction should happen via MBean invoke
         return agentRestClient
                 .streamAsyncProfile(id)
                 .map(

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -564,7 +564,7 @@ public class AgentClient {
                                 }));
     }
 
-    Uni<List<String>> listAsyncProfiles() {
+    Uni<List<AsyncProfile>> listAsyncProfiles() {
         return agentRestClient
                 .listAsyncProfiler()
                 .map(
@@ -573,7 +573,7 @@ public class AgentClient {
                                     try (resp;
                                             var is = (InputStream) resp.getEntity()) {
                                         return mapper.readValue(
-                                                is, new TypeReference<List<String>>() {});
+                                                is, new TypeReference<List<AsyncProfile>>() {});
                                     }
                                 }));
     }
@@ -842,6 +842,8 @@ public class AgentClient {
             }
         }
     }
+
+    public static record AsyncProfile(String id, long starttime, long endtime) {}
 
     public static record AsyncProfilerStatus(
             StartProfileRequest currentProfile,

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -16,6 +16,7 @@
 package io.cryostat.targets;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -314,20 +315,15 @@ public class AgentClient {
                         });
     }
 
-    Uni<InputStream> openStream(long id) {
+    Uni<InputStream> openFlightRecordingStream(long id) {
         return agentRestClient
                 .openStream(id)
                 .map(
                         resp -> {
                             int statusCode = resp.getStatus();
                             if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
-                                return new ProxyInputStream((InputStream) resp.getEntity()) {
-                                    @Override
-                                    public void close() throws IOException {
-                                        in.close();
-                                        resp.close();
-                                    }
-                                };
+                                return new ResponseCloserInputStream(
+                                        (InputStream) resp.getEntity(), resp::close);
                             } else if (statusCode == 403) {
                                 throw new AgentApiException(
                                         Response.Status.FORBIDDEN.getStatusCode(),
@@ -338,7 +334,7 @@ public class AgentClient {
                         });
     }
 
-    Uni<Void> stopRecording(long id) {
+    Uni<Void> stopFlightRecording(long id) {
         // FIXME this is a terrible hack, the interfaces here should not require only an
         // IConstrainedMap with IOptionDescriptors but allow us to pass other and more simply
         // serializable data to the Agent, such as this recording state entry
@@ -385,7 +381,7 @@ public class AgentClient {
         return updateRecordingOptions(id, map);
     }
 
-    Uni<Void> deleteRecording(long id) {
+    Uni<Void> deleteFlightRecording(long id) {
         return agentRestClient
                 .deleteRecording(id)
                 .invoke(Response::close)
@@ -590,6 +586,22 @@ public class AgentClient {
             }
             return new AgentClient(
                     target, agentRestClientBuilder.build(AgentRestClient.class), mapper, timeout);
+        }
+    }
+
+    private static class ResponseCloserInputStream extends ProxyInputStream {
+
+        private final Closeable closeable;
+
+        public ResponseCloserInputStream(InputStream proxy, Closeable closeable) {
+            super(proxy);
+            this.closeable = closeable;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closeable.close();
         }
     }
 

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -53,6 +53,7 @@ import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 import io.cryostat.util.HttpStatusCodeIdentifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -521,6 +522,94 @@ public class AgentClient {
                                 }));
     }
 
+    Uni<AsyncProfilerStatus> asyncProfilerStatus() {
+        // FIXME async-profiler interaction should happen via MBean invoke
+        return agentRestClient
+                .asyncProfilerStatus()
+                .map(
+                        Unchecked.function(
+                                resp -> {
+                                    try (resp;
+                                            var is = (InputStream) resp.getEntity()) {
+                                        return mapper.readValue(is, AsyncProfilerStatus.class);
+                                    }
+                                }));
+    }
+
+    Uni<String> dumpAsyncProfile(StartProfileRequest req) {
+        // FIXME async-profiler interaction should happen via MBean invoke
+        return agentRestClient
+                .dumpAsyncProfiler(req)
+                .map(
+                        Unchecked.function(
+                                resp -> {
+                                    int statusCode = resp.getStatus();
+                                    try (resp;
+                                            var is = (InputStream) resp.getEntity()) {
+                                        if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                                            return mapper.readValue(is, String.class);
+                                        } else if (statusCode == 403) {
+                                            logger.errorv(
+                                                    "dumpAsyncProfile for {0} failed: HTTP 403",
+                                                    getUri());
+                                            throw new AgentApiException(
+                                                    Response.Status.FORBIDDEN.getStatusCode(),
+                                                    new UnsupportedOperationException(
+                                                            "dumpAsyncProfile"));
+                                        } else {
+                                            logger.errorv(
+                                                    "dumpAsyncProfile for {0} failed: HTTP {1}",
+                                                    getUri(), statusCode);
+                                            throw new AgentApiException(statusCode);
+                                        }
+                                    }
+                                }));
+    }
+
+    Uni<List<String>> listAsyncProfiles() {
+        // FIXME async-profiler interaction should happen via MBean invoke
+        return agentRestClient
+                .listAsyncProfiler()
+                .map(
+                        Unchecked.function(
+                                resp -> {
+                                    try (resp;
+                                            var is = (InputStream) resp.getEntity()) {
+                                        return mapper.readValue(
+                                                is, new TypeReference<List<String>>() {});
+                                    }
+                                }));
+    }
+
+    Uni<Boolean> deleteAsyncProfile(String id) {
+        // FIXME async-profiler interaction should happen via MBean invoke
+        return agentRestClient
+                .deleteAsyncProfiler(id)
+                .map(
+                        Unchecked.function(
+                                resp -> HttpStatusCodeIdentifier.isSuccessCode(resp.getStatus())));
+    }
+
+    Uni<InputStream> streamAsyncProfile(String id) {
+        // FIXME async-profiler interaction should happen via MBean invoke
+        return agentRestClient
+                .streamAsyncProfile(id)
+                .map(
+                        resp -> {
+                            int statusCode = resp.getStatus();
+                            if (HttpStatusCodeIdentifier.isSuccessCode(statusCode)) {
+                                return new ResponseCloserInputStream(
+                                        (InputStream) resp.getEntity(), resp::close);
+                            } else if (statusCode == 403) {
+                                throw new AgentApiException(
+                                        Response.Status.FORBIDDEN.getStatusCode(),
+                                        new UnsupportedOperationException("openStream"));
+                            } else {
+                                throw new AgentApiException(statusCode);
+                            }
+                        });
+    }
+
     @ApplicationScoped
     public static class Factory {
 
@@ -741,4 +830,30 @@ public class AgentClient {
     }
 
     static record SmartTriggerRequest(String definitions) {}
+
+    public static record StartProfileRequest(List<String> events, long duration) {
+        public StartProfileRequest(List<String> events, Duration duration) {
+            this(events, duration.toSeconds());
+        }
+
+        public StartProfileRequest {
+            Objects.requireNonNull(events);
+            if (events.isEmpty()) {
+                throw new IllegalArgumentException();
+            }
+            if (duration < 1) {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    public static record AsyncProfilerStatus(
+            ProfilerStatus status, Map<String, List<String>> availableEvents) {}
+
+    public enum ProfilerStatus {
+        STOPPED,
+        RUNNING,
+        UNKNOWN,
+        ;
+    }
 }

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -843,7 +843,7 @@ public class AgentClient {
         }
     }
 
-    public static record AsyncProfile(String id, long starttime, long endtime, long size) {}
+    public static record AsyncProfile(String id, long startTime, long duration, long size) {}
 
     public static record AsyncProfilerStatus(
             StartProfileRequest currentProfile,

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -843,7 +843,7 @@ public class AgentClient {
         }
     }
 
-    public static record AsyncProfile(String id, long starttime, long endtime) {}
+    public static record AsyncProfile(String id, long starttime, long endtime, long size) {}
 
     public static record AsyncProfilerStatus(
             StartProfileRequest currentProfile,

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -16,8 +16,10 @@
 package io.cryostat.targets;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -42,6 +44,8 @@ import io.cryostat.libcryostat.net.IDException;
 import io.cryostat.libcryostat.net.MBeanMetrics;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.triggers.SmartTrigger;
+import io.cryostat.targets.AgentClient.AsyncProfilerStatus;
+import io.cryostat.targets.AgentClient.StartProfileRequest;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -81,6 +85,28 @@ public class AgentConnection implements JFRConnection {
 
     public URI getUri() {
         return client.getUri();
+    }
+
+    public AsyncProfilerStatus asyncProfilerStatus() {
+        return client.asyncProfilerStatus().await().atMost(client.getTimeout());
+    }
+
+    public String dumpAsyncProfile(List<String> events, Duration duration) {
+        return client.dumpAsyncProfile(new StartProfileRequest(events, duration))
+                .await()
+                .atMost(client.getTimeout());
+    }
+
+    public List<String> listAsyncProfiles() {
+        return client.listAsyncProfiles().await().atMost(client.getTimeout());
+    }
+
+    public boolean deleteAsyncProfile(String id) {
+        return client.deleteAsyncProfile(id).await().atMost(client.getTimeout());
+    }
+
+    public InputStream streamAsyncProfile(String id) {
+        return client.streamAsyncProfile(id).await().atMost(client.getTimeout());
     }
 
     @Override

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -44,6 +44,7 @@ import io.cryostat.libcryostat.net.IDException;
 import io.cryostat.libcryostat.net.MBeanMetrics;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.triggers.SmartTrigger;
+import io.cryostat.targets.AgentClient.AsyncProfile;
 import io.cryostat.targets.AgentClient.AsyncProfilerStatus;
 import io.cryostat.targets.AgentClient.StartProfileRequest;
 
@@ -97,7 +98,7 @@ public class AgentConnection implements JFRConnection {
                 .atMost(client.getTimeout());
     }
 
-    public List<String> listAsyncProfiles() {
+    public List<AsyncProfile> listAsyncProfiles() {
         return client.listAsyncProfiles().await().atMost(client.getTimeout());
     }
 

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -56,7 +56,7 @@ import org.jboss.logging.Logger;
  *
  * @see io.cryostat.targets.AgentClient
  */
-class AgentConnection implements JFRConnection {
+public class AgentConnection implements JFRConnection {
 
     private final AgentClient client;
     private final TemplateService customTemplateService;

--- a/src/main/java/io/cryostat/targets/AgentJFRService.java
+++ b/src/main/java/io/cryostat/targets/AgentJFRService.java
@@ -92,7 +92,7 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public void close(IRecordingDescriptor descriptor) throws FlightRecorderException {
-        client.deleteRecording(descriptor.getId()).await().atMost(client.getTimeout());
+        client.deleteFlightRecording(descriptor.getId()).await().atMost(client.getTimeout());
     }
 
     @Override
@@ -166,7 +166,7 @@ class AgentJFRService implements CryostatFlightRecorderService {
     @Override
     public InputStream openStream(IRecordingDescriptor descriptor, boolean removeOnClose)
             throws FlightRecorderException {
-        Uni<InputStream> u = client.openStream(descriptor.getId());
+        Uni<InputStream> u = client.openFlightRecordingStream(descriptor.getId());
         InputStream is = u.await().atMost(client.getTimeout());
         return new BufferedInputStream(is);
     }
@@ -197,7 +197,7 @@ class AgentJFRService implements CryostatFlightRecorderService {
 
     @Override
     public void stop(IRecordingDescriptor descriptor) throws FlightRecorderException {
-        client.stopRecording(descriptor.getId()).await().atMost(client.getTimeout());
+        client.stopFlightRecording(descriptor.getId()).await().atMost(client.getTimeout());
     }
 
     @Override

--- a/src/main/java/io/cryostat/targets/AgentRestClient.java
+++ b/src/main/java/io/cryostat/targets/AgentRestClient.java
@@ -19,6 +19,7 @@ package io.cryostat.targets;
 import java.io.InputStream;
 import java.util.Map;
 
+import io.cryostat.targets.AgentClient.StartProfileRequest;
 import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 
 import io.smallrye.mutiny.Uni;
@@ -105,4 +106,29 @@ interface AgentRestClient {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     Uni<Response> listEventTemplates();
+
+    @Path("/async-profiler/status")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<Response> asyncProfilerStatus();
+
+    @Path("/async-profiler/")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    Uni<Response> dumpAsyncProfiler(StartProfileRequest req);
+
+    @Path("/async-profiler/")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<Response> listAsyncProfiler();
+
+    @Path("/async-profiler/{id}")
+    @DELETE
+    Uni<Response> deleteAsyncProfiler(@PathParam("id") String id);
+
+    @Path("/async-profiler/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    Uni<Response> streamAsyncProfile(@PathParam("id") String id);
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #643
See https://github.com/cryostatio/cryostat-agent/pull/770

## Description of the change:
Adds API endpoints to interface with cryostat-agent integration for async-profiler. This should allow the user to start a customized async-profiler session (only one active session is supported at a time, I think), view in-progress and/or completed sessions and associated dump files, delete remote dump files, download remote dump files, and copy dump files to Cryostat's archives. Creating an async-profiler session dump file or copying it to the archives should not trigger other behaviours like autoanalysis.

Currently there is no feature for archival of completed async-profile sessions. However, since these sessions are valid JFR files, it is possible to download the session file to the local workstation and manually upload it into the Cryostat archives. Cryostat should accept this, and automated analysis/View in Grafana features should support it - though the event data within the file will be quite limited, so many analyses will not be available. There is also no support for recording metadata yet.

## Motivation for the change:
Add integration with https://github.com/async-profiler/async-profiler to address user requests in #643  and https://github.com/cryostatio/cryostat-legacy/issues/1456 .

## How to manually test:
See https://github.com/cryostatio/cryostat-agent/pull/770