### PR TITLE
ci(github): run PR CI in docker, not podman

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -165,6 +165,7 @@ jobs:
         PR_CI: true
       run: |
         ./mvnw -B -U \
+          -Dquarkus.container-image.builder=docker \
           -Dquarkus.log.level=debug \
           -Dquarkus.hibernate-orm.log.sql=true \
           -Dquarkus.http.access-log.enabled=true \

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-container-image-docker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -172,6 +172,7 @@ quarkus.quinoa.package-manager-command.dev=start:dev
 quarkus.scheduler.start-mode=forced
 
 quarkus.application.name=cryostat
+quarkus.container-image.builder=podman
 quarkus.container-image.build=true
 quarkus.container-image.push=false
 quarkus.container-image.registry=quay.io


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1328
https://github.com/cryostatio/cryostat/pull/1319#issuecomment-3973885245

## Description of the change:
1. Adds the Quarkus docker container image extension back
2. Sets podman container image extension as default
3. Keeps merge CI using podman, sets PR CI to use docker

## Motivation for the change:
#1328 fixed a CI issue with trying to use both Docker and Podman together in one workflow, but in #1319 it seems that Podman causes problems for the new integration tests.

It may end up that #1319 fails after merge due to using Podman for the merge CI and the integration tests might fail again, but we'll see.
