### PR TITLE
fix(tcm): fix bug where unwrapping runtime exceptions can skip causal levels

### DIFF
--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -19,6 +19,7 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.rmi.ConnectIOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -402,7 +403,7 @@ public class TargetConnectionManager {
             if (c == null) {
                 break;
             }
-            cause = cause.getCause();
+            cause = c;
         }
         return cause;
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1232
