### PR TITLE
feat(graphql): DiscoveryNodeFilter by JVM hash ID

### DIFF
--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -380,10 +380,13 @@ input DiscoveryNodeFilterInput {
   annotations: [String]
   id: BigInteger
   ids: [BigInteger]
+  jvmId: String
+  jvmIds: [String]
   labels: [String]
   name: String
   names: [String]
   nodeTypes: [String]
+  targetId: BigInteger
   targetIds: [BigInteger]
 }
 

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -66,7 +66,10 @@ public class RootNode {
     public static class DiscoveryNodeFilter implements Predicate<DiscoveryNode> {
         public @Nullable Long id;
         public @Nullable List<Long> ids;
+        public @Nullable Long targetId;
         public @Nullable List<Long> targetIds;
+        public @Nullable String jvmId;
+        public @Nullable List<String> jvmIds;
         public @Nullable String name;
         public @Nullable List<String> names;
         public @Nullable List<String> nodeTypes;
@@ -77,12 +80,14 @@ public class RootNode {
         public boolean test(DiscoveryNode t) {
             Predicate<DiscoveryNode> matchesId = n -> id == null || id.equals(n.id);
             Predicate<DiscoveryNode> matchesIds = n -> ids == null || ids.contains(n.id);
+            Predicate<DiscoveryNode> matchesJvmId =
+                    n -> jvmId == null || jvmId.equals(n.target.jvmId);
+            Predicate<DiscoveryNode> matchesJvmIds =
+                    n -> jvmIds == null || jvmIds.contains(n.target.jvmId);
+            Predicate<DiscoveryNode> matchesTargetId =
+                    n -> targetId == null || (n.target != null && targetId.equals(n.target.id));
             Predicate<DiscoveryNode> matchesTargetIds =
-                    n ->
-                            targetIds == null
-                                    || (targetIds != null
-                                            && n.target != null
-                                            && targetIds.contains(n.target.id));
+                    n -> targetIds == null || (n.target != null && targetIds.contains(n.target.id));
             Predicate<DiscoveryNode> matchesName = n -> name == null || name.equals(n.name);
             Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);
             Predicate<DiscoveryNode> matchesNodeTypes =
@@ -112,6 +117,9 @@ public class RootNode {
             return List.of(
                             matchesId,
                             matchesIds,
+                            matchesJvmId,
+                            matchesJvmIds,
+                            matchesTargetId,
                             matchesTargetIds,
                             matchesName,
                             matchesNames,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #294
See #1370

## Description of the change:
Adds GraphQL target node filter optional parameter for JVM hash ID. Also, adds missing singleton target db ID filter - this already supported filtering by a list of IDs, so the client could pass a singleton list of an interesting ID already, but there was no syntax shortcut for the single ID case here. Other filter parameters have both forms, so that should too.

## Motivation for the change:
Makes it easier for clients who have used some other API endpoint to do follow-up work using the GraphQL API, whether they have a Target database ID or JVM hash ID.
