### PR TITLE
perf(s3): avoid use of temporary file uploads to avoid disk write pressure

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1297,12 +1297,9 @@ paths:
             type: string
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          multipart/form-data:
             schema:
               properties:
-                heapDump:
-                  format: binary
-                  type: string
                 jobId:
                   type: string
                 labels:
@@ -1692,7 +1689,7 @@ paths:
             type: string
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          multipart/form-data:
             schema:
               properties:
                 labels:
@@ -1701,7 +1698,6 @@ paths:
                   format: int32
                   type: integer
                 recording:
-                  format: binary
                   type: string
               type: object
         required: true
@@ -2757,13 +2753,12 @@ paths:
         Cryostat, so that Cryostat can be used to perform online analysis of the file.
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          multipart/form-data:
             schema:
               properties:
                 labels:
                   $ref: '#/components/schemas/JsonObject'
                 recording:
-                  format: binary
                   type: string
               type: object
         required: true

--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -16,6 +16,7 @@
 package io.cryostat.diagnostic;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -23,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,6 +47,7 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -55,6 +56,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -66,7 +68,8 @@ import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.jboss.resteasy.reactive.server.multipart.FormValue;
+import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -338,36 +341,41 @@ public class Diagnostics {
         return request.id();
     }
 
+    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
     @Path("heapdump/upload/{jvmId}")
     @RolesAllowed("read")
     @Blocking
     @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     public void uploadHeapDump(
             @RestPath String jvmId,
-            @Parameter(required = true) @RestForm("heapDump") FileUpload heapDump,
-            @Parameter(required = true) @RestForm("jobId") String jobId,
-            @Parameter(required = false) @RestForm("labels") JsonObject rawLabels) {
+            @RestForm("jobId") String jobId,
+            @Parameter(required = false) @RestForm("labels") JsonObject rawLabels,
+            MultipartFormDataInput input) {
         log.tracev(
                 "Received heap dump upload request for target: {0} with job ID {1}", jvmId, jobId);
         jvmId = jvmId.strip();
-        doUpload(heapDump, jvmId, jobId);
-    }
+        FormValue heapDumpPart =
+                input.getValues().getOrDefault("heapDump", List.of()).stream()
+                        .findFirst()
+                        .orElse(null);
+        if (heapDumpPart == null || !heapDumpPart.isFileItem()) {
+            throw new BadRequestException();
+        }
+        String filename = heapDumpPart.getFileName().strip();
+        try (InputStream heapDump = heapDumpPart.getFileItem().getInputStream()) {
+            var dump = helper.addHeapDump(jvmId, heapDump, filename, jobId);
 
-    @Blocking
-    @Transactional
-    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
-    Map<String, Object> doUpload(FileUpload heapDump, String jvmId, String jobId) {
-        var dump = helper.addHeapDump(jvmId, heapDump, jobId);
-
-        io.cryostat.diagnostic.HeapDump.<io.cryostat.diagnostic.HeapDump>find("jobId", jobId)
-                .firstResultOptional()
-                .ifPresent(
-                        hd -> {
-                            hd.markCompleted(dump.heapDumpId(), dump.size());
-                            hd.persist();
-                        });
-
-        return Map.of("name", dump.heapDumpId());
+            io.cryostat.diagnostic.HeapDump.<io.cryostat.diagnostic.HeapDump>find("jobId", jobId)
+                    .firstResultOptional()
+                    .ifPresent(
+                            hd -> {
+                                hd.markCompleted(dump.heapDumpId(), dump.size());
+                                hd.persist();
+                            });
+        } catch (IOException ioe) {
+            throw new BadRequestException(ioe);
+        }
     }
 
     @Path("targets/{targetId}/heapdump")

--- a/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
+++ b/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
@@ -18,7 +18,6 @@ package io.cryostat.diagnostic;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,9 +27,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.Producers;
+import io.cryostat.ProgressInputStream;
 import io.cryostat.StorageBuckets;
 import io.cryostat.diagnostic.Diagnostics.HeapDump;
 import io.cryostat.diagnostic.Diagnostics.ThreadDump;
@@ -45,8 +48,6 @@ import io.cryostat.ws.Notification;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.ext.web.handler.HttpException;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -61,8 +62,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -77,7 +78,6 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 
 @ApplicationScoped
@@ -119,6 +119,7 @@ public class DiagnosticsHelper {
     @Inject Instance<ThreadDumpsMetadataService> threadDumpsMetadataService;
 
     @Inject S3Client storage;
+    @Inject S3AsyncClient storageAsync;
     @Inject S3TransferManager transferManager;
     @Inject Logger log;
     @Inject Clock clock;
@@ -126,6 +127,8 @@ public class DiagnosticsHelper {
     @Inject EventBus bus;
     @Inject TargetConnectionManager targetConnectionManager;
     @Inject StorageBuckets buckets;
+
+    final ExecutorService partUploader = Executors.newVirtualThreadPerTaskExecutor();
 
     void onStart(@Observes StartupEvent evt) {
         log.tracev("Creating heap dump bucket: {0}", heapDumpBucket);
@@ -431,8 +434,9 @@ public class DiagnosticsHelper {
                 new Metadata(Map.of()));
     }
 
-    public HeapDump addHeapDump(String jvmId, FileUpload heapDump, String requestId) {
-        String filename = heapDump.fileName().strip();
+    public HeapDump addHeapDump(
+            String jvmId, InputStream heapDumpStream, String filename, String requestId) {
+        filename = filename.strip();
         if (StringUtils.isBlank(filename)) {
             throw new BadRequestException();
         }
@@ -440,6 +444,11 @@ public class DiagnosticsHelper {
             filename = filename + ".hprof";
         }
         log.tracev("Putting Heap dump into storage with key: {0}", storageKey(jvmId, filename));
+
+        AtomicLong bytesUploaded = new AtomicLong(0);
+        ProgressInputStream progressStream =
+                new ProgressInputStream(heapDumpStream, bytesUploaded::addAndGet);
+
         var req =
                 PutObjectRequest.builder()
                         .bucket(heapDumpBucket)
@@ -465,25 +474,28 @@ public class DiagnosticsHelper {
                 throw new IllegalStateException();
         }
 
-        Uni.createFrom()
-                .completionStage(
-                        transferManager
-                                .uploadFile(
-                                        UploadFileRequest.builder()
-                                                .putObjectRequest(req.build())
-                                                .source(heapDump.filePath())
-                                                .build())
-                                .completionFuture())
-                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-                .await()
-                .atMost(uploadFailedTimeout);
+        try {
+            storageAsync
+                    .putObject(
+                            req.build(),
+                            AsyncRequestBody.fromInputStream(progressStream, null, partUploader))
+                    .join();
+        } finally {
+            try {
+                progressStream.close();
+            } catch (IOException ioe) {
+                log.warn("Failed to close progress stream", ioe);
+            }
+        }
+
+        long uploadedSize = bytesUploaded.get();
         var dump =
                 new HeapDump(
                         jvmId,
                         heapDumpDownloadUrl(jvmId, filename),
                         filename,
                         clock.now().getEpochSecond(),
-                        heapDump.filePath().toFile().length(),
+                        uploadedSize,
                         new Metadata(Map.of()));
         var event =
                 new HeapDumpEvent(
@@ -492,12 +504,6 @@ public class DiagnosticsHelper {
                 MessagingServer.class.getName(),
                 new Notification(event.category().category(), event.payload()));
 
-        try {
-            // Clean up temporary files
-            Files.delete(heapDump.filePath());
-        } catch (IOException ioe) {
-            log.warn(ioe);
-        }
         return dump;
     }
 

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -16,9 +16,9 @@
 package io.cryostat.recordings;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,12 +45,15 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -62,7 +65,8 @@ import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.RestResponse.ResponseBuilder;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.jboss.resteasy.reactive.server.multipart.FormValue;
+import org.jboss.resteasy.reactive.server.multipart.MultipartFormDataInput;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -115,9 +119,11 @@ public class ArchivedRecordings {
                     Cryostat version upgrades. This can also be used to upload JFR files which were not collected by
                     Cryostat, so that Cryostat can be used to perform online analysis of the file.
                     """)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Map<String, Object> upload(
-            @Parameter(required = true) @RestForm("recording") FileUpload recording,
-            @Parameter(required = false) @RestForm("labels") JsonObject rawLabels)
+            @RestForm("recording") String recording,
+            @Parameter(required = false) @RestForm("labels") JsonObject rawLabels,
+            MultipartFormDataInput input)
             throws Exception {
         Map<String, String> labels = new HashMap<>();
         if (rawLabels != null) {
@@ -126,7 +132,7 @@ public class ArchivedRecordings {
         labels.put("jvmId", "uploads");
         labels.put("connectUrl", "uploads");
         Metadata metadata = new Metadata(labels);
-        return doUpload(recording, metadata, "uploads");
+        return doUpload(recording, metadata, "uploads", input);
     }
 
     @POST
@@ -140,9 +146,10 @@ public class ArchivedRecordings {
                     Upload a JFR binary file into the archives, associating the archived recording with a particular
                     target JVM. This is primarily used by the Cryostat Agent for pushing harvested recording files.
                     """)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     public void agentPush(
             @Parameter(required = true) @RestPath String jvmId,
-            @Parameter(required = true) @RestForm("recording") FileUpload recording,
+            @RestForm("recording") String recording,
             @Parameter(required = false) @RestForm("labels") JsonObject rawLabels,
             @Parameter(
                             required = false,
@@ -153,7 +160,8 @@ public class ArchivedRecordings {
                                     'last modified' date and only the most recent 'maxFiles' will be retained.
                                     """)
                     @RestForm("maxFiles")
-                    int maxFiles)
+                    int maxFiles,
+            MultipartFormDataInput input)
             throws Exception {
         jvmId = jvmId.strip();
         int max = Integer.MAX_VALUE;
@@ -166,9 +174,8 @@ public class ArchivedRecordings {
         }
         labels.put("jvmId", jvmId);
         Metadata metadata = new Metadata(labels);
-        logger.tracev(
-                "recording:{0}, labels:{1}, maxFiles:{2}", recording.fileName(), labels, maxFiles);
-        doUpload(recording, metadata, jvmId);
+        logger.tracev("labels:{0}, maxFiles:{1}", labels, maxFiles);
+        doUpload(recording, metadata, jvmId, input);
         var objs = new ArrayList<S3Object>(recordingHelper.listArchivedRecordingObjects(jvmId));
         var toRemove =
                 objs.stream()
@@ -249,25 +256,28 @@ public class ArchivedRecordings {
     }
 
     @Blocking
-    Map<String, Object> doUpload(FileUpload recording, Metadata metadata, String jvmId)
+    Map<String, Object> doUpload(
+            String recordingName, Metadata metadata, String jvmId, MultipartFormDataInput input)
             throws IOException {
-        logger.tracev(
-                "Upload: {0} {1} {2} {3}",
-                recording.name(), recording.fileName(), recording.filePath(), metadata.labels());
-        var archivedRecording = recordingHelper.uploadArchivedRecording(jvmId, recording, metadata);
-        logger.trace("Upload complete");
-
-        // Clean up the recording file after uploading
-        try {
-            Files.delete(recording.filePath());
-        } catch (IOException ioe) {
-            logger.warn(ioe);
+        FormValue recordingPart =
+                input.getValues().getOrDefault("recording", List.of()).stream()
+                        .findFirst()
+                        .orElse(null);
+        if (recordingPart == null || !recordingPart.isFileItem()) {
+            throw new BadRequestException();
         }
-        return Map.of(
-                "name",
-                archivedRecording.name(),
-                "metadata",
-                archivedRecording.metadata().labels());
+        String filename = recordingPart.getFileName().strip();
+        logger.tracev("Upload: {0} {1}", filename, metadata.labels());
+        try (InputStream recording = recordingPart.getFileItem().getInputStream()) {
+            var archivedRecording =
+                    recordingHelper.uploadArchivedRecording(jvmId, recording, filename, metadata);
+            logger.trace("Upload complete");
+            return Map.of(
+                    "name",
+                    archivedRecording.name(),
+                    "metadata",
+                    archivedRecording.metadata().labels());
+        }
     }
 
     @DELETE

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -24,7 +24,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -42,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -54,6 +54,7 @@ import org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOptionsBu
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.Producers;
+import io.cryostat.ProgressInputStream;
 import io.cryostat.StorageBuckets;
 import io.cryostat.core.EventOptionsBuilder;
 import io.cryostat.core.FlightRecorderException;
@@ -112,7 +113,6 @@ import org.jboss.resteasy.reactive.PartFilename;
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestQuery;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
@@ -144,7 +144,6 @@ import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 /**
  * Utility class for all things relating to Flight Recording operations. This class is used to
@@ -1313,8 +1312,9 @@ public class RecordingHelper {
     }
 
     public ArchivedRecording uploadArchivedRecording(
-            String jvmId, FileUpload recording, Metadata metadata) throws IOException {
-        String filename = recording.fileName().strip();
+            String jvmId, InputStream recording, String filename, Metadata metadata)
+            throws IOException {
+        filename = filename.strip();
         if (StringUtils.isBlank(filename)) {
             throw new BadRequestException();
         }
@@ -1344,14 +1344,23 @@ public class RecordingHelper {
             default:
                 throw new IllegalStateException();
         }
-        transferManager
-                .uploadFile(
-                        UploadFileRequest.builder()
-                                .putObjectRequest(requestBuilder.build())
-                                .source(recording.filePath())
-                                .build())
-                .completionFuture()
-                .join();
+
+        AtomicLong bytesUploaded = new AtomicLong(0);
+        ProgressInputStream progressStream =
+                new ProgressInputStream(recording, bytesUploaded::addAndGet);
+        try {
+            storageAsync
+                    .putObject(
+                            requestBuilder.build(),
+                            AsyncRequestBody.fromInputStream(progressStream, null, partUploader))
+                    .join();
+        } finally {
+            try {
+                progressStream.close();
+            } catch (IOException ioe) {
+                logger.warn("Failed to close progress stream", ioe);
+            }
+        }
 
         String finalFilename = filename;
         QuarkusTransaction.joiningExisting()
@@ -1365,7 +1374,7 @@ public class RecordingHelper {
                         downloadUrl(jvmId, filename),
                         reportUrl(jvmId, filename),
                         metadata,
-                        recording.size(),
+                        bytesUploaded.get(),
                         clock.now().getEpochSecond());
         var event =
                 new ArchivedRecordingNotification(
@@ -1376,12 +1385,6 @@ public class RecordingHelper {
         bus.publish(
                 MessagingServer.class.getName(),
                 new Notification(event.category().category(), event.payload()));
-        // Clean up the recording file after uploading
-        try {
-            Files.delete(recording.filePath());
-        } catch (IOException ioe) {
-            logger.warn(ioe);
-        }
         return archivedRecording;
     }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
