### PR TITLE
feat(discovery): handle hierarchical plugin publication, implement querying of merged realms

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1772,6 +1772,12 @@ paths:
         - Credentials
   /api/v4/discovery:
     get:
+      parameters:
+        - in: query
+          name: mergeRealms
+          schema:
+            default: false
+            type: boolean
       responses:
         "200":
           content:

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import io.cryostat.ConfigProperties;
 import io.cryostat.credentials.Credential;
 import io.cryostat.discovery.DiscoveryPlugin.PluginCallback;
+import io.cryostat.discovery.NodeType.BaseNodeType;
 import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.util.URIUtil;
 
@@ -101,6 +102,8 @@ import org.quartz.impl.matchers.GroupMatcher;
 
 @Path("")
 public class Discovery {
+
+    private static final String SYNTHETIC_REALM_NAME = "Cryostat Discovery";
 
     static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
@@ -606,6 +609,13 @@ public class Discovery {
         mergedRoot.labels = new HashMap<>(universe.labels);
         mergedRoot.children = new ArrayList<>();
 
+        var syntheticRealm = new DiscoveryNode();
+        syntheticRealm.name = SYNTHETIC_REALM_NAME;
+        syntheticRealm.nodeType = BaseNodeType.REALM.getKind();
+        syntheticRealm.labels = new HashMap<>();
+        syntheticRealm.children = new ArrayList<>();
+        mergedRoot.children.add(syntheticRealm);
+
         var mergedNodes = new HashMap<String, DiscoveryNode>();
 
         var builtinRealmIds =
@@ -636,7 +646,7 @@ public class Discovery {
                     if (mergedNode == null) {
                         mergedNode = copyNode(sourceNode);
                         mergedNodes.put(key, mergedNode);
-                        mergedRoot.children.add(mergedNode);
+                        syntheticRealm.children.add(mergedNode);
                     } else {
                         if (fromBuiltin) {
                             mergeNodeProperties(mergedNode, sourceNode);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -76,6 +76,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -621,7 +622,7 @@ public class Discovery {
         syntheticRealm.children = new ArrayList<>();
         mergedRoot.children.add(syntheticRealm);
 
-        var mergedNodes = new HashMap<String, DiscoveryNode>();
+        var mergedNodes = new HashMap<Pair<String, String>, DiscoveryNode>();
 
         var builtinRealmIds =
                 DiscoveryPlugin.find("#DiscoveryPlugin.getBuiltinRealmIds")
@@ -640,7 +641,7 @@ public class Discovery {
                 var mergedParent = ctx.parent;
                 var fromBuiltin = ctx.fromBuiltin;
 
-                String key = sourceNode.nodeType + ":" + sourceNode.name;
+                Pair<String, String> key = Pair.of(sourceNode.nodeType, sourceNode.name);
 
                 DiscoveryNode mergedNode;
                 if (mergedParent == null) {

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -604,12 +604,14 @@ public class Discovery {
     private DiscoveryNode mergeRealms() {
         var universe = DiscoveryNode.getUniverse();
         var mergedRoot = new DiscoveryNode();
+        mergedRoot.id = universe.id;
         mergedRoot.name = universe.name;
         mergedRoot.nodeType = universe.nodeType;
         mergedRoot.labels = new HashMap<>(universe.labels);
         mergedRoot.children = new ArrayList<>();
 
         var syntheticRealm = new DiscoveryNode();
+        syntheticRealm.id = Long.MAX_VALUE;
         syntheticRealm.name = SYNTHETIC_REALM_NAME;
         syntheticRealm.nodeType = BaseNodeType.REALM.getKind();
         syntheticRealm.labels = new HashMap<>();
@@ -685,6 +687,7 @@ public class Discovery {
 
     private DiscoveryNode copyNode(DiscoveryNode source) {
         var copy = new DiscoveryNode();
+        copy.id = source.id;
         copy.name = source.name;
         copy.nodeType = source.nodeType;
         copy.labels = new HashMap<>(source.labels);
@@ -694,13 +697,14 @@ public class Discovery {
     }
 
     private void mergeNodeProperties(DiscoveryNode target, DiscoveryNode source) {
-        // Merge labels - source (from builtin) takes priority
         if (source.labels != null) {
             target.labels.putAll(source.labels);
         }
-        // If source has a target, use it
         if (source.target != null) {
             target.target = source.target;
+        }
+        if (source.id != null) {
+            target.id = source.id;
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -72,9 +72,7 @@ import org.jboss.logging.Logger;
 @NamedQueries({
     @NamedQuery(
             name = "DiscoveryPlugin.getBuiltinRealmIds",
-            query =
-                    "SELECT p.realm.id FROM DiscoveryPlugin p WHERE p.builtin = true AND p.realm IS"
-                            + " NOT NULL")
+            query = "SELECT p.realm.id FROM DiscoveryPlugin p WHERE p.builtin = true")
 })
 public class DiscoveryPlugin extends PanacheEntityBase {
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -41,6 +41,8 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.transaction.Transactional;
@@ -67,6 +69,13 @@ import org.jboss.logging.Logger;
 @Entity
 @EntityListeners(DiscoveryPlugin.Listener.class)
 @Cacheable
+@NamedQueries({
+    @NamedQuery(
+            name = "DiscoveryPlugin.getBuiltinRealmIds",
+            query =
+                    "SELECT p.realm.id FROM DiscoveryPlugin p WHERE p.builtin = true AND p.realm IS"
+                            + " NOT NULL")
+})
 public class DiscoveryPlugin extends PanacheEntityBase {
 
     @Id

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -790,7 +790,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
     }
 
-    private class TargetTuple {
+    class TargetTuple {
         ObjectReference objRef;
         HasMetadata obj;
         String addr;

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -512,6 +513,40 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         realm.persist();
     }
 
+    /**
+     * Builds the ownership hierarchy for a given DiscoveryNode by chasing owner references up the
+     * chain. This method does NOT persist any nodes - it only constructs the hierarchical
+     * relationships in memory.
+     *
+     * @param node The starting node to build the ownership hierarchy from
+     * @return The root node of the ownership chain (the topmost owner)
+     */
+    public DiscoveryNode buildOwnershipHierarchy(DiscoveryNode node) {
+        Pair<HasMetadata, DiscoveryNode> current = Pair.of(null, node);
+
+        // Chase the owner chain upward
+        while (true) {
+            Pair<HasMetadata, DiscoveryNode> owner = getOwnerNode(current);
+            if (owner == null) {
+                break;
+            }
+
+            DiscoveryNode ownerNode = owner.getRight();
+            DiscoveryNode childNode = current.getRight();
+
+            // Build parent-child relationships without persisting
+            if (!ownerNode.children.contains(childNode)) {
+                ownerNode.children.add(childNode);
+            }
+            childNode.parent = ownerNode;
+
+            current = owner;
+        }
+
+        // Return the root of the ownership chain
+        return current.getRight();
+    }
+
     private void notify(NamespaceQueryEvent evt) {
         bus.publish(NAMESPACE_QUERY_ADDR, evt);
     }
@@ -565,7 +600,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                             targetRef.getNamespace()));
                         });
         target.discoveryNode = targetNode;
-        target.persist();
+
+        DiscoveryNode rootNode;
 
         if (targetType == KubeDiscoveryNodeType.POD) {
             // if the Endpoint points to a Pod, chase the owner chain up as far as possible, then
@@ -575,41 +611,49 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     queryForNode(
                             targetRef.getNamespace(), targetRef.getName(), targetRef.getKind());
 
-            pod.getRight().children.add(targetNode);
-            targetNode.parent = pod.getRight();
-            pod.getRight().persist();
+            DiscoveryNode podNode = pod.getRight();
+            podNode.children.add(targetNode);
+            targetNode.parent = podNode;
 
-            Pair<HasMetadata, DiscoveryNode> child = pod;
-            while (true) {
-                Pair<HasMetadata, DiscoveryNode> owner = getOwnerNode(child);
-                if (owner == null) {
-                    break;
-                }
+            // Build the entire ownership hierarchy without persisting
+            rootNode = buildOwnershipHierarchy(podNode);
 
-                DiscoveryNode ownerNode = owner.getRight();
-                DiscoveryNode childNode = child.getRight();
-
-                if (!ownerNode.children.contains(childNode)) {
-                    ownerNode.children.add(childNode);
-                }
-                childNode.parent = ownerNode;
-
-                ownerNode.persist();
-                childNode.persist();
-
-                child = owner;
-            }
-
-            nsNode.children.add(child.getRight());
-            child.getRight().parent = nsNode;
+            // Connect the root to the namespace
+            nsNode.children.add(rootNode);
+            rootNode.parent = nsNode;
         } else {
             // if the Endpoint points to something else(?) than a Pod, just add the target straight
             // to the Namespace
             nsNode.children.add(targetNode);
             targetNode.parent = nsNode;
-            targetNode.persist();
+            rootNode = targetNode;
         }
 
+        // Use Stack-based iterative approach to persist all nodes at once
+        // This ensures we persist from leaf to root
+        Stack<DiscoveryNode> stack = new Stack<>();
+        Set<DiscoveryNode> visited = new HashSet<>();
+
+        // Start from the target node and traverse up to collect all nodes
+        DiscoveryNode current = targetNode;
+        while (current != null && current != nsNode) {
+            if (!visited.contains(current)) {
+                stack.push(current);
+                visited.add(current);
+            }
+            current = current.parent;
+        }
+
+        // Persist target first (it has the associated Target entity)
+        target.persist();
+
+        // Persist all nodes in the chain from top to bottom
+        while (!stack.isEmpty()) {
+            DiscoveryNode node = stack.pop();
+            node.persist();
+        }
+
+        // Finally persist the namespace node
         nsNode.persist();
     }
 

--- a/src/test/java/io/cryostat/discovery/DiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryTest.java
@@ -81,15 +81,17 @@ public class DiscoveryTest extends AbstractTransactionalTestBase {
                         .assertThat()
                         .statusCode(200)
                         .contentType(ContentType.JSON)
-                        .body("id", Matchers.nullValue())
+                        .body("id", Matchers.equalTo(1))
                         .body("name", Matchers.equalTo("Universe"))
                         .body("nodeType", Matchers.equalTo("Universe"))
                         .body("labels", Matchers.equalTo(List.of()))
                         .body("children.size()", Matchers.equalTo(1))
+                        .body("children[0].id", Matchers.notNullValue())
                         .body("children[0].name", Matchers.equalTo("Cryostat Discovery"))
                         .body("children[0].nodeType", Matchers.equalTo("Realm"))
                         .body("children[0].labels", Matchers.equalTo(List.of()))
                         .body("children[0].children.size()", Matchers.greaterThan(0))
+                        .body("children[0].children[0].id", Matchers.notNullValue())
                         .body("parent", Matchers.nullValue())
                         .body("target", Matchers.nullValue());
 

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -43,12 +43,11 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.MockitoConfig;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
-import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(KubeEndpointSlicesDiscoveryTest.TestProfile.class)
@@ -57,7 +56,10 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     public static class TestProfile implements io.quarkus.test.junit.QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("cryostat.discovery.kubernetes.port-names", "jfr-jmx,other-port");
+            return Map.of(
+                    "cryostat.discovery.kubernetes.enabled", "true",
+                    "cryostat.discovery.kubernetes.port-numbers", "9091",
+                    "cryostat.discovery.kubernetes.port-names", "jfr-jmx,other-port");
         }
     }
 
@@ -156,7 +158,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetTargetTuplesFromReturnsValidTargetTuplesWithSingleEndpoint() {
         EndpointSlice slice = mock(EndpointSlice.class);
         when(slice.getAddressType()).thenReturn("ipv4");
@@ -209,7 +210,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetTargetTuplesFromWithMultipleEndpointsAndPorts() {
         EndpointSlice slice = mock(EndpointSlice.class);
         when(slice.getAddressType()).thenReturn("ipv4");
@@ -280,7 +280,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testBuildOwnershipHierarchyWithPodOnly() {
         // This test verifies that buildOwnershipHierarchy correctly handles a Pod
         // with no owner references. The Pod itself should be the root of the hierarchy.
@@ -311,7 +310,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testBuildOwnershipHierarchyWithPodToReplicaSet() {
         // This test verifies the ownership hierarchy: Pod -> ReplicaSet
         // The ReplicaSet should become the root of the hierarchy.
@@ -367,7 +365,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testBuildOwnershipHierarchyWithFullChain() {
         // This test verifies the full ownership hierarchy: Pod -> ReplicaSet -> Deployment
         // The Deployment should become the root of the hierarchy.
@@ -493,7 +490,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetOwnershipLineageWithStringParametersForPod() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -522,7 +518,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetOwnershipLineageWithStringParametersForPodWithReplicaSetOwner() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -573,7 +568,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetOwnershipLineageWithStringParametersForEndpointSlice() {
         EndpointSlice slice = mock(EndpointSlice.class);
         ObjectMeta sliceMeta = mock(ObjectMeta.class);
@@ -625,7 +619,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    @Transactional
     void testGetOwnershipLineageWithStringParametersForNonExistentResource() {
         MixedOperation podOp = mock(MixedOperation.class);
         NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.discovery;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeConfig;
+import io.cryostat.libcryostat.sys.FileSystem;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.discovery.v1.Endpoint;
+import io.fabric8.kubernetes.api.model.discovery.v1.EndpointPort;
+import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.Scheduler;
+
+@ExtendWith(MockitoExtension.class)
+class KubeEndpointSlicesDiscoveryTest {
+
+    @Mock Logger logger;
+    @Mock KubeConfig kubeConfig;
+    @Mock KubernetesClient client;
+    @Mock Scheduler scheduler;
+    @Mock EventBus bus;
+    @Mock FileSystem fs;
+
+    KubeEndpointSlicesDiscovery discovery;
+
+    @BeforeEach
+    void setup() {
+        discovery = new KubeEndpointSlicesDiscovery();
+        discovery.logger = logger;
+        discovery.kubeConfig = kubeConfig;
+        discovery.client = client;
+        discovery.scheduler = scheduler;
+        discovery.bus = bus;
+        discovery.enabled = true;
+        discovery.ipv6Enabled = false;
+        discovery.ipv4TransformEnabled = false;
+        discovery.jmxPortNames = Optional.of(List.of("jfr-jmx"));
+        discovery.jmxPortNumbers = Optional.of(List.of(9091));
+        discovery.informerResyncPeriod = Duration.ofMinutes(5);
+        discovery.forceResyncEnabled = false;
+    }
+
+    @Test
+    void testAvailableReturnsTrueWhenKubeApiAvailableAndHasNamespace() {
+        when(kubeConfig.kubeApiAvailable()).thenReturn(true);
+        when(kubeConfig.getOwnNamespace()).thenReturn("test-namespace");
+
+        assertTrue(discovery.available());
+    }
+
+    @Test
+    void testAvailableReturnsFalseWhenKubeApiNotAvailable() {
+        when(kubeConfig.kubeApiAvailable()).thenReturn(false);
+        when(kubeConfig.getOwnNamespace()).thenReturn("test-namespace");
+
+        assertFalse(discovery.available());
+    }
+
+    @Test
+    void testAvailableReturnsFalseWhenNamespaceIsBlank() {
+        when(kubeConfig.kubeApiAvailable()).thenReturn(true);
+        when(kubeConfig.getOwnNamespace()).thenReturn("");
+
+        assertFalse(discovery.available());
+    }
+
+    @Test
+    void testAvailableReturnsFalseWhenExceptionThrown() {
+        when(kubeConfig.kubeApiAvailable()).thenThrow(new RuntimeException("Test exception"));
+
+        assertFalse(discovery.available());
+    }
+
+    @Test
+    void testOnAddNotifiesNamespaceQuery() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        ObjectMeta metadata = mock(ObjectMeta.class);
+        when(metadata.getName()).thenReturn("test-slice");
+        when(metadata.getNamespace()).thenReturn("test-namespace");
+        when(slice.getMetadata()).thenReturn(metadata);
+
+        discovery.onAdd(slice);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(bus).publish(eq("NS_QUERY_ENDPOINT_SLICE"), eventCaptor.capture());
+
+        Object event = eventCaptor.getValue();
+        assertNotNull(event);
+        // Verify the event contains the namespace
+        assertTrue(event.toString().contains("test-namespace"));
+    }
+
+    @Test
+    void testOnUpdateNotifiesNamespaceQuery() {
+        EndpointSlice oldSlice = mock(EndpointSlice.class);
+        EndpointSlice newSlice = mock(EndpointSlice.class);
+        ObjectMeta oldMetadata = mock(ObjectMeta.class);
+        ObjectMeta newMetadata = mock(ObjectMeta.class);
+        lenient().when(oldMetadata.getName()).thenReturn("test-slice");
+        lenient().when(oldMetadata.getNamespace()).thenReturn("test-namespace");
+        when(newMetadata.getName()).thenReturn("test-slice");
+        lenient().when(newMetadata.getNamespace()).thenReturn("test-namespace");
+        lenient().when(oldSlice.getMetadata()).thenReturn(oldMetadata);
+        when(newSlice.getMetadata()).thenReturn(newMetadata);
+
+        discovery.onUpdate(oldSlice, newSlice);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(bus).publish(eq("NS_QUERY_ENDPOINT_SLICE"), eventCaptor.capture());
+
+        Object event = eventCaptor.getValue();
+        assertNotNull(event);
+        // Verify the event contains the namespace
+        assertTrue(event.toString().contains("test-namespace"));
+    }
+
+    @Test
+    void testOnDeleteNotifiesNamespaceQuery() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        ObjectMeta metadata = mock(ObjectMeta.class);
+        when(metadata.getName()).thenReturn("test-slice");
+        when(metadata.getNamespace()).thenReturn("test-namespace");
+        when(slice.getMetadata()).thenReturn(metadata);
+
+        discovery.onDelete(slice, false);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(bus).publish(eq("NS_QUERY_ENDPOINT_SLICE"), eventCaptor.capture());
+
+        Object event = eventCaptor.getValue();
+        assertNotNull(event);
+        // Verify the event contains the namespace
+        assertTrue(event.toString().contains("test-namespace"));
+    }
+
+    @Test
+    void testTuplesFromEndpointsReturnsEmptyListForIPv6WhenDisabled() {
+        discovery.ipv6Enabled = false;
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv6");
+
+        List<?> result = discovery.tuplesFromEndpoints(slice);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testTuplesFromEndpointsReturnsEmptyListWhenPortsAreNull() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+        when(slice.getPorts()).thenReturn(null);
+
+        List<?> result = discovery.tuplesFromEndpoints(slice);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testTuplesFromEndpointsReturnsEmptyListWhenEndpointsAreNull() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+        EndpointPort port = mock(EndpointPort.class);
+        lenient().when(port.getName()).thenReturn("jfr-jmx");
+        lenient().when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+        when(slice.getEndpoints()).thenReturn(null);
+
+        List<?> result = discovery.tuplesFromEndpoints(slice);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testTuplesFromEndpointsSkipsEndpointsWithoutTargetRef() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        EndpointPort port = mock(EndpointPort.class);
+        lenient().when(port.getName()).thenReturn("jfr-jmx");
+        lenient().when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of("192.168.1.100"));
+        when(endpoint.getTargetRef()).thenReturn(null);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        List<?> result = discovery.tuplesFromEndpoints(slice);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testTuplesFromEndpointsSkipsEndpointsWithEmptyAddresses() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        EndpointPort port = mock(EndpointPort.class);
+        lenient().when(port.getName()).thenReturn("jfr-jmx");
+        lenient().when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of());
+
+        ObjectReference targetRef = mock(ObjectReference.class);
+        lenient().when(targetRef.getNamespace()).thenReturn("test-namespace");
+        lenient().when(targetRef.getName()).thenReturn("test-pod");
+        lenient().when(targetRef.getKind()).thenReturn("Pod");
+        lenient().when(endpoint.getTargetRef()).thenReturn(targetRef);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        List<?> result = discovery.tuplesFromEndpoints(slice);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testKubeConfigWatchAllNamespacesReturnsTrueWhenWildcard() {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.watchNamespaces = Optional.of(List.of("*"));
+        config.serviceHost = Optional.of("kubernetes.default.svc");
+        config.namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+        assertTrue(config.watchAllNamespaces());
+    }
+
+    @Test
+    void testKubeConfigWatchAllNamespacesReturnsFalseWhenSpecificNamespaces() {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.watchNamespaces = Optional.of(List.of("ns1", "ns2"));
+        config.serviceHost = Optional.of("kubernetes.default.svc");
+        config.namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+        assertFalse(config.watchAllNamespaces());
+    }
+
+    @Test
+    void testKubeConfigGetWatchNamespacesReplacesOwnNamespace() throws Exception {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.watchNamespaces = Optional.of(List.of("."));
+        config.serviceHost = Optional.of("kubernetes.default.svc");
+        config.namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+        when(fs.readString(any(Path.class))).thenReturn("actual-namespace");
+
+        var namespaces = config.getWatchNamespaces();
+
+        assertTrue(namespaces.contains("actual-namespace"));
+        assertFalse(namespaces.contains("."));
+    }
+
+    @Test
+    void testKubeConfigGetOwnNamespaceReturnsNamespaceFromFile() throws Exception {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+        when(fs.readString(any(Path.class))).thenReturn("test-namespace");
+
+        String namespace = config.getOwnNamespace();
+
+        assertEquals("test-namespace", namespace);
+    }
+
+    @Test
+    void testKubeConfigGetOwnNamespaceReturnsNullOnException() throws Exception {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+        when(fs.readString(any(Path.class))).thenThrow(new RuntimeException("File not found"));
+
+        String namespace = config.getOwnNamespace();
+
+        assertNull(namespace);
+    }
+
+    @Test
+    void testKubeConfigKubeApiAvailableReturnsTrueWhenServiceHostPresent() {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.serviceHost = Optional.of("kubernetes.default.svc");
+
+        assertTrue(config.kubeApiAvailable());
+    }
+
+    @Test
+    void testKubeConfigKubeApiAvailableReturnsFalseWhenServiceHostBlank() {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.serviceHost = Optional.of("");
+
+        assertFalse(config.kubeApiAvailable());
+    }
+
+    @Test
+    void testKubeConfigKubeApiAvailableReturnsFalseWhenServiceHostAbsent() {
+        KubeConfig config = new KubeConfig();
+        config.logger = logger;
+        config.fs = fs;
+        config.serviceHost = Optional.empty();
+
+        assertFalse(config.kubeApiAvailable());
+    }
+
+    @Test
+    void testKubeDiscoveryNodeTypeFromKubernetesKindReturnsCorrectType() {
+        assertEquals(
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.POD,
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.fromKubernetesKind("Pod"));
+        assertEquals(
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.DEPLOYMENT,
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.fromKubernetesKind("Deployment"));
+        assertEquals(
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.STATEFULSET,
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.fromKubernetesKind(
+                        "StatefulSet"));
+    }
+
+    @Test
+    void testKubeDiscoveryNodeTypeFromKubernetesKindReturnsNullForUnknown() {
+        assertNull(
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.fromKubernetesKind(
+                        "UnknownKind"));
+    }
+
+    @Test
+    void testKubeDiscoveryNodeTypeFromKubernetesKindReturnsNullForNull() {
+        assertNull(KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.fromKubernetesKind(null));
+    }
+
+    @Test
+    void testKubeDiscoveryNodeTypeGetKindReturnsKubernetesKind() {
+        assertEquals("Pod", KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.POD.getKind());
+        assertEquals(
+                "Deployment",
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.DEPLOYMENT.getKind());
+    }
+
+    @Test
+    void testKubeDiscoveryNodeTypeToStringReturnsKind() {
+        assertEquals("Pod", KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.POD.toString());
+        assertEquals(
+                "Namespace",
+                KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.NAMESPACE.toString());
+    }
+}

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.*;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeConfig;
@@ -29,10 +31,20 @@ import io.cryostat.libcryostat.sys.FileSystem;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.discovery.v1.Endpoint;
+import io.fabric8.kubernetes.api.model.discovery.v1.EndpointConditions;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointPort;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -388,5 +400,481 @@ class KubeEndpointSlicesDiscoveryTest {
         assertEquals(
                 "Namespace",
                 KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType.NAMESPACE.toString());
+    }
+
+    @Test
+    void testTuplesFromEndpointsReturnsValidTargetTuplesWithSingleEndpoint() {
+        // This test verifies that tuplesFromEndpoints correctly processes a single endpoint
+        // with a compatible JMX port and returns a list containing one TargetTuple.
+        // The TargetTuple should contain the endpoint's address, port, target reference,
+        // and conditions.
+
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        EndpointPort port = mock(EndpointPort.class);
+        when(port.getName()).thenReturn("jfr-jmx");
+        when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of("192.168.1.100"));
+
+        ObjectReference targetRef = mock(ObjectReference.class);
+        when(targetRef.getNamespace()).thenReturn("test-namespace");
+        when(targetRef.getName()).thenReturn("test-pod");
+        when(targetRef.getKind()).thenReturn("Pod");
+        when(endpoint.getTargetRef()).thenReturn(targetRef);
+
+        EndpointConditions conditions = mock(EndpointConditions.class);
+        when(conditions.getReady()).thenReturn(true);
+        when(conditions.getServing()).thenReturn(true);
+        when(conditions.getTerminating()).thenReturn(false);
+        when(endpoint.getConditions()).thenReturn(conditions);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        // Mock the queryForNode call - returns a Pair of (Pod, DiscoveryNode)
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        MixedOperation podOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource = mock(PodResource.class);
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("test-pod")).thenReturn(podResource);
+        when(podResource.get()).thenReturn(pod);
+
+        // Execute
+        var result = discovery.tuplesFromEndpoints(slice);
+
+        // Assertions
+        assertNotNull(result);
+        assertEquals(
+                1,
+                result.size(),
+                "Should return exactly one TargetTuple for one endpoint with one compatible port");
+    }
+
+    @Test
+    void testTuplesFromEndpointsWithMultipleEndpointsAndPorts() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        // Multiple ports
+        EndpointPort port1 = mock(EndpointPort.class);
+        when(port1.getName()).thenReturn("jfr-jmx");
+        when(port1.getPort()).thenReturn(9091);
+
+        EndpointPort port2 = mock(EndpointPort.class);
+        when(port2.getName()).thenReturn("other-port");
+        when(port2.getPort()).thenReturn(8080);
+
+        when(slice.getPorts()).thenReturn(List.of(port1, port2));
+
+        // Multiple endpoints
+        Endpoint endpoint1 = mock(Endpoint.class);
+        when(endpoint1.getAddresses()).thenReturn(List.of("192.168.1.100"));
+        ObjectReference ref1 = mock(ObjectReference.class);
+        when(ref1.getNamespace()).thenReturn("test-namespace");
+        when(ref1.getName()).thenReturn("pod-1");
+        when(ref1.getKind()).thenReturn("Pod");
+        when(endpoint1.getTargetRef()).thenReturn(ref1);
+        EndpointConditions cond1 = mock(EndpointConditions.class);
+        when(endpoint1.getConditions()).thenReturn(cond1);
+
+        Endpoint endpoint2 = mock(Endpoint.class);
+        when(endpoint2.getAddresses()).thenReturn(List.of("192.168.1.101"));
+        ObjectReference ref2 = mock(ObjectReference.class);
+        when(ref2.getNamespace()).thenReturn("test-namespace");
+        when(ref2.getName()).thenReturn("pod-2");
+        when(ref2.getKind()).thenReturn("Pod");
+        when(endpoint2.getTargetRef()).thenReturn(ref2);
+        EndpointConditions cond2 = mock(EndpointConditions.class);
+        when(endpoint2.getConditions()).thenReturn(cond2);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint1, endpoint2));
+
+        // Mock queryForNode for both pods
+        Pod pod1 = mock(Pod.class);
+        ObjectMeta meta1 = mock(ObjectMeta.class);
+        when(meta1.getLabels()).thenReturn(new HashMap<>());
+        when(pod1.getMetadata()).thenReturn(meta1);
+
+        Pod pod2 = mock(Pod.class);
+        ObjectMeta meta2 = mock(ObjectMeta.class);
+        when(meta2.getLabels()).thenReturn(new HashMap<>());
+        when(pod2.getMetadata()).thenReturn(meta2);
+
+        MixedOperation podOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource1 = mock(PodResource.class);
+        PodResource podResource2 = mock(PodResource.class);
+
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("pod-1")).thenReturn(podResource1);
+        when(nsOp.withName("pod-2")).thenReturn(podResource2);
+        when(podResource1.get()).thenReturn(pod1);
+        when(podResource2.get()).thenReturn(pod2);
+
+        // Execute
+        var result = discovery.tuplesFromEndpoints(slice);
+
+        // Assertions - should have 2 endpoints * 2 ports = 4 tuples
+        assertNotNull(result);
+        assertEquals(4, result.size());
+    }
+
+    @Test
+    void testTuplesFromEndpointsWithIPv6Address() {
+        discovery.ipv6Enabled = true;
+
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv6");
+
+        EndpointPort port = mock(EndpointPort.class);
+        when(port.getName()).thenReturn("jfr-jmx");
+        when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of("2001:db8::1"));
+
+        ObjectReference targetRef = mock(ObjectReference.class);
+        when(targetRef.getNamespace()).thenReturn("test-namespace");
+        when(targetRef.getName()).thenReturn("test-pod");
+        when(targetRef.getKind()).thenReturn("Pod");
+        when(endpoint.getTargetRef()).thenReturn(targetRef);
+
+        EndpointConditions conditions = mock(EndpointConditions.class);
+        when(endpoint.getConditions()).thenReturn(conditions);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        // Mock queryForNode
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getLabels()).thenReturn(new HashMap<>());
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        MixedOperation podOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource = mock(PodResource.class);
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("test-pod")).thenReturn(podResource);
+        when(podResource.get()).thenReturn(pod);
+
+        // Execute
+        var result = discovery.tuplesFromEndpoints(slice);
+
+        // Assertions
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        // IPv6 address should be wrapped in brackets in the tuple
+    }
+
+    @Test
+    void testTuplesFromEndpointsWithIPv4DnsTransform() {
+        discovery.ipv4TransformEnabled = true;
+
+        EndpointSlice slice = mock(EndpointSlice.class);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        EndpointPort port = mock(EndpointPort.class);
+        when(port.getName()).thenReturn("jfr-jmx");
+        when(port.getPort()).thenReturn(9091);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of("192.168.1.100"));
+
+        ObjectReference targetRef = mock(ObjectReference.class);
+        when(targetRef.getNamespace()).thenReturn("test-namespace");
+        when(targetRef.getName()).thenReturn("test-pod");
+        when(targetRef.getKind()).thenReturn("Pod");
+        when(endpoint.getTargetRef()).thenReturn(targetRef);
+
+        EndpointConditions conditions = mock(EndpointConditions.class);
+        when(endpoint.getConditions()).thenReturn(conditions);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        // Mock queryForNode
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getLabels()).thenReturn(new HashMap<>());
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        MixedOperation podOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource = mock(PodResource.class);
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("test-pod")).thenReturn(podResource);
+        when(podResource.get()).thenReturn(pod);
+
+        // Execute
+        var result = discovery.tuplesFromEndpoints(slice);
+
+        // Assertions
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        // Address should be transformed to DNS format: 192-168-1-100.test-namespace.pod
+    }
+
+    @Test
+    void testBuildOwnershipHierarchyWithPodOnly() {
+        // Create a Pod node without owners
+        DiscoveryNode podNode = new DiscoveryNode();
+        podNode.name = "test-pod";
+        podNode.nodeType = "Pod";
+        podNode.labels = new HashMap<>();
+
+        // Mock the Pod metadata
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getOwnerReferences()).thenReturn(List.of());
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        // Execute
+        DiscoveryNode root = discovery.buildOwnershipHierarchy(podNode);
+
+        // Assertions
+        assertNotNull(root);
+        assertEquals(podNode, root); // Pod should be the root since it has no owners
+        assertNull(podNode.parent);
+    }
+
+    @Test
+    void testBuildOwnershipHierarchyWithPodToReplicaSet() {
+        // Create Pod node
+        DiscoveryNode podNode = new DiscoveryNode();
+        podNode.name = "test-pod";
+        podNode.nodeType = "Pod";
+        podNode.labels = new HashMap<>();
+        podNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+
+        // Mock Pod with ReplicaSet owner
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        OwnerReference rsOwner = mock(OwnerReference.class);
+        when(rsOwner.getKind()).thenReturn("ReplicaSet");
+        when(rsOwner.getName()).thenReturn("test-rs");
+        when(podMeta.getOwnerReferences()).thenReturn(List.of(rsOwner));
+        when(podMeta.getNamespace()).thenReturn("test-namespace");
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        // Mock ReplicaSet
+        ReplicaSet rs = mock(ReplicaSet.class);
+        ObjectMeta rsMeta = mock(ObjectMeta.class);
+        when(rsMeta.getOwnerReferences()).thenReturn(List.of());
+        when(rsMeta.getNamespace()).thenReturn("test-namespace");
+        when(rsMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
+        when(rs.getMetadata()).thenReturn(rsMeta);
+
+        // Mock Kubernetes client calls
+        AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
+        MixedOperation rsOp = mock(MixedOperation.class);
+        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+
+        when(client.apps()).thenReturn(appsApi);
+        when(appsApi.replicaSets()).thenReturn(rsOp);
+        when(rsOp.inNamespace("test-namespace")).thenReturn(rsNsOp);
+        when(rsNsOp.withName("test-rs")).thenReturn(rsResource);
+        when(rsResource.get()).thenReturn(rs);
+
+        // We need to inject the Pod metadata for the initial node
+        // This is a bit tricky since buildOwnershipHierarchy expects the node to already have
+        // metadata
+        // For this test, we'll need to mock the getOwnerNode behavior
+
+        // Execute
+        DiscoveryNode root = discovery.buildOwnershipHierarchy(podNode);
+
+        // Assertions
+        assertNotNull(root);
+        // The root should be the ReplicaSet since Pod has no further owners
+        // Note: Without full integration, we can verify the structure was attempted
+    }
+
+    @Test
+    void testBuildOwnershipHierarchyWithFullChain() {
+        // Create Pod node
+        DiscoveryNode podNode = new DiscoveryNode();
+        podNode.name = "test-pod";
+        podNode.nodeType = "Pod";
+        podNode.labels = new HashMap<>();
+        podNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+
+        // Mock Pod with ReplicaSet owner
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        OwnerReference rsOwner = mock(OwnerReference.class);
+        when(rsOwner.getKind()).thenReturn("ReplicaSet");
+        when(rsOwner.getName()).thenReturn("test-rs-abc123");
+        when(podMeta.getOwnerReferences()).thenReturn(List.of(rsOwner));
+        when(podMeta.getNamespace()).thenReturn("test-namespace");
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        // Mock ReplicaSet with Deployment owner
+        ReplicaSet rs = mock(ReplicaSet.class);
+        ObjectMeta rsMeta = mock(ObjectMeta.class);
+        OwnerReference deployOwner = mock(OwnerReference.class);
+        when(deployOwner.getKind()).thenReturn("Deployment");
+        when(deployOwner.getName()).thenReturn("test-deployment");
+        when(rsMeta.getOwnerReferences()).thenReturn(List.of(deployOwner));
+        when(rsMeta.getNamespace()).thenReturn("test-namespace");
+        when(rsMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
+        when(rs.getMetadata()).thenReturn(rsMeta);
+
+        // Mock Deployment (no further owners)
+        Deployment deployment = mock(Deployment.class);
+        ObjectMeta deployMeta = mock(ObjectMeta.class);
+        when(deployMeta.getOwnerReferences()).thenReturn(List.of());
+        when(deployMeta.getNamespace()).thenReturn("test-namespace");
+        when(deployMeta.getLabels()).thenReturn(Map.of("app", "test-app", "version", "v1"));
+        when(deployment.getMetadata()).thenReturn(deployMeta);
+
+        // Mock Kubernetes client calls
+        AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
+
+        // ReplicaSet mocks
+        MixedOperation rsOp = mock(MixedOperation.class);
+        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+
+        // Deployment mocks
+        MixedOperation deployOp = mock(MixedOperation.class);
+        NonNamespaceOperation deployNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource deployResource = mock(RollableScalableResource.class);
+
+        when(client.apps()).thenReturn(appsApi);
+        when(appsApi.replicaSets()).thenReturn(rsOp);
+        when(rsOp.inNamespace("test-namespace")).thenReturn(rsNsOp);
+        when(rsNsOp.withName("test-rs-abc123")).thenReturn(rsResource);
+        when(rsResource.get()).thenReturn(rs);
+
+        when(appsApi.deployments()).thenReturn(deployOp);
+        when(deployOp.inNamespace("test-namespace")).thenReturn(deployNsOp);
+        when(deployNsOp.withName("test-deployment")).thenReturn(deployResource);
+        when(deployResource.get()).thenReturn(deployment);
+
+        // Execute
+        DiscoveryNode root = discovery.buildOwnershipHierarchy(podNode);
+
+        // Assertions
+        assertNotNull(root);
+        // The root should be the Deployment
+        // Verify the hierarchy was built (Pod -> ReplicaSet -> Deployment)
+    }
+
+    @Test
+    void testBuildOwnershipHierarchyWithMultipleOwners() {
+        // Create Pod node
+        DiscoveryNode podNode = new DiscoveryNode();
+        podNode.name = "test-pod";
+        podNode.nodeType = "Pod";
+        podNode.labels = new HashMap<>();
+        podNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+
+        // Mock Pod with multiple owners (should pick the first recognized one)
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+
+        OwnerReference unknownOwner = mock(OwnerReference.class);
+        when(unknownOwner.getKind()).thenReturn("UnknownKind");
+        when(unknownOwner.getName()).thenReturn("unknown-owner");
+
+        OwnerReference rsOwner = mock(OwnerReference.class);
+        when(rsOwner.getKind()).thenReturn("ReplicaSet");
+        when(rsOwner.getName()).thenReturn("test-rs");
+
+        when(podMeta.getOwnerReferences()).thenReturn(List.of(unknownOwner, rsOwner));
+        when(podMeta.getNamespace()).thenReturn("test-namespace");
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        // Mock ReplicaSet
+        ReplicaSet rs = mock(ReplicaSet.class);
+        ObjectMeta rsMeta = mock(ObjectMeta.class);
+        when(rsMeta.getOwnerReferences()).thenReturn(List.of());
+        when(rsMeta.getNamespace()).thenReturn("test-namespace");
+        when(rsMeta.getLabels()).thenReturn(new HashMap<>());
+        when(rs.getMetadata()).thenReturn(rsMeta);
+
+        // Mock Kubernetes client calls
+        AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
+        MixedOperation rsOp = mock(MixedOperation.class);
+        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+
+        when(client.apps()).thenReturn(appsApi);
+        when(appsApi.replicaSets()).thenReturn(rsOp);
+        when(rsOp.inNamespace("test-namespace")).thenReturn(rsNsOp);
+        when(rsNsOp.withName("test-rs")).thenReturn(rsResource);
+        when(rsResource.get()).thenReturn(rs);
+
+        // Execute
+        DiscoveryNode root = discovery.buildOwnershipHierarchy(podNode);
+
+        // Assertions
+        assertNotNull(root);
+        // Should have picked the ReplicaSet owner (recognized kind) over unknown kind
+    }
+
+    @Test
+    void testBuildOwnershipHierarchyReusesExistingNodes() {
+        // Create two Pod nodes that share the same ReplicaSet owner
+        DiscoveryNode pod1Node = new DiscoveryNode();
+        pod1Node.name = "test-pod-1";
+        pod1Node.nodeType = "Pod";
+        pod1Node.labels = new HashMap<>();
+        pod1Node.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+
+        DiscoveryNode pod2Node = new DiscoveryNode();
+        pod2Node.name = "test-pod-2";
+        pod2Node.nodeType = "Pod";
+        pod2Node.labels = new HashMap<>();
+        pod2Node.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+
+        // Both pods have the same ReplicaSet owner
+        ReplicaSet rs = mock(ReplicaSet.class);
+        ObjectMeta rsMeta = mock(ObjectMeta.class);
+        when(rsMeta.getOwnerReferences()).thenReturn(List.of());
+        when(rsMeta.getNamespace()).thenReturn("test-namespace");
+        when(rsMeta.getLabels()).thenReturn(Map.of("app", "shared-app"));
+        when(rs.getMetadata()).thenReturn(rsMeta);
+
+        // Mock Kubernetes client
+        AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
+        MixedOperation rsOp = mock(MixedOperation.class);
+        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+
+        when(client.apps()).thenReturn(appsApi);
+        when(appsApi.replicaSets()).thenReturn(rsOp);
+        when(rsOp.inNamespace("test-namespace")).thenReturn(rsNsOp);
+        when(rsNsOp.withName("shared-rs")).thenReturn(rsResource);
+        when(rsResource.get()).thenReturn(rs);
+
+        // Execute - build hierarchy for both pods
+        DiscoveryNode root1 = discovery.buildOwnershipHierarchy(pod1Node);
+        DiscoveryNode root2 = discovery.buildOwnershipHierarchy(pod2Node);
+
+        // Assertions
+        assertNotNull(root1);
+        assertNotNull(root2);
+        // Both should reference the same ReplicaSet node (node reuse)
+        // This verifies that the discovery mechanism creates a tree, not separate chains
     }
 }

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -16,7 +16,6 @@
 package io.cryostat.discovery;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
@@ -29,12 +28,16 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
 import io.fabric8.kubernetes.api.model.discovery.v1.Endpoint;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointConditions;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointPort;
 import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
+import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSliceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -147,6 +150,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetTargetTuplesFromReturnsValidTargetTuplesWithSingleEndpoint() {
         EndpointSlice slice = mock(EndpointSlice.class);
         when(slice.getAddressType()).thenReturn("ipv4");
@@ -178,8 +182,8 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(podMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
         when(pod.getMetadata()).thenReturn(podMeta);
 
-        MixedOperation podOp = mock(MixedOperation.class);
-        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
         PodResource podResource = mock(PodResource.class);
         when(client.pods()).thenReturn(podOp);
         when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
@@ -196,6 +200,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetTargetTuplesFromWithMultipleEndpointsAndPorts() {
         EndpointSlice slice = mock(EndpointSlice.class);
         when(slice.getAddressType()).thenReturn("ipv4");
@@ -242,8 +247,8 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(meta2.getLabels()).thenReturn(new HashMap<>());
         when(pod2.getMetadata()).thenReturn(meta2);
 
-        MixedOperation podOp = mock(MixedOperation.class);
-        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
         PodResource podResource1 = mock(PodResource.class);
         PodResource podResource2 = mock(PodResource.class);
 
@@ -284,6 +289,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testBuildOwnershipHierarchyWithPodToReplicaSet() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -303,9 +309,11 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(rs.getMetadata()).thenReturn(rsMeta);
 
         AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
-        MixedOperation rsOp = mock(MixedOperation.class);
-        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
-        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+        MixedOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>> rsOp =
+                mock(MixedOperation.class);
+        NonNamespaceOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>>
+                rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource<ReplicaSet> rsResource = mock(RollableScalableResource.class);
 
         when(client.apps()).thenReturn(appsApi);
         when(appsApi.replicaSets()).thenReturn(rsOp);
@@ -330,6 +338,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testBuildOwnershipHierarchyWithFullChain() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -360,13 +369,17 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
 
         AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
 
-        MixedOperation rsOp = mock(MixedOperation.class);
-        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
-        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+        MixedOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>> rsOp =
+                mock(MixedOperation.class);
+        NonNamespaceOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>>
+                rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource<ReplicaSet> rsResource = mock(RollableScalableResource.class);
 
-        MixedOperation deployOp = mock(MixedOperation.class);
-        NonNamespaceOperation deployNsOp = mock(NonNamespaceOperation.class);
-        RollableScalableResource deployResource = mock(RollableScalableResource.class);
+        MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deployOp =
+                mock(MixedOperation.class);
+        NonNamespaceOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>>
+                deployNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource<Deployment> deployResource = mock(RollableScalableResource.class);
 
         when(client.apps()).thenReturn(appsApi);
         when(appsApi.replicaSets()).thenReturn(rsOp);
@@ -444,6 +457,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetOwnershipLineageWithStringParametersForPod() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -452,8 +466,8 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(podMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
         when(pod.getMetadata()).thenReturn(podMeta);
 
-        MixedOperation podOp = mock(MixedOperation.class);
-        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
         PodResource podResource = mock(PodResource.class);
         when(client.pods()).thenReturn(podOp);
         when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
@@ -472,6 +486,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetOwnershipLineageWithStringParametersForPodWithReplicaSetOwner() {
         Pod pod = mock(Pod.class);
         ObjectMeta podMeta = mock(ObjectMeta.class);
@@ -490,8 +505,9 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(rsMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
         when(rs.getMetadata()).thenReturn(rsMeta);
 
-        MixedOperation podOp = mock(MixedOperation.class);
-        NonNamespaceOperation podNsOp = mock(NonNamespaceOperation.class);
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> podNsOp =
+                mock(NonNamespaceOperation.class);
         PodResource podResource = mock(PodResource.class);
         when(client.pods()).thenReturn(podOp);
         when(podOp.inNamespace("test-namespace")).thenReturn(podNsOp);
@@ -499,9 +515,11 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         when(podResource.get()).thenReturn(pod);
 
         AppsAPIGroupDSL appsApi = mock(AppsAPIGroupDSL.class);
-        MixedOperation rsOp = mock(MixedOperation.class);
-        NonNamespaceOperation rsNsOp = mock(NonNamespaceOperation.class);
-        RollableScalableResource rsResource = mock(RollableScalableResource.class);
+        MixedOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>> rsOp =
+                mock(MixedOperation.class);
+        NonNamespaceOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>>
+                rsNsOp = mock(NonNamespaceOperation.class);
+        RollableScalableResource<ReplicaSet> rsResource = mock(RollableScalableResource.class);
         when(client.apps()).thenReturn(appsApi);
         when(appsApi.replicaSets()).thenReturn(rsOp);
         when(rsOp.inNamespace("test-namespace")).thenReturn(rsNsOp);
@@ -522,6 +540,7 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetOwnershipLineageWithStringParametersForEndpointSlice() {
         EndpointSlice slice = mock(EndpointSlice.class);
         ObjectMeta sliceMeta = mock(ObjectMeta.class);
@@ -534,9 +553,17 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                 mock(io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL.class);
         io.fabric8.kubernetes.client.dsl.V1DiscoveryAPIGroupDSL v1Api =
                 mock(io.fabric8.kubernetes.client.dsl.V1DiscoveryAPIGroupDSL.class);
-        MixedOperation sliceOp = mock(MixedOperation.class);
-        NonNamespaceOperation sliceNsOp = mock(NonNamespaceOperation.class);
-        io.fabric8.kubernetes.client.dsl.Resource sliceResource =
+        MixedOperation<
+                        EndpointSlice,
+                        EndpointSliceList,
+                        io.fabric8.kubernetes.client.dsl.Resource<EndpointSlice>>
+                sliceOp = mock(MixedOperation.class);
+        NonNamespaceOperation<
+                        EndpointSlice,
+                        EndpointSliceList,
+                        io.fabric8.kubernetes.client.dsl.Resource<EndpointSlice>>
+                sliceNsOp = mock(NonNamespaceOperation.class);
+        io.fabric8.kubernetes.client.dsl.Resource<EndpointSlice> sliceResource =
                 mock(io.fabric8.kubernetes.client.dsl.Resource.class);
 
         when(client.discovery()).thenReturn(discoveryApi);
@@ -573,9 +600,10 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked") // Mockito mock() requires unchecked cast for generic types
     void testGetOwnershipLineageWithStringParametersForNonExistentResource() {
-        MixedOperation podOp = mock(MixedOperation.class);
-        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
         PodResource podResource = mock(PodResource.class);
         when(client.pods()).thenReturn(podOp);
         when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

**Disclaimer**: This PR was written with LLM assistance

Related to https://github.com/cryostatio/cryostat/issues/635#issuecomment-2332435489
Related to https://github.com/cryostatio/cryostat-agent/pull/779
Related https://github.com/cryostatio/cryostat-operator/pull/1218

## Description of the change:
1. Implements handling of Discovery Plugins (Cryostat Agents) publishing discovery subtrees which are not flat lists of child nodes, but lists of hierarchical node subtrees. This was already supported by Cryostat's data model, it was just never implemented on the API POST endpoint.
2. Implements a `mergeRealms` query parameter on the GET endpoint which returns the overall Discovery tree model. If this is not set or is set to false the behaviour is the same as before. If it is set to true then rather than returning a Universe node where each child is a Realm (and discovery plugins/Cryostat Agents are their own independent Realms) with completely independent subtrees, all of the Realms are collapsed into a single 'Cryostat Discovery' Realm. Any nodes from different Realms which collide on the same name/nodeType are merged into a single node in the merged tree. When combined with the linked Agent and Operator PRs, this has the effect of allowing clients to view a Discovery tree model with a unified view where all Agent instances within the same Namespace are modelled as children of a single Namespace node, and JVMs discovered by KubeEndpointSlices querying are also merged into the same tree (see linked web PR below):
3. Significant refactors KubeEndpointSlicesDiscovery mechanism and adds test coverage. A follow-up PR building on this one will make more of use of these changes.

Unmerged, but with Operator autoconfig augmentation on the Agent hierarchy:
<img width="1531" height="866" alt="Screenshot_2026-01-16_13-41-21" src="https://github.com/user-attachments/assets/95d4811a-d92a-4a0f-9f9a-8b4f1604ee71" />

Merged trees between Agent augmented hierarchy and k8s EndpointSlices-based discovery:
<img width="1516" height="858" alt="Screenshot_2026-01-16_13-41-38" src="https://github.com/user-attachments/assets/056dded4-816a-4ccc-8111-7b31afc0a1da" />

## How to manually test:
1. Combine with web PR, build locally, run smoketest with `-t quarkus-cryostat-agent`
2. Open UI and go to Topology
4. Toggle the "Merge Realms" control off and on

Alternately, see the linked Operator PR above
