### PR TITLE
feat(triggers): Add support for querying mbean attributes

### DIFF
--- a/src/main/java/io/cryostat/mbean/MbeanQuery.java
+++ b/src/main/java/io/cryostat/mbean/MbeanQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.mbean;
+
+import java.time.Duration;
+import java.util.List;
+
+import io.cryostat.ConfigProperties;
+import io.cryostat.libcryostat.net.MbeanAttributeMap;
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("/")
+public class MbeanQuery {
+
+    @Inject Logger log;
+
+    @Inject TargetConnectionManager targetConnectionManager;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_UPLOAD_TIMEOUT)
+    Duration uploadFailedTimeout;
+
+    @Inject ObjectMapper mapper;
+
+    @Path("api/beta/targets/{targetId}/mbean-query")
+    @RolesAllowed("read")
+    @Transactional
+    @Produces({MediaType.APPLICATION_JSON})
+    @GET
+    @Operation(summary = "Retrieve all currently available mbean attributes")
+    public List<MbeanAttributeMap> queryMbeans(@RestPath long targetId) {
+        log.tracev("Mbean query received for target {0}", targetId);
+        Target target = Target.getTargetById(targetId);
+        return targetConnectionManager.executeConnectedTask(
+                target,
+                conn -> {
+                    return conn.queryMbeanAttributes();
+                },
+                uploadFailedTimeout);
+    }
+}

--- a/src/main/java/io/cryostat/targets/AgentClient.java
+++ b/src/main/java/io/cryostat/targets/AgentClient.java
@@ -48,6 +48,7 @@ import io.cryostat.core.serialization.JmcSerializableRecordingDescriptor;
 import io.cryostat.discovery.DiscoveryPlugin;
 import io.cryostat.discovery.DiscoveryPlugin.PluginCallback.DiscoveryPluginAuthorizationHeaderFactory;
 import io.cryostat.libcryostat.net.MBeanMetrics;
+import io.cryostat.libcryostat.net.MbeanAttributeMap;
 import io.cryostat.libcryostat.triggers.SmartTrigger;
 import io.cryostat.targets.AgentJFRService.StartRecordingRequest;
 import io.cryostat.util.HttpStatusCodeIdentifier;
@@ -247,6 +248,20 @@ public class AgentClient {
             logger.error("invokeMBeanOperation request failed", e);
             return Uni.createFrom().failure(e);
         }
+    }
+
+    Uni<List<MbeanAttributeMap>> queryMbeanAttributes() {
+        return agentRestClient
+                .queryMbeanAttributes()
+                .map(
+                        Unchecked.function(
+                                resp -> {
+                                    try (resp;
+                                            var is = (InputStream) resp.getEntity()) {
+                                        return Arrays.asList(
+                                                mapper.readValue(is, MbeanAttributeMap[].class));
+                                    }
+                                }));
     }
 
     Uni<IRecordingDescriptor> startRecording(StartRecordingRequest req) {

--- a/src/main/java/io/cryostat/targets/AgentConnection.java
+++ b/src/main/java/io/cryostat/targets/AgentConnection.java
@@ -42,6 +42,7 @@ import io.cryostat.libcryostat.JvmIdentifier;
 import io.cryostat.libcryostat.net.CryostatAgentMXBean;
 import io.cryostat.libcryostat.net.IDException;
 import io.cryostat.libcryostat.net.MBeanMetrics;
+import io.cryostat.libcryostat.net.MbeanAttributeMap;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.triggers.SmartTrigger;
 import io.cryostat.targets.AgentClient.AsyncProfile;
@@ -159,6 +160,15 @@ public class AgentConnection implements JFRConnection {
         return client.invokeMBeanOperation(beanName, operation, parameters, signature, returnType)
                 .await()
                 .atMost(client.getTimeout());
+    }
+
+    @Override
+    public List<MbeanAttributeMap> queryMbeanAttributes()
+            throws IOException,
+                    InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException {
+        return client.queryMbeanAttributes().await().atMost(client.getTimeout());
     }
 
     @Override

--- a/src/main/java/io/cryostat/targets/AgentRestClient.java
+++ b/src/main/java/io/cryostat/targets/AgentRestClient.java
@@ -54,6 +54,11 @@ interface AgentRestClient {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     Uni<Response> invokeMBeanOperation(InputStream payload);
 
+    @Path("/mbean-query/")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Uni<Response> queryMbeanAttributes();
+
     @Path("/smart-triggers/")
     @POST
     Uni<Response> addTriggers(InputStream payload);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [#<issue number>](https://github.com/cryostatio/cryostat-web/issues/2092)

Depends on: https://github.com/cryostatio/cryostat-core/pull/667 https://github.com/cryostatio/cryostat-agent/pull/849

## Description of the change:
- Adds a new endpoint /targets/{targetId}/mbean-query that returns all currently available mbean attributes. Required for the smart triggers mbean selector form, and in future can be used to build an mbean viewer page in the frontend or other similar components.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
