### PR TITLE
chore(template): add quarkus runtime events to template

### DIFF
--- a/src/main/docker/include/template_presets/quarkus.jfc
+++ b/src/main/docker/include/template_presets/quarkus.jfc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration version="2.0" label="Quarkus" description="Quarkus-specific REST events" provider="Cryostat">
+<configuration version="2.0" label="Quarkus" description="Quarkus-specific events" provider="Cryostat">
   <event name="quarkus.runtime">
     <setting name="enabled">true</setting>
   </event>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/pull/733
Related to https://github.com/quarkusio/quarkus/issues/50392
See also https://github.com/quarkusio/quarkus/pull/48687

## Description of the change:
Adds new `quarkus.runtime`, `quarkus.application`, and `quarkus.extension` JFR event types to the `quarkus.jfc` preset event template shipped with Cryostat.

## Motivation for the change:
These are normally enabled by the Quarkus JFR extension anyway, but in case they have been explicitly disabled by the user previously, it makes sense that Cryostat's preset template for enabling Quarkus-specific events should (re-)enable them, along with the older REST events.
