### PR TITLE
test(smoketest): update oauth2-proxy alpha config

### DIFF
--- a/compose/auth_proxy_alpha_config_https.yml
+++ b/compose/auth_proxy_alpha_config_https.yml
@@ -29,7 +29,9 @@ providers:
 injectRequestHeaders:
   - name: "X-Forwarded-Proto"
     values:
-      - fromEnv: CRYOSTAT_PROXY_PROTOCOL
+      - secretSource:
+          fromEnv: CRYOSTAT_PROXY_PROTOCOL
   - name: "X-Forwarded-Port"
     values:
-      - fromEnv: CRYOSTAT_PROXY_PORT
+      - secretSource:
+          fromEnv: CRYOSTAT_PROXY_PORT


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1255 

## Description of the change:

Update `compose/auth_proxy_alpha_config_https.yml` to use the new oauth2-proxy v7.14.x alpha config format for header injections by wrapping `fromEnv` values under `secretSource`:

## Motivation for the change:

- oauth2-proxy v7.14.x changed the alpha config format requiring `fromEnv` to be nested under `secretSource`
- The latest-alpine tag now pulls a version with this breaking change, causing the smoketest to fail with:
```
  'injectRequestHeaders[0].values[0]' has invalid keys: fromEnv
```

## How to manually test:

- Run `./smoketest.bash -O` (or any flags that enable the auth proxy with TLS)
- Verify the auth container starts successfully without config errors
- Verify you can access the Cryostat UI through the proxy
