### PR TITLE
feat(automated-analysis): keep cached reports for lost targets

### DIFF
--- a/src/main/java/io/cryostat/reports/AnalysisReportAggregator.java
+++ b/src/main/java/io/cryostat/reports/AnalysisReportAggregator.java
@@ -38,8 +38,6 @@ import io.cryostat.recordings.LongRunningRequestGenerator.ArchivedReportCompleti
 import io.cryostat.recordings.LongRunningRequestGenerator.ArchivedReportRequest;
 import io.cryostat.recordings.RecordingHelper;
 import io.cryostat.targets.Target;
-import io.cryostat.targets.Target.EventKind;
-import io.cryostat.targets.Target.TargetDiscovery;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.cache.Cache;
@@ -120,7 +118,6 @@ public class AnalysisReportAggregator {
                                     cache.as(CaffeineCache.class).put(jvmId, future);
                                 } catch (Exception e) {
                                     logger.warn(e);
-                                    cache.invalidate(jvmId).await().atMost(Duration.ofMillis(100));
                                 }
                             });
         }
@@ -185,13 +182,6 @@ public class AnalysisReportAggregator {
                         });
     }
 
-    @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY, blocking = true)
-    void onMessage(TargetDiscovery event) {
-        if (EventKind.LOST.equals(event.kind())) {
-            cache.invalidate(event.serviceRef().jvmId).await().atMost(Duration.ofMillis(100));
-        }
-    }
-
     public void reset() {
         cache.invalidateAll().await().atMost(Duration.ofMillis(100));
     }
@@ -207,7 +197,6 @@ public class AnalysisReportAggregator {
                     Retrieve the latest aggregate report data across all targets with recent automated analysis reports
                     scores. These are multi-dimensional metrics in Prometheus format.
                     """)
-    // TODO should this include results from lost targets?
     public Multi<String> scrape() {
         var multis =
                 cache.as(CaffeineCache.class).keySet().stream()
@@ -233,7 +222,6 @@ public class AnalysisReportAggregator {
                     Retrieve the latest aggregate report data for a given target's recent automated analysis reports
                     scores. These are multi-dimensional metrics in Prometheus format.
                     """)
-    // TODO should this include results from lost targets?
     public Uni<RestResponse<String>> scrape(@RestPath String jvmId) {
         return getEntry(jvmId)
                 .onItem()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #859

## Description of the change:
Removes the event handler for "target discovery lost" events which invalidated reports cache entries for those targets.

## Motivation for the change:
This reports cache, and in particular its Prometheus-formatted scraping endpoint, is a useful data source for external tools that do incident reporting or otherwise watch for trends and alerts. These most likely work on a periodic scraping interval. If a target application experiences some kind of incident which results in the application crashing or being shut down (ex. k8s OOM kill), there may be a signal about the conditions leading up to this event in the automated analysis report. If the cache entry for the target is invalidated when it is lost, then the metrics scraper may never see the increasing score trend or the final score result and no incident report will be generated.

This is especially apparent if we consider the case of a target using the Cryostat Agent and its Harvest facility for tail-end data collection. In this case, the automated analysis report for that target based on its shutdown JFR push will almost certainly contain interesting information about the reason for the shutdown. These reports should definitely be kept in cache until they naturally expire.
