### PR TITLE
test(logs): upload PR CI test log artifacts for inspection

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -165,11 +165,20 @@ jobs:
         PR_CI: true
       run: |
         ./mvnw -B -U \
-          -Dquarkus.log.level=error \
-          -Dquarkus.hibernate-orm.log.sql=false \
-          -Dquarkus.http.access-log.enabled=false \
-          clean verify
-
+          -Dquarkus.log.level=debug \
+          -Dquarkus.hibernate-orm.log.sql=true \
+          -Dquarkus.http.access-log.enabled=true \
+          clean verify > test.log 2>&1
+    - uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: cryostat-test-log
+        path: test.log
+    - uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: cryostat-itest-server-log
+        path: target/quarkus.log
     - name: Add workflow result as comment on PR
       uses: actions/github-script@v8
       if: always()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/1319#issuecomment-3970379074

## Description of the change:
Writes the regular test output to file rather than dumping to stdout, since the logs are large and reading them in the GitHub UI doesn't work well anyway. Sets the log level back to a more verbose setting, undoing part of https://github.com/cryostatio/cryostat/pull/971 which was an earlier attempt to try to stabilize the tests thinking that the logging verbosity might have been a problem for the runner. And, uploads the test output file as well as the integration test container log file (Cryostat itself, instead of the test harness) to GitHub artifacts associated with the workflow so that both can be downloaded for inspection.
