### PR TITLE
ci(renovate): enable submodule updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,11 +10,14 @@
     "chore",
     "safe-to-test"
   ],
+  "stopUpdatingLabel": "blocked",
   "semanticCommits": "enabled",
   "major": {
     "dependencyDashboardApproval": true
   },
-  "stopUpdatingLabel": "blocked",
+  "git-submodules": {
+      "enabled": true
+  },
   "packageRules": [
     {
       "description": "Require approval for Quarkus minor version updates",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat-web#2103 through cryostatio/cryostat-web#2110

Rather than -web's CI having a submodule workflow which tries to directly push commits to protected branches of cryostat and cryostat-openshift-console-plugin (not good for security), or rolling our own automatic update PR workflow (troublesome and error-prone), just try getting Renovate to automate that.
