### PR TITLE
fix(discovery): clean up KubeEndpointSlicesDiscovery in-memory vs database boundaries

### DIFF
--- a/src/main/java/io/cryostat/credentials/Credentials.java
+++ b/src/main/java/io/cryostat/credentials/Credentials.java
@@ -233,6 +233,9 @@ public class Credentials {
     }
 
     @Transactional
+    @Bulkhead
+    @Timeout
+    @RateLimit
     @DELETE
     @RolesAllowed("write")
     @Path("/{id}")

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.credentials.Credential;
+import io.cryostat.discovery.DiscoveryPlugin.PluginCallback;
 import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType;
 import io.cryostat.discovery.NodeType.BaseNodeType;
 import io.cryostat.targets.TargetConnectionManager;
@@ -80,6 +81,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -878,135 +880,131 @@ public class Discovery {
         public void execute(JobExecutionContext context) throws JobExecutionException {
             boolean refresh = context.getMergedJobDataMap().getBoolean(REFRESH_MAP_KEY);
             UUID pluginId = (UUID) context.getMergedJobDataMap().get(PLUGIN_ID_MAP_KEY);
+            if (pluginId == null) {
+                var ex =
+                        new JobExecutionException(
+                                new NullPointerException("pluginId cannot be null"));
+                ex.setUnscheduleFiringTrigger(true);
+                throw ex;
+            }
 
             try {
                 QuarkusTransaction.requiringNew()
                         .run(
                                 () -> {
-                                    try {
-                                        var p = DiscoveryPlugin.<DiscoveryPlugin>findById(pluginId);
+                                    var p = DiscoveryPlugin.<DiscoveryPlugin>findById(pluginId);
 
-                                        if (p == null) {
-                                            throw new NoResultException(
-                                                    "Plugin not found: " + pluginId);
-                                        }
-
-                                        if (p.nextPingAt != null
-                                                && Instant.now().isBefore(p.nextPingAt)) {
-                                            logger.debugv(
-                                                    "Skipping ping due to backoff: {0} @ {1}",
-                                                    p.realm.name, p.callback);
-                                            return;
-                                        }
-
-                                        var cb = callbackFactory.create(p);
-                                        if (refresh) {
-                                            cb.refresh();
-                                            logger.debugv(
-                                                    "Refreshed discovery plugin: {0} @ {1}",
-                                                    p.realm.name, p.callback);
-                                        } else {
-                                            cb.ping();
-                                            logger.debugv(
-                                                    "Retained discovery plugin: {0} @ {1}",
-                                                    p.realm.name, p.callback);
-                                        }
-
-                                        p.consecutiveFailures = 0;
-                                        p.lastSuccessfulPing = Instant.now();
-                                        p.backoffMultiplier = 1;
-                                        p.nextPingAt = null;
-                                        p.persist();
-
-                                        logger.debugv(
-                                                "Plugin ping successful - lastSuccessfulPing: {0},"
-                                                        + " consecutiveFailures reset to 0,"
-                                                        + " backoffMultiplier reset to 1: {1} @"
-                                                        + " {2}",
-                                                p.lastSuccessfulPing, p.realm.name, p.callback);
-                                    } catch (NoResultException e) {
-                                        throw e;
-                                    } catch (Exception e) {
-                                        throw new RuntimeException(e);
+                                    if (p == null) {
+                                        throw new NoResultException(
+                                                "Plugin not found: " + pluginId);
                                     }
+
+                                    if (p.nextPingAt != null
+                                            && Instant.now().isBefore(p.nextPingAt)) {
+                                        logger.debugv(
+                                                "Skipping ping due to backoff: {0} @ {1}",
+                                                p.realm.name, p.callback);
+                                        return;
+                                    }
+
+                                    PluginCallback cb;
+                                    try {
+                                        cb = callbackFactory.create(p);
+                                    } catch (URISyntaxException use) {
+                                        throw new IllegalStateException(use);
+                                    }
+                                    if (refresh) {
+                                        cb.refresh();
+                                        logger.debugv(
+                                                "Refreshed discovery plugin: {0} @ {1}",
+                                                p.realm.name, p.callback);
+                                    } else {
+                                        cb.ping();
+                                        logger.debugv(
+                                                "Retained discovery plugin: {0} @ {1}",
+                                                p.realm.name, p.callback);
+                                    }
+
+                                    p.consecutiveFailures = 0;
+                                    p.lastSuccessfulPing = Instant.now();
+                                    p.backoffMultiplier = 1;
+                                    p.nextPingAt = null;
+                                    p.persist();
+
+                                    logger.debugv(
+                                            "Plugin ping successful - lastSuccessfulPing: {0},"
+                                                    + " consecutiveFailures reset to 0,"
+                                                    + " backoffMultiplier reset to 1: {1} @"
+                                                    + " {2}",
+                                            p.lastSuccessfulPing, p.realm.name, p.callback);
                                 });
-            } catch (NoResultException e) {
-                logger.debugv(
-                        e,
-                        "Unscheduled job for nonexistent discovery plugin: {0}",
-                        context.getMergedJobDataMap().get(PLUGIN_ID_MAP_KEY));
-                var ex = new JobExecutionException(e);
-                ex.setUnscheduleFiringTrigger(true);
-                throw ex;
             } catch (Exception e) {
-                // Unwrap RuntimeException wrappers to get the actual cause
-                Throwable cause = e;
-                while (cause instanceof RuntimeException && cause.getCause() != null) {
-                    cause = cause.getCause();
-                }
+                logger.warnv(e, "Plugin ping failed");
 
-                if (pluginId != null) {
-                    final Throwable finalCause = cause;
-                    QuarkusTransaction.requiringNew()
-                            .run(
-                                    () -> {
-                                        var p = DiscoveryPlugin.<DiscoveryPlugin>findById(pluginId);
-                                        if (p != null) {
-                                            p.consecutiveFailures++;
-                                            p.lastFailedPing = Instant.now();
-                                            p.backoffMultiplier =
-                                                    Math.min(
-                                                            p.backoffMultiplier * 2,
-                                                            maxBackoffMultiplier);
-                                            Duration backoffPeriod =
-                                                    basePingPeriod.multipliedBy(
-                                                            p.backoffMultiplier);
-                                            p.nextPingAt = Instant.now().plus(backoffPeriod);
-                                            p.persist();
-
-                                            logger.debugv(
-                                                    "Plugin ping failed - lastFailedPing: {0},"
-                                                            + " consecutiveFailures: {1}/{2},"
-                                                            + " backoffMultiplier: {3}, nextPingAt:"
-                                                            + " {4}: {5} @ {6}",
-                                                    p.lastFailedPing,
-                                                    p.consecutiveFailures,
-                                                    maxConsecutiveFailures,
-                                                    p.backoffMultiplier,
-                                                    p.nextPingAt,
-                                                    p.realm.name,
-                                                    p.callback);
-
-                                            if (p.consecutiveFailures >= maxConsecutiveFailures) {
-                                                logger.warnv(
-                                                        "Pruning discovery plugin after {0}"
-                                                                + " consecutive failures: {1} @"
-                                                                + " {2}",
-                                                        p.consecutiveFailures,
-                                                        p.realm.name,
-                                                        p.callback);
-                                                p.delete();
-                                            } else {
-                                                logger.warnv(
-                                                        finalCause,
-                                                        "Plugin ping failed ({0}/{1}), backing off"
-                                                                + " for {2}: {3} @ {4}",
-                                                        p.consecutiveFailures,
-                                                        maxConsecutiveFailures,
-                                                        backoffPeriod,
-                                                        p.realm.name,
-                                                        p.callback);
-                                            }
-                                        }
-                                    });
-
-                    var ex = new JobExecutionException(e);
-                    throw ex;
-                } else {
+                boolean noSuchPlugin = ExceptionUtils.indexOfType(e, NoResultException.class) >= 0;
+                boolean unknownHost =
+                        ExceptionUtils.indexOfType(e, UnknownHostException.class) >= 0;
+                boolean illegalState =
+                        ExceptionUtils.indexOfType(e, IllegalStateException.class) >= 0;
+                if (noSuchPlugin || unknownHost || illegalState) {
+                    logger.warnv(
+                            "Unscheduled job for unknown discovery plugin: {0}",
+                            context.getMergedJobDataMap().get(PLUGIN_ID_MAP_KEY));
                     var ex = new JobExecutionException(e);
                     ex.setUnscheduleFiringTrigger(true);
                     throw ex;
                 }
+
+                QuarkusTransaction.joiningExisting()
+                        .run(
+                                () -> {
+                                    var p = DiscoveryPlugin.<DiscoveryPlugin>findById(pluginId);
+                                    if (p != null) {
+                                        p.consecutiveFailures++;
+                                        p.lastFailedPing = Instant.now();
+                                        p.backoffMultiplier =
+                                                Math.min(
+                                                        p.backoffMultiplier * 2,
+                                                        maxBackoffMultiplier);
+                                        Duration backoffPeriod =
+                                                basePingPeriod.multipliedBy(p.backoffMultiplier);
+                                        p.nextPingAt = Instant.now().plus(backoffPeriod);
+                                        p.persist();
+
+                                        logger.debugv(
+                                                "Plugin ping failed - lastFailedPing: {0},"
+                                                        + " consecutiveFailures: {1}/{2},"
+                                                        + " backoffMultiplier: {3}, nextPingAt:"
+                                                        + " {4}: {5} @ {6}",
+                                                p.lastFailedPing,
+                                                p.consecutiveFailures,
+                                                maxConsecutiveFailures,
+                                                p.backoffMultiplier,
+                                                p.nextPingAt,
+                                                p.realm.name,
+                                                p.callback);
+
+                                        if (p.consecutiveFailures >= maxConsecutiveFailures) {
+                                            logger.warnv(
+                                                    "Pruning discovery plugin after {0}"
+                                                            + " consecutive failures: {1} @"
+                                                            + " {2}",
+                                                    p.consecutiveFailures,
+                                                    p.realm.name,
+                                                    p.callback);
+                                            p.delete();
+                                        } else {
+                                            logger.warnv(
+                                                    "Plugin ping failed ({0}/{1}), backing off"
+                                                            + " for {2}: {3} @ {4}",
+                                                    p.consecutiveFailures,
+                                                    maxConsecutiveFailures,
+                                                    backoffPeriod,
+                                                    p.realm.name,
+                                                    p.callback);
+                                        }
+                                    }
+                                });
             }
         }
     }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1435,12 +1435,22 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             DiscoveryNode nsNode, TargetDTO targetDto, DiscoveryNodeDTO hierarchyRoot) {
         logger.debugv("Persisting owner chain from DTO for target: {0}", targetDto.connectUrl());
 
+        URI connectUrl = URI.create(targetDto.connectUrl());
+        Target existingTarget = Target.getTargetByConnectUrl(connectUrl);
+
+        if (existingTarget != null) {
+            logger.debugv(
+                    "Target already exists for connectUrl: {0} (id: {1}), skipping persistence",
+                    connectUrl, existingTarget.id);
+            return;
+        }
+
         // Convert the DTO tree to entities
         DiscoveryNode leafNode = convertDtoTreeToEntities(hierarchyRoot, nsNode);
 
         // Create the Target entity from DTO
         Target target = new Target();
-        target.connectUrl = URI.create(targetDto.connectUrl());
+        target.connectUrl = connectUrl;
         target.alias = targetDto.alias();
         target.labels = new HashMap<>(targetDto.labels());
         target.annotations = targetDto.annotations();

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -543,9 +543,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         HasMetadata obj =
                 nodeCache.computeIfAbsent(
                         cacheKey,
-                        k ->
-                                queryForNode(ref.getNamespace(), ref.getName(), ref.getKind())
-                                        .getLeft());
+                        k -> {
+                            KubeDiscoveryNodeType nodeType =
+                                    KubeDiscoveryNodeType.fromKubernetesKind(ref.getKind());
+                            if (nodeType == null) {
+                                return null;
+                            }
+                            return nodeType.getQueryFunction()
+                                    .apply(client)
+                                    .apply(ref.getNamespace())
+                                    .apply(ref.getName());
+                        });
 
         return new TargetTuple(ref, obj, transformedAddr, port, endpoint.getConditions());
     }
@@ -1150,45 +1158,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, namespace);
         node.labels.putAll(labels);
 
-        return Pair.of(kubeObj, node);
-    }
-
-    /**
-     * Queries Kubernetes API for a node and retrieves or creates a DiscoveryNode from the database.
-     * This method DOES access the database.
-     *
-     * @param namespace Kubernetes namespace
-     * @param name Resource name
-     * @param kind Resource kind
-     * @return Pair of Kubernetes object and DiscoveryNode from database, or null if not found
-     */
-    private Pair<HasMetadata, DiscoveryNode> queryForNode(
-            String namespace, String name, String kind) {
-
-        KubeDiscoveryNodeType nodeType = KubeDiscoveryNodeType.fromKubernetesKind(kind);
-        if (nodeType == null) {
-            return null;
-        }
-
-        HasMetadata kubeObj =
-                nodeType.getQueryFunction().apply(client).apply(namespace).apply(name);
-
-        DiscoveryNode node =
-                DiscoveryNode.byTypeWithName(
-                        nodeType,
-                        name,
-                        n ->
-                                namespace.equals(n.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY))
-                                        && isInKubernetesApiRealm(n),
-                        n -> {
-                            Map<String, String> labels = new HashMap<>();
-                            if (kubeObj != null && kubeObj.getMetadata().getLabels() != null) {
-                                labels.putAll(kubeObj.getMetadata().getLabels());
-                            }
-                            // Add namespace to label to retrieve node later
-                            labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, namespace);
-                            n.labels.putAll(labels);
-                        });
         return Pair.of(kubeObj, node);
     }
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -614,7 +614,12 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                             Objects.equals(
                                                     ep.getMetadata().getNamespace(), namespace));
         } else {
-            endpoints = safeGetInformers().get(namespace).getStore().list().stream();
+            var informer = safeGetInformers().get(namespace);
+            if (informer == null) {
+                logger.warnv("No informer found for namespace: {0}", namespace);
+                return result;
+            }
+            endpoints = informer.getStore().list().stream();
         }
 
         endpoints

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1076,7 +1076,12 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         logger.debugv("Persisting namespace node: {0} (id: {1})", nsNode.name, nsNode.id);
         nsNode.persist();
 
-        // Persist the Target last (after all nodes are persisted)
+        // Flush to ensure all DiscoveryNode changes are written to DB
+        // This prevents other transactions from seeing stale/incomplete entities
+        entityManager.flush();
+        logger.debugv("Flushed DiscoveryNode changes to database");
+
+        // Persist the Target last (after all nodes are persisted and flushed)
         logger.debugv("Persisting target: {0}", target.connectUrl);
         target.persist();
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1293,7 +1293,37 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         logger.debugv("Converting DTO tree to entities, root: {0}", rootDto.name());
 
         // Walk the tree depth-first, converting DTOs to entities
-        DiscoveryNode rootEntity = convertDtoNodeToEntity(rootDto, nsNode, true);
+        DiscoveryNode rootEntity = convertDtoNodeToEntity(rootDto, nsNode, false);
+
+        // Find the topmost node in the chain (the one without a parent)
+        DiscoveryNode topmost = rootEntity;
+        while (topmost.parent != null && !topmost.parent.equals(nsNode)) {
+            topmost = topmost.parent;
+        }
+
+        // Ensure the topmost node is linked to the namespace
+        if (topmost.parent == null || !topmost.parent.equals(nsNode)) {
+            topmost.parent = nsNode;
+            logger.debugv(
+                    "Set parent of topmost node {0} to namespace {1}", topmost.name, nsNode.name);
+        }
+
+        // Add to namespace children if not already present
+        final Long topmostId = topmost.id;
+        final DiscoveryNode topmostNode = topmost;
+        boolean alreadyChild =
+                nsNode.children.stream()
+                        .anyMatch(
+                                child ->
+                                        child == topmostNode
+                                                || (child.id != null
+                                                        && topmostId != null
+                                                        && child.id.equals(topmostId)));
+        if (!alreadyChild) {
+            nsNode.children.add(topmost);
+            logger.debugv(
+                    "Added topmost node {0} to namespace {1} children", topmost.name, nsNode.name);
+        }
 
         // Find and return the leaf node (EndpointSlice wrapper)
         DiscoveryNode leafNode = rootEntity;
@@ -1316,20 +1346,22 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
      */
     private DiscoveryNode convertDtoNodeToEntity(
             DiscoveryNodeDTO dto, DiscoveryNode nsNode, boolean isRoot) {
-        DiscoveryNode entity;
+        final DiscoveryNode entity;
 
         if (dto.existsInDb()) {
             // Load existing entity from database using Panache
             logger.debugv(
                     "Loading existing node from DB: {0} (id: {1})", dto.name(), dto.existingId());
-            entity = DiscoveryNode.findById(dto.existingId());
+            DiscoveryNode loaded = DiscoveryNode.findById(dto.existingId());
 
-            if (entity == null) {
+            if (loaded == null) {
                 logger.warnv(
                         "Node marked as existing but not found in DB: {0} (id: {1}), creating new"
                                 + " node",
                         dto.name(), dto.existingId());
                 entity = createNewNodeEntity(dto);
+            } else {
+                entity = loaded;
             }
         } else {
             // Create new entity
@@ -1354,15 +1386,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             if (!childExists) {
                 entity.children.add(childEntity);
             }
-        }
-
-        // If this is the root node and it's new, link it to the namespace
-        if (isRoot && !dto.existsInDb()) {
-            entity.parent = nsNode;
-            if (!nsNode.children.contains(entity)) {
-                nsNode.children.add(entity);
-            }
-            logger.debugv("Linked root node {0} to namespace {1}", entity.name, nsNode.name);
         }
 
         return entity;

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1343,7 +1343,20 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
             // Build bidirectional relationship
             childEntity.parent = entity;
-            if (!entity.children.contains(childEntity)) {
+
+            boolean childExists =
+                    entity.children.stream()
+                            .anyMatch(
+                                    existing ->
+                                            existing.name.equals(childEntity.name)
+                                                    && existing.nodeType.equals(
+                                                            childEntity.nodeType)
+                                                    && Objects.equals(
+                                                            existing.labels.get(
+                                                                    DISCOVERY_NAMESPACE_LABEL_KEY),
+                                                            childEntity.labels.get(
+                                                                    DISCOVERY_NAMESPACE_LABEL_KEY)));
+            if (!childExists) {
                 entity.children.add(childEntity);
             }
         }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -53,6 +52,7 @@ import io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.quarkus.panache.common.Parameters;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.vertx.ConsumeEvent;
@@ -103,6 +103,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     public static final String REALM = "KubernetesApi";
 
     public static final String DISCOVERY_NAMESPACE_LABEL_KEY = "discovery.cryostat.io/namespace";
+
+    // SQL query to find orphaned nodes - nodes with no children and no associated Target
+    // Uses native SQL to access JSONB map keys/values which HQL doesn't support well
+    private static final String FIND_ORPHANED_NODES_SQL =
+            "SELECT n.* FROM DiscoveryNode n "
+                    + "WHERE n.labels->:namespaceKey = to_jsonb(CAST(:namespace AS text)) "
+                    + "AND (SELECT COUNT(*) FROM DiscoveryNode c WHERE c.parentNode = n.id) = 0 "
+                    + "AND n.nodeType != :namespaceType "
+                    + "AND NOT EXISTS ("
+                    + "  SELECT 1 FROM Target t WHERE t.discoveryNode = n.id"
+                    + ")";
 
     private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
 
@@ -715,7 +726,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         return current.getRight();
     }
 
-    private void pruneOwnerChain(DiscoveryNode nsNode, Target target) {
+    void pruneOwnerChain(DiscoveryNode nsNode, Target target) {
         logger.debugv("Pruning owner chain for target: {0}", target.connectUrl);
         try {
             Target managedTarget = Target.getTargetByConnectUrl(target.connectUrl);
@@ -796,6 +807,35 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             }
 
             entityManager.flush();
+
+            String namespace = nsNode.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY);
+            if (namespace != null) {
+                logger.debugv("Cleaning up orphaned nodes in namespace: {0}", namespace);
+                List<DiscoveryNode> orphans = findOrphanedNodesInNamespace(namespace);
+
+                for (DiscoveryNode orphan : orphans) {
+                    logger.debugv(
+                            "Removing orphaned node: {0} (id: {1}, type: {2})",
+                            orphan.name, orphan.id, orphan.nodeType);
+
+                    DiscoveryNode orphanParent = orphan.parent;
+                    if (orphanParent != null) {
+                        entityManager.refresh(orphanParent);
+                        orphanParent.children.remove(orphan);
+                        orphan.parent = null;
+                    }
+
+                    orphan.delete();
+                }
+
+                if (!orphans.isEmpty()) {
+                    logger.debugv(
+                            "Removed {0} orphaned nodes from namespace {1}",
+                            orphans.size(), namespace);
+                    entityManager.flush();
+                }
+            }
+
             nsNode.persist();
 
         } catch (EntityNotFoundException e) {
@@ -842,13 +882,38 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
 
         Pair<HasMetadata, DiscoveryNode> pod =
-                queryForNode(targetRef.getNamespace(), targetRef.getName(), targetRef.getKind());
+                queryForNodeReadOnly(
+                        targetRef.getNamespace(), targetRef.getName(), targetRef.getKind());
 
+        if (pod == null || pod.getLeft() == null) {
+            logger.warnv(
+                    "Pod not found for target: {0}/{1}",
+                    targetRef.getNamespace(), targetRef.getName());
+            nsNode.children.add(targetNode);
+            targetNode.parent = nsNode;
+            return targetNode;
+        }
+
+        HasMetadata podObj = pod.getLeft();
         DiscoveryNode podNode = pod.getRight();
+
+        if (podNode == null) {
+            Map<String, String> labels = new HashMap<>();
+            if (podObj.getMetadata().getLabels() != null) {
+                labels.putAll(podObj.getMetadata().getLabels());
+            }
+            podNode =
+                    findOrCreateNodeInMemory(
+                            targetRef.getNamespace(),
+                            targetRef.getName(),
+                            targetRef.getKind(),
+                            labels);
+        }
+
         podNode.children.add(targetNode);
         targetNode.parent = podNode;
 
-        DiscoveryNode rootNode = buildOwnershipHierarchyWithDbLookup(pod.getLeft(), podNode);
+        DiscoveryNode rootNode = buildOwnershipHierarchyWithDbLookup(podObj, podNode);
 
         nsNode.children.add(rootNode);
         rootNode.parent = nsNode;
@@ -909,45 +974,84 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                         .filter(o -> KubeDiscoveryNodeType.fromKubernetesKind(o.getKind()) != null)
                         .findFirst()
                         .orElse(owners.get(0));
-        return queryForNode(namespace, owner.getName(), owner.getKind());
+
+        Pair<HasMetadata, DiscoveryNode> ownerPair =
+                queryForNodeReadOnly(namespace, owner.getName(), owner.getKind());
+
+        if (ownerPair == null || ownerPair.getLeft() == null) {
+            return null;
+        }
+
+        HasMetadata ownerObj = ownerPair.getLeft();
+        DiscoveryNode ownerNode = ownerPair.getRight();
+
+        if (ownerNode == null) {
+            Map<String, String> labels = new HashMap<>();
+            if (ownerObj.getMetadata().getLabels() != null) {
+                labels.putAll(ownerObj.getMetadata().getLabels());
+            }
+            ownerNode =
+                    findOrCreateNodeInMemory(namespace, owner.getName(), owner.getKind(), labels);
+        }
+
+        return Pair.of(ownerObj, ownerNode);
     }
 
-    private void persistNodeChain(DiscoveryNode nsNode, Target target, DiscoveryNode targetNode) {
+    void persistNodeChain(DiscoveryNode nsNode, Target target, DiscoveryNode targetNode) {
+        logger.debugv("Persisting node chain for target: {0}", target.connectUrl);
+
         List<DiscoveryNode> nodeChain = collectNodeChain(targetNode, nsNode);
 
         target.persist();
 
         for (int i = nodeChain.size() - 1; i >= 0; i--) {
-            nodeChain.get(i).persist();
-        }
+            DiscoveryNode node = nodeChain.get(i);
 
-        // Use Stack-based iterative approach to persist all nodes at once
-        // This ensures we persist from leaf to root
-        Stack<DiscoveryNode> stack = new Stack<>();
-        Set<DiscoveryNode> visited = new HashSet<>();
-
-        // Start from the target node and traverse up to collect all nodes
-        DiscoveryNode current = targetNode;
-        while (current != null && current != nsNode) {
-            if (!visited.contains(current)) {
-                stack.push(current);
-                visited.add(current);
+            if (node.id != null) {
+                logger.debugv("Node already persisted: {0} (id: {1})", node.name, node.id);
+                continue;
             }
-            current = current.parent;
+
+            DiscoveryNode existingNode =
+                    DiscoveryNode.<DiscoveryNode>find(
+                                    "#DiscoveryNode.byTypeWithName",
+                                    Parameters.with("nodeType", node.nodeType)
+                                            .and("name", node.name))
+                            .stream()
+                            .filter(
+                                    n ->
+                                            node.labels
+                                                            .get(DISCOVERY_NAMESPACE_LABEL_KEY)
+                                                            .equals(
+                                                                    n.labels.get(
+                                                                            DISCOVERY_NAMESPACE_LABEL_KEY))
+                                                    && isInKubernetesApiRealm(n))
+                            .findFirst()
+                            .orElse(null);
+
+            if (existingNode != null) {
+                logger.debugv(
+                        "Reusing existing node from DB: {0} (id: {1})",
+                        existingNode.name, existingNode.id);
+
+                if (node.parent != null) {
+                    if (!existingNode.children.contains(node)) {
+                        existingNode.children.add(node);
+                    }
+                    node.parent = existingNode;
+                }
+
+                nodeChain.set(i, existingNode);
+            } else {
+                logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
+                node.persist();
+            }
         }
 
-        // Persist target first (it has the associated Target entity)
-        target.persist();
-
-        // Persist all nodes in the chain from top to bottom
-        while (!stack.isEmpty()) {
-            DiscoveryNode node = stack.pop();
-            node.persist();
-        }
-
-        // Finally persist the namespace node
         entityManager.flush();
         nsNode.persist();
+
+        logger.debugv("Node chain persistence complete for target: {0}", target.connectUrl);
     }
 
     private List<DiscoveryNode> collectNodeChain(DiscoveryNode startNode, DiscoveryNode endNode) {
@@ -960,6 +1064,27 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
 
         return chain;
+    }
+
+    /**
+     * Finds orphaned nodes in a namespace that have no children and no associated Target. These are
+     * intermediate nodes (like Pods, Deployments, etc.) that were created during hierarchy building
+     * but are no longer needed.
+     *
+     * @param namespace The namespace to search for orphaned nodes
+     * @return List of orphaned DiscoveryNodes
+     */
+    List<DiscoveryNode> findOrphanedNodesInNamespace(String namespace) {
+        List<DiscoveryNode> orphans =
+                entityManager
+                        .createNativeQuery(FIND_ORPHANED_NODES_SQL, DiscoveryNode.class)
+                        .setParameter("namespaceKey", DISCOVERY_NAMESPACE_LABEL_KEY)
+                        .setParameter("namespace", namespace)
+                        .setParameter("namespaceType", KubeDiscoveryNodeType.NAMESPACE.getKind())
+                        .getResultList();
+
+        logger.debugv("Found {0} orphaned nodes in namespace {1}", orphans.size(), namespace);
+        return orphans;
     }
 
     /**
@@ -1065,6 +1190,107 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
+     * Queries Kubernetes API for a node and retrieves existing DiscoveryNode from the database.
+     * This is a pure query method that NEVER persists nodes.
+     *
+     * @param namespace Kubernetes namespace
+     * @param name Resource name
+     * @param kind Resource kind
+     * @return Pair of Kubernetes object and existing DiscoveryNode from database, or null if K8s
+     *     object not found
+     */
+    Pair<HasMetadata, DiscoveryNode> queryForNodeReadOnly(
+            String namespace, String name, String kind) {
+
+        KubeDiscoveryNodeType nodeType = KubeDiscoveryNodeType.fromKubernetesKind(kind);
+        if (nodeType == null) {
+            logger.debugv("Unknown Kubernetes kind: {0}", kind);
+            return null;
+        }
+
+        HasMetadata kubeObj =
+                nodeType.getQueryFunction().apply(client).apply(namespace).apply(name);
+
+        if (kubeObj == null) {
+            logger.debugv(
+                    "Kubernetes object not found: {0}/{1} (kind: {2})", namespace, name, kind);
+            return null;
+        }
+
+        DiscoveryNode existingNode =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "#DiscoveryNode.byTypeWithName",
+                                Parameters.with("nodeType", nodeType.getKind()).and("name", name))
+                        .stream()
+                        .filter(
+                                n ->
+                                        namespace.equals(
+                                                        n.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY))
+                                                && isInKubernetesApiRealm(n))
+                        .findFirst()
+                        .orElse(null);
+
+        logger.debugv(
+                "Query read-only for {0}/{1} (kind: {2}): found in DB = {3}",
+                namespace, name, kind, existingNode != null);
+
+        return Pair.of(kubeObj, existingNode);
+    }
+
+    /**
+     * Finds an existing node in the database or creates an in-memory node (NOT persisted). This
+     * method is used during hierarchy building to avoid premature persistence.
+     *
+     * @param namespace Kubernetes namespace
+     * @param name Resource name
+     * @param kind Resource kind
+     * @param labels Labels to apply to the node
+     * @return Existing DiscoveryNode from DB or new in-memory node
+     */
+    DiscoveryNode findOrCreateNodeInMemory(
+            String namespace, String name, String kind, Map<String, String> labels) {
+
+        KubeDiscoveryNodeType nodeType = KubeDiscoveryNodeType.fromKubernetesKind(kind);
+        if (nodeType == null) {
+            logger.warnv("Cannot create node for unknown Kubernetes kind: {0}", kind);
+            return null;
+        }
+
+        DiscoveryNode existingNode =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "#DiscoveryNode.byTypeWithName",
+                                Parameters.with("nodeType", nodeType.getKind()).and("name", name))
+                        .stream()
+                        .filter(
+                                n ->
+                                        namespace.equals(
+                                                        n.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY))
+                                                && isInKubernetesApiRealm(n))
+                        .findFirst()
+                        .orElse(null);
+
+        if (existingNode != null) {
+            logger.debugv(
+                    "Found existing node in DB: {0}/{1} (kind: {2}, id: {3})",
+                    namespace, name, kind, existingNode.id);
+            return existingNode;
+        }
+
+        DiscoveryNode newNode = new DiscoveryNode();
+        newNode.name = name;
+        newNode.nodeType = nodeType.getKind();
+        newNode.labels = new HashMap<>(labels);
+        newNode.labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, namespace);
+        newNode.children = new ArrayList<>();
+
+        logger.debugv(
+                "Created in-memory node (NOT persisted): {0}/{1} (kind: {2})",
+                namespace, name, kind);
+
+        return newNode;
+    }
+
+    /**
      * Check if a node belongs to the KubernetesApi Realm by walking up its parent chain.
      *
      * @param node The node to check
@@ -1150,7 +1376,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
     }
 
-    private static record NamespaceQueryEvent(Collection<String> namespaces) {
+    static record NamespaceQueryEvent(Collection<String> namespaces) {
         static NamespaceQueryEvent from(Collection<String> namespaces) {
             return new NamespaceQueryEvent(namespaces);
         }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -701,15 +701,11 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         Map<String, String> labels = new HashMap<>();
         labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, tuple.objRef.getNamespace());
 
-        // Create a unique name for this endpoint by including address and port
-        // This ensures each endpoint in an EndpointSlice gets its own DiscoveryNode
-        String uniqueName =
-                String.format(
-                        "%s-%s-%d",
-                        tuple.objRef.getName(), tuple.addr.replace(".", "-"), tuple.port.getPort());
+        Target target = tuple.toTarget();
+        String nodeName = target.connectUrl.toString();
 
         return new DiscoveryNodeDTO(
-                uniqueName,
+                nodeName,
                 KubeDiscoveryNodeType.ENDPOINT_SLICE.getKind(),
                 labels,
                 new ArrayList<>(),

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -413,7 +413,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                             DiscoveryNodeDTO hierarchy =
                                     observedTargetsWithHierarchy.get(targetDto);
                             logger.debugv(
-                                    "Publishing FOUND event for target: {0} (DTO flow)",
+                                    "Publishing FOUND event for target: {0}",
                                     targetDto.connectUrl());
                             notify(
                                     EndpointDiscoveryEvent.from(

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1436,14 +1436,18 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         logger.debugv("Persisting owner chain from DTO for target: {0}", targetDto.connectUrl());
 
         URI connectUrl = URI.create(targetDto.connectUrl());
-        Target existingTarget = Target.getTargetByConnectUrl(connectUrl);
 
-        if (existingTarget != null) {
+        Optional<Target> existingTarget =
+                Target.<Target>find("connectUrl", connectUrl).singleResultOptional();
+
+        if (existingTarget.isPresent()) {
             logger.debugv(
                     "Target already exists for connectUrl: {0} (id: {1}), skipping persistence",
-                    connectUrl, existingTarget.id);
+                    connectUrl, existingTarget.get().id);
             return;
         }
+
+        logger.debugv("No existing target found for connectUrl: {0}, creating new", connectUrl);
 
         // Convert the DTO tree to entities
         DiscoveryNode leafNode = convertDtoTreeToEntities(hierarchyRoot, nsNode);

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1004,6 +1004,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
         target.persist();
 
+        // Persist nodes from parent to child (top to bottom)
         for (int i = nodeChain.size() - 1; i >= 0; i--) {
             DiscoveryNode node = nodeChain.get(i);
 
@@ -1034,16 +1035,29 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                         "Reusing existing node from DB: {0} (id: {1})",
                         existingNode.name, existingNode.id);
 
-                if (node.parent != null) {
-                    if (!existingNode.children.contains(node)) {
-                        existingNode.children.add(node);
-                    }
-                    node.parent = existingNode;
-                }
-
+                // Update the chain to use the existing node
                 nodeChain.set(i, existingNode);
+
+                // Update child's parent reference to point to the existing node
+                if (i > 0) {
+                    DiscoveryNode child = nodeChain.get(i - 1);
+                    child.parent = existingNode;
+                    if (!existingNode.children.contains(child)) {
+                        existingNode.children.add(child);
+                    }
+                }
             } else {
                 logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
+
+                // Ensure parent reference is set before persisting
+                if (i < nodeChain.size() - 1) {
+                    DiscoveryNode parent = nodeChain.get(i + 1);
+                    node.parent = parent;
+                    if (!parent.children.contains(node)) {
+                        parent.children.add(node);
+                    }
+                }
+
                 node.persist();
             }
         }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1059,16 +1059,22 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         for (int i = nodeChain.size() - 1; i >= 0; i--) {
             DiscoveryNode node = nodeChain.get(i);
 
-            // Skip nodes that are already persisted (loaded from DB)
             if (node.id != null) {
-                logger.debugv("Node already persisted: {0} (id: {1})", node.name, node.id);
-                continue;
+                // Node already exists in DB - persist any relationship changes
+                logger.debugv(
+                        "Node already persisted, persisting updates: {0} (id: {1})",
+                        node.name, node.id);
+                node.persist();
+            } else {
+                // Persist new nodes
+                logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
+                node.persist();
             }
-
-            // Persist new nodes
-            logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
-            node.persist();
         }
+
+        // Persist namespace node to save any relationship changes
+        logger.debugv("Persisting namespace node: {0} (id: {1})", nsNode.name, nsNode.id);
+        nsNode.persist();
 
         // Persist the Target last (after all nodes are persisted)
         logger.debugv("Persisting target: {0}", target.connectUrl);

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -691,7 +691,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Creates an in-memory DiscoveryNodeDTO for a target without database access.
+     * Creates an in-memory DiscoveryNodeDTO for a target without database access. The node name
+     * includes the address and port to ensure uniqueness per endpoint.
      *
      * @param tuple The TargetTuple containing target information
      * @return DiscoveryNodeDTO representing the target
@@ -700,8 +701,15 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         Map<String, String> labels = new HashMap<>();
         labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, tuple.objRef.getNamespace());
 
+        // Create a unique name for this endpoint by including address and port
+        // This ensures each endpoint in an EndpointSlice gets its own DiscoveryNode
+        String uniqueName =
+                String.format(
+                        "%s-%s-%d",
+                        tuple.objRef.getName(), tuple.addr.replace(".", "-"), tuple.port.getPort());
+
         return new DiscoveryNodeDTO(
-                tuple.objRef.getName(),
+                uniqueName,
                 KubeDiscoveryNodeType.ENDPOINT_SLICE.getKind(),
                 labels,
                 new ArrayList<>(),

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -416,6 +416,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                             DiscoveryNode.environment(
                                                     namespace, KubeDiscoveryNodeType.NAMESPACE);
                                     created.parent = lockedRealm;
+                                    created.persist();
                                     return created;
                                 });
 
@@ -921,80 +922,79 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         return rootNode;
     }
 
-    /**
-     * Builds the ownership hierarchy using database lookups to reuse existing nodes.
-     *
-     * @param kubeObj The Kubernetes object to start from
-     * @param node The DiscoveryNode representing the Kubernetes object
-     * @return The root node of the ownership chain (the topmost owner)
-     */
     private DiscoveryNode buildOwnershipHierarchyWithDbLookup(
             HasMetadata kubeObj, DiscoveryNode node) {
-        Pair<HasMetadata, DiscoveryNode> current = Pair.of(kubeObj, node);
+        // Build a list of node descriptors from child to parent
+        List<NodeDescriptor> hierarchy = new ArrayList<>();
+        HasMetadata current = kubeObj;
 
-        while (true) {
-            Pair<HasMetadata, DiscoveryNode> owner = getOwnerNodeWithDbLookup(current);
-            if (owner == null) {
+        while (current != null) {
+            List<OwnerReference> owners = current.getMetadata().getOwnerReferences();
+            if (owners.isEmpty()) {
                 break;
             }
 
-            DiscoveryNode ownerNode = owner.getRight();
-            DiscoveryNode childNode = current.getRight();
+            String namespace = current.getMetadata().getNamespace();
+            OwnerReference owner =
+                    owners.stream()
+                            .filter(
+                                    o ->
+                                            KubeDiscoveryNodeType.fromKubernetesKind(o.getKind())
+                                                    != null)
+                            .findFirst()
+                            .orElse(owners.get(0));
 
-            if (!ownerNode.children.contains(childNode)) {
-                ownerNode.children.add(childNode);
+            Pair<HasMetadata, DiscoveryNode> ownerPair =
+                    queryForNodeReadOnly(namespace, owner.getName(), owner.getKind());
+
+            if (ownerPair == null || ownerPair.getLeft() == null) {
+                break;
             }
-            childNode.parent = ownerNode;
 
-            current = owner;
-        }
+            HasMetadata ownerObj = ownerPair.getLeft();
+            DiscoveryNode existingNode = ownerPair.getRight();
 
-        return current.getRight();
-    }
-
-    /**
-     * Gets the owner node using database lookup to reuse existing nodes.
-     *
-     * @param child Pair of Kubernetes object and its DiscoveryNode
-     * @return Pair of owner Kubernetes object and its DiscoveryNode from DB, or null if no owner
-     */
-    private Pair<HasMetadata, DiscoveryNode> getOwnerNodeWithDbLookup(
-            Pair<HasMetadata, DiscoveryNode> child) {
-        HasMetadata childRef = child.getLeft();
-        if (childRef == null) {
-            return null;
-        }
-        List<OwnerReference> owners = childRef.getMetadata().getOwnerReferences();
-        if (owners.isEmpty()) {
-            return null;
-        }
-        String namespace = childRef.getMetadata().getNamespace();
-        OwnerReference owner =
-                owners.stream()
-                        .filter(o -> KubeDiscoveryNodeType.fromKubernetesKind(o.getKind()) != null)
-                        .findFirst()
-                        .orElse(owners.get(0));
-
-        Pair<HasMetadata, DiscoveryNode> ownerPair =
-                queryForNodeReadOnly(namespace, owner.getName(), owner.getKind());
-
-        if (ownerPair == null || ownerPair.getLeft() == null) {
-            return null;
-        }
-
-        HasMetadata ownerObj = ownerPair.getLeft();
-        DiscoveryNode ownerNode = ownerPair.getRight();
-
-        if (ownerNode == null) {
             Map<String, String> labels = new HashMap<>();
             if (ownerObj.getMetadata().getLabels() != null) {
                 labels.putAll(ownerObj.getMetadata().getLabels());
             }
-            ownerNode =
-                    findOrCreateNodeInMemory(namespace, owner.getName(), owner.getKind(), labels);
+
+            Long id = null;
+            if (existingNode != null) {
+                id = existingNode.id;
+            }
+            NodeDescriptor descriptor =
+                    new NodeDescriptor(namespace, owner.getName(), owner.getKind(), labels, id);
+            hierarchy.add(descriptor);
+
+            current = ownerObj;
         }
 
-        return Pair.of(ownerObj, ownerNode);
+        // Now create/link nodes from parent to child, only creating entities when needed
+        DiscoveryNode parentNode = node;
+        for (NodeDescriptor descriptor : hierarchy) {
+            DiscoveryNode ownerNode;
+            if (descriptor.existingId != null) {
+                // Node exists in DB, fetch it
+                ownerNode = DiscoveryNode.findById(descriptor.existingId);
+            } else {
+                // Create new node entity only now, when we know it's part of a valid chain
+                ownerNode =
+                        findOrCreateNodeInMemory(
+                                descriptor.namespace,
+                                descriptor.name,
+                                descriptor.kind,
+                                descriptor.labels);
+            }
+
+            if (!ownerNode.children.contains(parentNode)) {
+                ownerNode.children.add(parentNode);
+            }
+            parentNode.parent = ownerNode;
+            parentNode = ownerNode;
+        }
+
+        return parentNode;
     }
 
     void persistNodeChain(DiscoveryNode nsNode, Target target, DiscoveryNode targetNode) {
@@ -1012,6 +1012,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 continue;
             }
 
+            final String nodeNamespace = node.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY);
             DiscoveryNode existingNode =
                     DiscoveryNode.<DiscoveryNode>find(
                                     "#DiscoveryNode.byTypeWithName",
@@ -1020,11 +1021,9 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                             .stream()
                             .filter(
                                     n ->
-                                            node.labels
-                                                            .get(DISCOVERY_NAMESPACE_LABEL_KEY)
-                                                            .equals(
-                                                                    n.labels.get(
-                                                                            DISCOVERY_NAMESPACE_LABEL_KEY))
+                                            nodeNamespace.equals(
+                                                            n.labels.get(
+                                                                    DISCOVERY_NAMESPACE_LABEL_KEY))
                                                     && isInKubernetesApiRealm(n))
                             .findFirst()
                             .orElse(null);
@@ -1073,11 +1072,9 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 }
 
                 node.persist();
+                nodeChain.set(i, node);
             }
         }
-
-        entityManager.flush();
-        nsNode.persist();
 
         // Now that all nodes are persisted, persist the Target
         // The targetNode should now have an ID from the database
@@ -1340,6 +1337,21 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
         return false;
     }
+
+    /**
+     * Builds the ownership hierarchy using database lookups to reuse existing nodes.
+     *
+     * @param kubeObj The Kubernetes object to start from
+     * @param node The DiscoveryNode representing the Kubernetes object
+     * @return The root node of the ownership chain (the topmost owner)
+     */
+    /** Represents a node in the ownership hierarchy that hasn't been persisted yet. */
+    record NodeDescriptor(
+            String namespace,
+            String name,
+            String kind,
+            Map<String, String> labels,
+            Long existingId) {}
 
     @DisallowConcurrentExecution
     static class EndpointsResyncJob implements Job {

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -433,7 +433,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             realm.children.add(nsNode);
             nsNode.parent = realm;
         }
-        entityManager.flush();
         realm.persist();
     }
 
@@ -760,7 +759,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             // Delete the target first - this will cascade delete its discoveryNode (the
             // Endpoint/EndpointSlice)
             managedTarget.delete();
-            entityManager.flush();
 
             // If there's no parent, we're done
             if (child == null) {
@@ -807,8 +805,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 child = parent;
             }
 
-            entityManager.flush();
-
             String namespace = nsNode.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY);
             if (namespace != null) {
                 logger.debugv("Cleaning up orphaned nodes in namespace: {0}", namespace);
@@ -833,7 +829,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     logger.debugv(
                             "Removed {0} orphaned nodes from namespace {1}",
                             orphans.size(), namespace);
-                    entityManager.flush();
                 }
             }
 
@@ -841,7 +836,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
         } catch (EntityNotFoundException e) {
             logger.debugv("Target was deleted during pruning operation: {0}", target.connectUrl, e);
-            entityManager.flush();
             nsNode.persist();
         }
     }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -120,8 +120,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             "SELECT n.id FROM DiscoveryNode n"
                     + " WHERE n.name = :name AND"
                     + " n.nodeType = :nodeType AND"
-                    + " jsonb_extract_path_text(n.labels,"
-                    + " 'discovery.cryostat.io/namespace') = :namespace";
+                    + " n.labels->>'discovery.cryostat.io/namespace' = :namespace";
 
     private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
 
@@ -1239,14 +1238,23 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
      */
     private Long findExistingNodeId(String namespace, String name, String nodeType) {
         try {
-            return entityManager
-                    .createQuery(FIND_NAMESPACED_NODE_SQL, Long.class)
-                    .setParameter("name", name)
-                    .setParameter("nodeType", nodeType)
-                    .setParameter("namespace", namespace)
-                    .getSingleResult();
+            Object result =
+                    entityManager
+                            .createNativeQuery(FIND_NAMESPACED_NODE_SQL)
+                            .setParameter("name", name)
+                            .setParameter("nodeType", nodeType)
+                            .setParameter("namespace", namespace)
+                            .getResultStream()
+                            .findFirst()
+                            .orElse(null);
+            return result != null ? ((Number) result).longValue() : null;
         } catch (Exception e) {
-            // Node not found or multiple results - treat as not existing
+            logger.errorv(
+                    e,
+                    "Error finding existing node: name={0}, type={1}, namespace={2}",
+                    name,
+                    nodeType,
+                    namespace);
             return null;
         }
     }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -916,10 +916,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     void pruneOwnerChain(DiscoveryNode nsNode, Target target) {
         logger.debugv("Pruning owner chain for target: {0}", target.connectUrl);
         try {
-            Target managedTarget = Target.getTargetByConnectUrl(target.connectUrl);
+            Optional<Target> managedTargetOpt =
+                    Target.<Target>find("connectUrl", target.connectUrl).singleResultOptional();
 
-            if (managedTarget == null || managedTarget.id == null) {
+            if (managedTargetOpt.isEmpty()) {
                 logger.debugv("Target already deleted: {0}", target.connectUrl);
+                return;
+            }
+
+            Target managedTarget = managedTargetOpt.get();
+            if (managedTarget.id == null) {
+                logger.debugv("Target has no id: {0}", target.connectUrl);
                 return;
             }
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1300,6 +1300,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         logger.debugv("Converting DTO tree to entities, root: {0}", rootDto.name());
 
         // Walk the tree depth-first, converting DTOs to entities
+        // This returns the root of the converted tree
         DiscoveryNode rootEntity = convertDtoNodeToEntity(rootDto, nsNode, false);
 
         // Find the topmost node in the chain (the one without a parent)
@@ -1332,14 +1333,49 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     "Added topmost node {0} to namespace {1} children", topmost.name, nsNode.name);
         }
 
-        // Find and return the leaf node (EndpointSlice wrapper)
-        DiscoveryNode leafNode = rootEntity;
-        while (!leafNode.children.isEmpty()) {
-            leafNode = leafNode.children.get(0);
-        }
+        // Find and return the leaf node (EndpointSlice wrapper) by walking down from rootEntity
+        // We need to walk down the DTO tree structure, not the entity children collection,
+        // because the entity children may include nodes from previous discoveries
+        DiscoveryNode leafNode = findLeafNodeFromDto(rootDto, rootEntity);
 
         logger.debugv("DTO tree conversion complete, leaf node: {0}", leafNode.name);
         return leafNode;
+    }
+
+    /**
+     * Finds the leaf node entity that corresponds to the leaf of the DTO tree. This walks down the
+     * DTO tree structure to find the correct leaf, rather than using the entity's children
+     * collection which may contain nodes from previous discoveries.
+     *
+     * @param dto The DTO node to search from
+     * @param entity The corresponding entity node
+     * @return The leaf node entity
+     */
+    private DiscoveryNode findLeafNodeFromDto(DiscoveryNodeDTO dto, DiscoveryNode entity) {
+        // If this DTO has no children, this entity is the leaf
+        if (dto.children().isEmpty()) {
+            return entity;
+        }
+
+        // Otherwise, find the child entity that matches the first DTO child
+        DiscoveryNodeDTO childDto = dto.children().get(0);
+
+        // Find the matching child entity by name and type
+        DiscoveryNode childEntity =
+                entity.children.stream()
+                        .filter(
+                                child ->
+                                        child.name.equals(childDto.name())
+                                                && child.nodeType.equals(childDto.nodeType()))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Could not find child entity for DTO: "
+                                                        + childDto.name()));
+
+        // Recursively search down the tree
+        return findLeafNodeFromDto(childDto, childEntity);
     }
 
     /**

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -114,6 +114,14 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     + "AND NOT EXISTS ("
                     + "  SELECT 1 FROM Target t WHERE t.discoveryNode = n.id"
                     + ")";
+    // SQL query to find existing DiscoveryNode entities by name/nodeType within a particular
+    // namespace
+    private static final String FIND_NAMESPACED_NODE_SQL =
+            "SELECT n.id FROM DiscoveryNode n"
+                    + " WHERE n.name = :name AND"
+                    + " n.nodeType = :nodeType AND"
+                    + " jsonb_extract_path_text(n.labels,"
+                    + " 'discovery.cryostat.io/namespace') = :namespace";
 
     private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
 
@@ -359,20 +367,41 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             try {
                 Set<Target> persistedTargets = queryPersistedTargets(namespace);
 
-                Map<Target, TargetWithHierarchy> observedTargetsWithHierarchy =
-                        buildInMemoryTreeForNamespace(namespace);
+                Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
+                        buildInMemoryTreeForNamespaceDTO(namespace);
 
-                Set<Target> observedTargets = observedTargetsWithHierarchy.keySet();
+                Set<TargetDTO> observedTargetDtos = observedTargetsWithHierarchy.keySet();
 
-                var removedTargets = Target.compare(persistedTargets).to(observedTargets).removed();
+                Set<String> observedConnectUrls =
+                        observedTargetDtos.stream()
+                                .map(TargetDTO::connectUrl)
+                                .collect(Collectors.toSet());
+
+                Set<String> persistedConnectUrls =
+                        persistedTargets.stream()
+                                .map(t -> t.connectUrl.toString())
+                                .collect(Collectors.toSet());
+
+                // Find removed targets (in persisted but not in observed)
+                Set<Target> removedTargets =
+                        persistedTargets.stream()
+                                .filter(t -> !observedConnectUrls.contains(t.connectUrl.toString()))
+                                .collect(Collectors.toSet());
+
+                // Find added targets (in observed but not in persisted)
+                Set<TargetDTO> addedTargetDtos =
+                        observedTargetDtos.stream()
+                                .filter(dto -> !persistedConnectUrls.contains(dto.connectUrl()))
+                                .collect(Collectors.toSet());
 
                 logger.debugv(
                         "Namespace {0}: Found {1} persisted targets, {2} observed targets, {3}"
-                                + " removed targets",
+                                + " removed targets, {4} added targets",
                         namespace,
                         persistedTargets.size(),
-                        observedTargets.size(),
-                        removedTargets.size());
+                        observedTargetDtos.size(),
+                        removedTargets.size(),
+                        addedTargetDtos.size());
 
                 removedTargets.forEach(
                         (t) -> {
@@ -380,20 +409,22 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                             notify(EndpointDiscoveryEvent.from(namespace, t, null, EventKind.LOST));
                         });
 
-                Target.compare(persistedTargets)
-                        .to(observedTargets)
-                        .added()
-                        .forEach(
-                                (t) -> {
-                                    TargetWithHierarchy hierarchy =
-                                            observedTargetsWithHierarchy.get(t);
-                                    notify(
-                                            EndpointDiscoveryEvent.from(
-                                                    namespace,
-                                                    t,
-                                                    hierarchy.objRef,
-                                                    EventKind.FOUND));
-                                });
+                addedTargetDtos.forEach(
+                        (targetDto) -> {
+                            DiscoveryNodeDTO hierarchy =
+                                    observedTargetsWithHierarchy.get(targetDto);
+                            logger.debugv(
+                                    "Publishing FOUND event for target: {0} (DTO flow)",
+                                    targetDto.connectUrl());
+                            notify(
+                                    EndpointDiscoveryEvent.from(
+                                            namespace,
+                                            null,
+                                            null,
+                                            EventKind.FOUND,
+                                            targetDto,
+                                            hierarchy));
+                        });
             } catch (Exception e) {
                 logger.errorv(
                         e, "Failed to synchronize EndpointSlices in namespace {0}", namespace);
@@ -421,7 +452,14 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                 });
 
         if (evt.eventKind == EventKind.FOUND) {
-            persistOwnerChain(nsNode, evt.target, evt.objRef);
+            if (evt.targetDto != null && evt.hierarchyRoot != null) {
+                logger.debugv("Persisting target from DTO: {0}", evt.targetDto.connectUrl());
+                persistOwnerChainFromDTO(nsNode, evt.targetDto, evt.hierarchyRoot);
+            } else {
+                logger.warnv(
+                        "FOUND event missing DTOs for target: {0}",
+                        evt.target != null ? evt.target.connectUrl : "null");
+            }
         } else {
             pruneOwnerChain(nsNode, evt.target);
         }
@@ -550,15 +588,15 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Build in-memory discovery tree for all targets in a namespace. This method does NOT persist
-     * anything to the database - it only queries Kubernetes API and builds the tree structure in
-     * memory.
+     * Build in-memory discovery tree for all targets in a namespace using DTOs. This method does
+     * NOT persist anything to the database - it only queries Kubernetes API and builds the tree
+     * structure in memory using DTOs.
      *
      * @param namespace The Kubernetes namespace
-     * @return Map of Target to TargetWithHierarchy containing the full ownership chain
+     * @return Map of TargetDTO to DiscoveryNodeDTO containing the full ownership chain
      */
-    private Map<Target, TargetWithHierarchy> buildInMemoryTreeForNamespace(String namespace) {
-        Map<Target, TargetWithHierarchy> result = new HashMap<>();
+    private Map<TargetDTO, DiscoveryNodeDTO> buildInMemoryTreeForNamespaceDTO(String namespace) {
+        Map<TargetDTO, DiscoveryNodeDTO> result = new HashMap<>();
 
         Stream<EndpointSlice> endpoints;
         if (kubeConfig.watchAllNamespaces()) {
@@ -580,8 +618,16 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                         (tuple) -> {
                             Target t = tuple.toTarget();
                             if (t != null) {
-                                DiscoveryNode hierarchyRoot = buildOwnershipLineageForTarget(tuple);
-                                result.put(t, new TargetWithHierarchy(tuple.objRef, hierarchyRoot));
+                                DiscoveryNodeDTO hierarchyRoot =
+                                        buildOwnershipLineageForTargetDTO(tuple);
+                                TargetDTO targetDTO =
+                                        new TargetDTO(
+                                                t.connectUrl.toString(),
+                                                t.alias,
+                                                new HashMap<>(t.labels),
+                                                t.annotations,
+                                                hierarchyRoot);
+                                result.put(targetDTO, hierarchyRoot);
                             }
                         });
 
@@ -589,33 +635,42 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Builds the complete ownership lineage for a target, from the leaf node (EndpointSlice)
-     * through Pod, ReplicaSet, Deployment, up to the Namespace. This method constructs the entire
-     * tree in memory without any database access.
+     * Builds the complete ownership lineage for a target using DTOs, from the leaf node
+     * (EndpointSlice) through Pod, ReplicaSet, Deployment, up to the Namespace. This method
+     * constructs the entire tree in memory without creating Hibernate entities.
      *
      * @param tuple The TargetTuple containing target information and Kubernetes references
-     * @return The root DiscoveryNode of the ownership hierarchy (typically a Namespace or the
+     * @return The root DiscoveryNodeDTO of the ownership hierarchy (typically a Namespace or the
      *     highest owner)
      */
-    private DiscoveryNode buildOwnershipLineageForTarget(TargetTuple tuple) {
+    private DiscoveryNodeDTO buildOwnershipLineageForTargetDTO(TargetTuple tuple) {
         String targetKind = tuple.objRef.getKind();
         KubeDiscoveryNodeType targetType = KubeDiscoveryNodeType.fromKubernetesKind(targetKind);
 
-        DiscoveryNode targetNode = createInMemoryTargetNode(tuple);
+        DiscoveryNodeDTO targetNode = createInMemoryTargetNodeDTO(tuple);
 
         if (targetType == KubeDiscoveryNodeType.POD) {
-            Pair<HasMetadata, DiscoveryNode> pod =
-                    queryForNodeInMemory(
+            Pair<HasMetadata, DiscoveryNodeDTO> pod =
+                    queryForNodeDTO(
                             tuple.objRef.getNamespace(),
                             tuple.objRef.getName(),
                             tuple.objRef.getKind());
 
             if (pod != null) {
-                DiscoveryNode podNode = pod.getRight();
-                podNode.children.add(targetNode);
-                targetNode.parent = podNode;
+                DiscoveryNodeDTO podNode = pod.getRight();
+                List<DiscoveryNodeDTO> podChildren = new ArrayList<>(podNode.children());
+                podChildren.add(targetNode);
+                DiscoveryNodeDTO updatedPodNode =
+                        new DiscoveryNodeDTO(
+                                podNode.name(),
+                                podNode.nodeType(),
+                                podNode.labels(),
+                                podChildren,
+                                podNode.parent(),
+                                podNode.existingId());
 
-                DiscoveryNode rootNode = buildOwnershipHierarchy(pod.getLeft(), podNode);
+                DiscoveryNodeDTO rootNode =
+                        buildOwnershipHierarchyDTO(pod.getLeft(), updatedPodNode);
                 return rootNode;
             }
         }
@@ -624,19 +679,135 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Creates an in-memory DiscoveryNode for a target without database access.
+     * Creates an in-memory DiscoveryNodeDTO for a target without database access.
      *
      * @param tuple The TargetTuple containing target information
-     * @return In-memory DiscoveryNode representing the target
+     * @return DiscoveryNodeDTO representing the target
      */
-    private DiscoveryNode createInMemoryTargetNode(TargetTuple tuple) {
-        DiscoveryNode targetNode = new DiscoveryNode();
-        targetNode.name = tuple.objRef.getName();
-        targetNode.nodeType = KubeDiscoveryNodeType.ENDPOINT_SLICE.getKind();
-        targetNode.labels = new HashMap<>();
-        targetNode.labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, tuple.objRef.getNamespace());
-        targetNode.children = new ArrayList<>();
-        return targetNode;
+    private DiscoveryNodeDTO createInMemoryTargetNodeDTO(TargetTuple tuple) {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, tuple.objRef.getNamespace());
+
+        return new DiscoveryNodeDTO(
+                tuple.objRef.getName(),
+                KubeDiscoveryNodeType.ENDPOINT_SLICE.getKind(),
+                labels,
+                new ArrayList<>(),
+                null,
+                null);
+    }
+
+    /**
+     * Queries Kubernetes API for a node and creates a DiscoveryNodeDTO. Checks if the node exists
+     * in the database and marks the DTO accordingly.
+     *
+     * @param namespace Kubernetes namespace
+     * @param name Resource name
+     * @param kind Resource kind
+     * @return Pair of Kubernetes object and DiscoveryNodeDTO, or null if not found
+     */
+    private Pair<HasMetadata, DiscoveryNodeDTO> queryForNodeDTO(
+            String namespace, String name, String kind) {
+
+        KubeDiscoveryNodeType nodeType = KubeDiscoveryNodeType.fromKubernetesKind(kind);
+        if (nodeType == null) {
+            return null;
+        }
+
+        HasMetadata kubeObj =
+                nodeType.getQueryFunction().apply(client).apply(namespace).apply(name);
+
+        Map<String, String> labels = new HashMap<>();
+        if (kubeObj != null && kubeObj.getMetadata().getLabels() != null) {
+            labels.putAll(kubeObj.getMetadata().getLabels());
+        }
+        labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, namespace);
+
+        Long existingId = findExistingNodeId(namespace, name, nodeType.getKind());
+
+        DiscoveryNodeDTO nodeDTO =
+                new DiscoveryNodeDTO(
+                        name, nodeType.getKind(), labels, new ArrayList<>(), null, existingId);
+
+        return Pair.of(kubeObj, nodeDTO);
+    }
+
+    /**
+     * Builds the ownership hierarchy for a given Kubernetes object by chasing owner references up
+     * the chain using DTOs. This method does NOT persist any nodes or create Hibernate entities -
+     * it only constructs the hierarchical relationships in memory using DTOs. Stops walking up the
+     * hierarchy when reaching an existing node (common ancestor).
+     *
+     * @param kubeObj The Kubernetes object to start from
+     * @param node The DiscoveryNodeDTO representing the Kubernetes object
+     * @return The root DiscoveryNodeDTO of the ownership chain (the topmost owner)
+     */
+    private DiscoveryNodeDTO buildOwnershipHierarchyDTO(
+            HasMetadata kubeObj, DiscoveryNodeDTO node) {
+        Pair<HasMetadata, DiscoveryNodeDTO> current = Pair.of(kubeObj, node);
+
+        while (true) {
+            DiscoveryNodeDTO currentNode = current.getRight();
+
+            if (currentNode.existsInDb()) {
+                logger.debugv(
+                        "Reached existing node in DB: {0}/{1} (id: {2}), stopping hierarchy walk",
+                        currentNode.name(), currentNode.nodeType(), currentNode.existingId());
+                break;
+            }
+
+            Pair<HasMetadata, DiscoveryNodeDTO> owner = getOwnerNodeDTO(current);
+            if (owner == null) {
+                break;
+            }
+
+            DiscoveryNodeDTO ownerNode = owner.getRight();
+            DiscoveryNodeDTO childNode = currentNode;
+
+            List<DiscoveryNodeDTO> ownerChildren = new ArrayList<>(ownerNode.children());
+            if (!ownerChildren.contains(childNode)) {
+                ownerChildren.add(childNode);
+            }
+
+            DiscoveryNodeDTO updatedOwnerNode =
+                    new DiscoveryNodeDTO(
+                            ownerNode.name(),
+                            ownerNode.nodeType(),
+                            ownerNode.labels(),
+                            ownerChildren,
+                            ownerNode.parent(),
+                            ownerNode.existingId());
+
+            current = Pair.of(owner.getLeft(), updatedOwnerNode);
+        }
+
+        return current.getRight();
+    }
+
+    /**
+     * Gets the owner node for a given child node by querying Kubernetes API. Creates a
+     * DiscoveryNodeDTO and checks if it exists in the database.
+     *
+     * @param child Pair of Kubernetes object and its DiscoveryNodeDTO
+     * @return Pair of owner Kubernetes object and its DiscoveryNodeDTO, or null if no owner
+     */
+    private Pair<HasMetadata, DiscoveryNodeDTO> getOwnerNodeDTO(
+            Pair<HasMetadata, DiscoveryNodeDTO> child) {
+        HasMetadata childRef = child.getLeft();
+        if (childRef == null) {
+            return null;
+        }
+        List<OwnerReference> owners = childRef.getMetadata().getOwnerReferences();
+        if (owners.isEmpty()) {
+            return null;
+        }
+        String namespace = childRef.getMetadata().getNamespace();
+        OwnerReference owner =
+                owners.stream()
+                        .filter(o -> KubeDiscoveryNodeType.fromKubernetesKind(o.getKind()) != null)
+                        .findFirst()
+                        .orElse(owners.get(0));
+        return queryForNodeDTO(namespace, owner.getName(), owner.getKind());
     }
 
     /**
@@ -841,237 +1012,46 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Persists the ownership chain to the database. This is Stage 2 of the two-stage process. The
-     * in-memory tree should already be built before calling this method.
+     * Persists the node chain to the database. This method works with pre-converted entities that
+     * are already linked in parent-child relationships by convertDtoTreeToEntities().
+     *
+     * <p>The method:
+     *
+     * <ol>
+     *   <li>Walks up from leaf to root, collecting nodes
+     *   <li>Persists from root to leaf (to satisfy foreign key constraints)
+     *   <li>Persists the Target last
+     *   <li>Ensures namespace and realm are persisted
+     * </ol>
      *
      * @param nsNode The namespace node
      * @param target The target to persist
-     * @param targetRef The Kubernetes object reference for the target
+     * @param targetNode The leaf node (EndpointSlice wrapper)
      */
-    private void persistOwnerChain(DiscoveryNode nsNode, Target target, ObjectReference targetRef) {
-        DiscoveryNode targetNode = createTargetNode(target, targetRef);
-        target.discoveryNode = targetNode;
-
-        buildOwnershipHierarchy(targetRef, targetNode, nsNode);
-        persistNodeChain(nsNode, target, targetNode);
-    }
-
-    private DiscoveryNode createTargetNode(Target target, ObjectReference targetRef) {
-        return DiscoveryNode.target(
-                target,
-                KubeDiscoveryNodeType.ENDPOINT_SLICE,
-                n ->
-                        n.labels.putAll(
-                                Map.of(DISCOVERY_NAMESPACE_LABEL_KEY, targetRef.getNamespace())));
-    }
-
-    private DiscoveryNode buildOwnershipHierarchy(
-            ObjectReference targetRef, DiscoveryNode targetNode, DiscoveryNode nsNode) {
-        KubeDiscoveryNodeType targetType =
-                KubeDiscoveryNodeType.fromKubernetesKind(targetRef.getKind());
-
-        if (targetType != KubeDiscoveryNodeType.POD) {
-            nsNode.children.add(targetNode);
-            targetNode.parent = nsNode;
-            return targetNode;
-        }
-
-        Pair<HasMetadata, DiscoveryNode> pod =
-                queryForNodeReadOnly(
-                        targetRef.getNamespace(), targetRef.getName(), targetRef.getKind());
-
-        if (pod == null || pod.getLeft() == null) {
-            logger.warnv(
-                    "Pod not found for target: {0}/{1}",
-                    targetRef.getNamespace(), targetRef.getName());
-            nsNode.children.add(targetNode);
-            targetNode.parent = nsNode;
-            return targetNode;
-        }
-
-        HasMetadata podObj = pod.getLeft();
-        DiscoveryNode podNode = pod.getRight();
-
-        if (podNode == null) {
-            Map<String, String> labels = new HashMap<>();
-            if (podObj.getMetadata().getLabels() != null) {
-                labels.putAll(podObj.getMetadata().getLabels());
-            }
-            podNode =
-                    findOrCreateNodeInMemory(
-                            targetRef.getNamespace(),
-                            targetRef.getName(),
-                            targetRef.getKind(),
-                            labels);
-        }
-
-        podNode.children.add(targetNode);
-        targetNode.parent = podNode;
-
-        DiscoveryNode rootNode = buildOwnershipHierarchyWithDbLookup(podObj, podNode);
-
-        nsNode.children.add(rootNode);
-        rootNode.parent = nsNode;
-
-        return rootNode;
-    }
-
-    private DiscoveryNode buildOwnershipHierarchyWithDbLookup(
-            HasMetadata kubeObj, DiscoveryNode node) {
-        // Build a list of node descriptors from child to parent
-        List<NodeDescriptor> hierarchy = new ArrayList<>();
-        HasMetadata current = kubeObj;
-
-        while (current != null) {
-            List<OwnerReference> owners = current.getMetadata().getOwnerReferences();
-            if (owners.isEmpty()) {
-                break;
-            }
-
-            String namespace = current.getMetadata().getNamespace();
-            OwnerReference owner =
-                    owners.stream()
-                            .filter(
-                                    o ->
-                                            KubeDiscoveryNodeType.fromKubernetesKind(o.getKind())
-                                                    != null)
-                            .findFirst()
-                            .orElse(owners.get(0));
-
-            Pair<HasMetadata, DiscoveryNode> ownerPair =
-                    queryForNodeReadOnly(namespace, owner.getName(), owner.getKind());
-
-            if (ownerPair == null || ownerPair.getLeft() == null) {
-                break;
-            }
-
-            HasMetadata ownerObj = ownerPair.getLeft();
-            DiscoveryNode existingNode = ownerPair.getRight();
-
-            Map<String, String> labels = new HashMap<>();
-            if (ownerObj.getMetadata().getLabels() != null) {
-                labels.putAll(ownerObj.getMetadata().getLabels());
-            }
-
-            Long id = null;
-            if (existingNode != null) {
-                id = existingNode.id;
-            }
-            NodeDescriptor descriptor =
-                    new NodeDescriptor(namespace, owner.getName(), owner.getKind(), labels, id);
-            hierarchy.add(descriptor);
-
-            current = ownerObj;
-        }
-
-        // Now create/link nodes from parent to child, only creating entities when needed
-        DiscoveryNode parentNode = node;
-        for (NodeDescriptor descriptor : hierarchy) {
-            DiscoveryNode ownerNode;
-            if (descriptor.existingId != null) {
-                // Node exists in DB, fetch it
-                ownerNode = DiscoveryNode.findById(descriptor.existingId);
-            } else {
-                // Create new node entity only now, when we know it's part of a valid chain
-                ownerNode =
-                        findOrCreateNodeInMemory(
-                                descriptor.namespace,
-                                descriptor.name,
-                                descriptor.kind,
-                                descriptor.labels);
-            }
-
-            if (!ownerNode.children.contains(parentNode)) {
-                ownerNode.children.add(parentNode);
-            }
-            parentNode.parent = ownerNode;
-            parentNode = ownerNode;
-        }
-
-        return parentNode;
-    }
-
     void persistNodeChain(DiscoveryNode nsNode, Target target, DiscoveryNode targetNode) {
         logger.debugv("Persisting node chain for target: {0}", target.connectUrl);
 
+        // Collect the node chain from leaf to root
         List<DiscoveryNode> nodeChain = collectNodeChain(targetNode, nsNode);
 
-        // Persist nodes from parent to child (top to bottom)
-        // This ensures all nodes exist before we persist the Target
+        // Persist nodes from parent to child (root to leaf)
+        // This ensures foreign key constraints are satisfied
         for (int i = nodeChain.size() - 1; i >= 0; i--) {
             DiscoveryNode node = nodeChain.get(i);
 
+            // Skip nodes that are already persisted (loaded from DB)
             if (node.id != null) {
                 logger.debugv("Node already persisted: {0} (id: {1})", node.name, node.id);
                 continue;
             }
 
-            final String nodeNamespace = node.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY);
-            DiscoveryNode existingNode =
-                    DiscoveryNode.<DiscoveryNode>find(
-                                    "#DiscoveryNode.byTypeWithName",
-                                    Parameters.with("nodeType", node.nodeType)
-                                            .and("name", node.name))
-                            .stream()
-                            .filter(
-                                    n ->
-                                            nodeNamespace.equals(
-                                                            n.labels.get(
-                                                                    DISCOVERY_NAMESPACE_LABEL_KEY))
-                                                    && isInKubernetesApiRealm(n))
-                            .findFirst()
-                            .orElse(null);
-
-            if (existingNode != null) {
-                logger.debugv(
-                        "Reusing existing node from DB: {0} (id: {1})",
-                        existingNode.name, existingNode.id);
-
-                // Update the chain to use the existing node
-                nodeChain.set(i, existingNode);
-
-                // Update child's parent reference to point to the existing node
-                if (i > 0) {
-                    DiscoveryNode child = nodeChain.get(i - 1);
-                    child.parent = existingNode;
-                    if (!existingNode.children.contains(child)) {
-                        existingNode.children.add(child);
-                    }
-                }
-
-                // Special case: if this is the targetNode (EndpointSlice), update the target
-                // reference
-                if (node == targetNode) {
-                    target.discoveryNode = existingNode;
-                }
-            } else {
-                logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
-
-                // Ensure parent reference is set before persisting
-                // The topmost node in the chain (i == nodeChain.size() - 1) has nsNode as parent
-                // All other nodes have the next node in the chain as parent
-                if (i == nodeChain.size() - 1) {
-                    // Topmost node in chain - parent is the namespace node
-                    node.parent = nsNode;
-                    if (!nsNode.children.contains(node)) {
-                        nsNode.children.add(node);
-                    }
-                } else {
-                    // Not topmost - parent is next node in chain
-                    DiscoveryNode parent = nodeChain.get(i + 1);
-                    node.parent = parent;
-                    if (!parent.children.contains(node)) {
-                        parent.children.add(node);
-                    }
-                }
-
-                node.persist();
-                nodeChain.set(i, node);
-            }
+            // Persist new nodes
+            logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
+            node.persist();
         }
 
-        // Now that all nodes are persisted, persist the Target
-        // The targetNode should now have an ID from the database
+        // Persist the Target last (after all nodes are persisted)
+        logger.debugv("Persisting target: {0}", target.connectUrl);
         target.persist();
 
         logger.debugv("Node chain persistence complete for target: {0}", target.connectUrl);
@@ -1261,59 +1241,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Finds an existing node in the database or creates an in-memory node (NOT persisted). This
-     * method is used during hierarchy building to avoid premature persistence.
-     *
-     * @param namespace Kubernetes namespace
-     * @param name Resource name
-     * @param kind Resource kind
-     * @param labels Labels to apply to the node
-     * @return Existing DiscoveryNode from DB or new in-memory node
-     */
-    DiscoveryNode findOrCreateNodeInMemory(
-            String namespace, String name, String kind, Map<String, String> labels) {
-
-        KubeDiscoveryNodeType nodeType = KubeDiscoveryNodeType.fromKubernetesKind(kind);
-        if (nodeType == null) {
-            logger.warnv("Cannot create node for unknown Kubernetes kind: {0}", kind);
-            return null;
-        }
-
-        DiscoveryNode existingNode =
-                DiscoveryNode.<DiscoveryNode>find(
-                                "#DiscoveryNode.byTypeWithName",
-                                Parameters.with("nodeType", nodeType.getKind()).and("name", name))
-                        .stream()
-                        .filter(
-                                n ->
-                                        namespace.equals(
-                                                        n.labels.get(DISCOVERY_NAMESPACE_LABEL_KEY))
-                                                && isInKubernetesApiRealm(n))
-                        .findFirst()
-                        .orElse(null);
-
-        if (existingNode != null) {
-            logger.debugv(
-                    "Found existing node in DB: {0}/{1} (kind: {2}, id: {3})",
-                    namespace, name, kind, existingNode.id);
-            return existingNode;
-        }
-
-        DiscoveryNode newNode = new DiscoveryNode();
-        newNode.name = name;
-        newNode.nodeType = nodeType.getKind();
-        newNode.labels = new HashMap<>(labels);
-        newNode.labels.put(DISCOVERY_NAMESPACE_LABEL_KEY, namespace);
-        newNode.children = new ArrayList<>();
-
-        logger.debugv(
-                "Created in-memory node (NOT persisted): {0}/{1} (kind: {2})",
-                namespace, name, kind);
-
-        return newNode;
-    }
-
-    /**
      * Check if a node belongs to the KubernetesApi Realm by walking up its parent chain.
      *
      * @param node The node to check
@@ -1333,19 +1260,172 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
-     * Builds the ownership hierarchy using database lookups to reuse existing nodes.
+     * Queries the database to find an existing DiscoveryNode by composite ID. A DiscoveryNode is
+     * uniquely identified by: name + nodeType + namespace label.
      *
-     * @param kubeObj The Kubernetes object to start from
-     * @param node The DiscoveryNode representing the Kubernetes object
-     * @return The root node of the ownership chain (the topmost owner)
+     * @param namespace The namespace from the discovery.cryostat.io/namespace label
+     * @param name The node name
+     * @param nodeType The node type (e.g., "Pod", "Deployment")
+     * @return The node ID if found, null otherwise
      */
-    /** Represents a node in the ownership hierarchy that hasn't been persisted yet. */
-    record NodeDescriptor(
-            String namespace,
-            String name,
-            String kind,
-            Map<String, String> labels,
-            Long existingId) {}
+    private Long findExistingNodeId(String namespace, String name, String nodeType) {
+        try {
+            return entityManager
+                    .createQuery(FIND_NAMESPACED_NODE_SQL, Long.class)
+                    .setParameter("name", name)
+                    .setParameter("nodeType", nodeType)
+                    .setParameter("namespace", namespace)
+                    .getSingleResult();
+        } catch (Exception e) {
+            // Node not found or multiple results - treat as not existing
+            return null;
+        }
+    }
+
+    /**
+     * Converts a DiscoveryNodeDTO tree to DiscoveryNode entities. This is the bridge between the
+     * DTO world (in-memory tree building) and the entity world (persistence).
+     *
+     * <p>This method walks the DTO tree from root to leaf (depth-first) and:
+     *
+     * <ul>
+     *   <li>If existsInDb=true: Loads existing entity using entityManager.find()
+     *   <li>If existsInDb=false: Creates new DiscoveryNode() entity
+     *   <li>Builds parent-child relationships bidirectionally
+     *   <li>Ensures the topmost new node links to the namespace node
+     * </ul>
+     *
+     * @param rootDto The root of the DTO tree to convert
+     * @param nsNode The namespace node to link the topmost new node to
+     * @return The leaf node (EndpointSlice wrapper) entity
+     */
+    private DiscoveryNode convertDtoTreeToEntities(DiscoveryNodeDTO rootDto, DiscoveryNode nsNode) {
+        logger.debugv("Converting DTO tree to entities, root: {0}", rootDto.name());
+
+        // Walk the tree depth-first, converting DTOs to entities
+        DiscoveryNode rootEntity = convertDtoNodeToEntity(rootDto, nsNode, true);
+
+        // Find and return the leaf node (EndpointSlice wrapper)
+        DiscoveryNode leafNode = rootEntity;
+        while (!leafNode.children.isEmpty()) {
+            leafNode = leafNode.children.get(0);
+        }
+
+        logger.debugv("DTO tree conversion complete, leaf node: {0}", leafNode.name);
+        return leafNode;
+    }
+
+    /**
+     * Recursively converts a single DiscoveryNodeDTO to a DiscoveryNode entity, including all its
+     * children.
+     *
+     * @param dto The DTO to convert
+     * @param nsNode The namespace node (used for linking the topmost new node)
+     * @param isRoot Whether this is the root node of the tree
+     * @return The converted entity
+     */
+    private DiscoveryNode convertDtoNodeToEntity(
+            DiscoveryNodeDTO dto, DiscoveryNode nsNode, boolean isRoot) {
+        DiscoveryNode entity;
+
+        if (dto.existsInDb()) {
+            // Load existing entity from database
+            logger.debugv(
+                    "Loading existing node from DB: {0} (id: {1})", dto.name(), dto.existingId());
+            entity = entityManager.find(DiscoveryNode.class, dto.existingId());
+
+            if (entity == null) {
+                logger.warnv(
+                        "Node marked as existing but not found in DB: {0} (id: {1}), creating new"
+                                + " node",
+                        dto.name(), dto.existingId());
+                entity = createNewNodeEntity(dto);
+            }
+        } else {
+            // Create new entity
+            logger.debugv("Creating new node entity: {0} (type: {1})", dto.name(), dto.nodeType());
+            entity = createNewNodeEntity(dto);
+        }
+
+        // Convert children recursively
+        for (DiscoveryNodeDTO childDto : dto.children()) {
+            DiscoveryNode childEntity = convertDtoNodeToEntity(childDto, nsNode, false);
+
+            // Build bidirectional relationship
+            childEntity.parent = entity;
+            if (!entity.children.contains(childEntity)) {
+                entity.children.add(childEntity);
+            }
+        }
+
+        // If this is the root node and it's new, link it to the namespace
+        if (isRoot && !dto.existsInDb()) {
+            entity.parent = nsNode;
+            if (!nsNode.children.contains(entity)) {
+                nsNode.children.add(entity);
+            }
+            logger.debugv("Linked root node {0} to namespace {1}", entity.name, nsNode.name);
+        }
+
+        return entity;
+    }
+
+    /**
+     * Creates a new DiscoveryNode entity from a DTO.
+     *
+     * @param dto The DTO to convert
+     * @return A new DiscoveryNode entity
+     */
+    private DiscoveryNode createNewNodeEntity(DiscoveryNodeDTO dto) {
+        DiscoveryNode node = new DiscoveryNode();
+        node.name = dto.name();
+        node.nodeType = dto.nodeType();
+        node.labels = new HashMap<>(dto.labels());
+        node.children = new ArrayList<>();
+        node.target = null;
+        return node;
+    }
+
+    /**
+     * Persists the ownership chain from DTOs.
+     *
+     * <p>This method:
+     *
+     * <ol>
+     *   <li>Converts the DTO tree to entities using convertDtoTreeToEntities()
+     *   <li>Gets the leaf node (EndpointSlice wrapper) from conversion
+     *   <li>Creates the Target entity from TargetDTO
+     *   <li>Links Target to its DiscoveryNode
+     *   <li>Calls persistNodeChain() with the converted entities
+     * </ol>
+     *
+     * @param nsNode The namespace node
+     * @param targetDto The target DTO to persist
+     * @param hierarchyRoot The root of the DTO hierarchy
+     */
+    private void persistOwnerChainFromDTO(
+            DiscoveryNode nsNode, TargetDTO targetDto, DiscoveryNodeDTO hierarchyRoot) {
+        logger.debugv("Persisting owner chain from DTO for target: {0}", targetDto.connectUrl());
+
+        // Convert the DTO tree to entities
+        DiscoveryNode leafNode = convertDtoTreeToEntities(hierarchyRoot, nsNode);
+
+        // Create the Target entity from DTO
+        Target target = new Target();
+        target.connectUrl = URI.create(targetDto.connectUrl());
+        target.alias = targetDto.alias();
+        target.labels = new HashMap<>(targetDto.labels());
+        target.annotations = targetDto.annotations();
+
+        // Link Target to its DiscoveryNode
+        target.discoveryNode = leafNode;
+        leafNode.target = target;
+
+        logger.debugv("Calling persistNodeChain for target: {0}", target.connectUrl);
+
+        // Persist the node chain
+        persistNodeChain(nsNode, target, leafNode);
+    }
 
     @DisallowConcurrentExecution
     static class EndpointsResyncJob implements Job {
@@ -1425,15 +1505,61 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     private static record EndpointDiscoveryEvent(
-            String namespace, Target target, ObjectReference objRef, EventKind eventKind) {
+            String namespace,
+            Target target,
+            ObjectReference objRef,
+            EventKind eventKind,
+            TargetDTO targetDto,
+            DiscoveryNodeDTO hierarchyRoot) {
         static EndpointDiscoveryEvent from(
                 String namespace, Target target, ObjectReference objRef, EventKind eventKind) {
-            return new EndpointDiscoveryEvent(namespace, target, objRef, eventKind);
+            return new EndpointDiscoveryEvent(namespace, target, objRef, eventKind, null, null);
+        }
+
+        static EndpointDiscoveryEvent from(
+                String namespace,
+                Target target,
+                ObjectReference objRef,
+                EventKind eventKind,
+                TargetDTO targetDto,
+                DiscoveryNodeDTO hierarchyRoot) {
+            return new EndpointDiscoveryEvent(
+                    namespace, target, objRef, eventKind, targetDto, hierarchyRoot);
         }
     }
 
-    private static record TargetWithHierarchy(
-            ObjectReference objRef, DiscoveryNode hierarchyRoot) {}
+    /**
+     * Represents a Target before it becomes a Hibernate entity. Used to build the discovery tree in
+     * memory without creating entities.
+     */
+    record TargetDTO(
+            String connectUrl,
+            String alias,
+            Map<String, String> labels,
+            Target.Annotations annotations,
+            DiscoveryNodeDTO discoveryNode) {}
+
+    /**
+     * Represents a DiscoveryNode before it becomes a Hibernate entity. Used to build the discovery
+     * tree in memory without creating entities. The existingId holds the database ID if this node
+     * already exists in the database (null if it's a new node).
+     */
+    record DiscoveryNodeDTO(
+            String name,
+            String nodeType,
+            Map<String, String> labels,
+            List<DiscoveryNodeDTO> children,
+            DiscoveryNodeDTO parent,
+            Long existingId) {
+        /**
+         * Returns true if this node already exists in the database.
+         *
+         * @return true if existingId is not null, false otherwise
+         */
+        boolean existsInDb() {
+            return existingId != null;
+        }
+    }
 
     class TargetTuple {
         ObjectReference objRef;

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1050,7 +1050,16 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
 
                 // Ensure parent reference is set before persisting
-                if (i < nodeChain.size() - 1) {
+                // The topmost node in the chain (i == nodeChain.size() - 1) has nsNode as parent
+                // All other nodes have the next node in the chain as parent
+                if (i == nodeChain.size() - 1) {
+                    // Topmost node in chain - parent is the namespace node
+                    node.parent = nsNode;
+                    if (!nsNode.children.contains(node)) {
+                        nsNode.children.add(node);
+                    }
+                } else {
+                    // Not topmost - parent is next node in chain
                     DiscoveryNode parent = nodeChain.get(i + 1);
                     node.parent = parent;
                     if (!parent.children.contains(node)) {

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -939,7 +939,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                 return;
             }
 
-            endpointNode = entityManager.find(DiscoveryNode.class, endpointNode.id);
+            endpointNode = DiscoveryNode.findById(endpointNode.id);
             logger.debugv(
                     "Loaded discoveryNode {0} with parent {1}",
                     endpointNode.id, endpointNode.parent != null ? endpointNode.parent.id : "null");
@@ -1279,7 +1279,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
      * <p>This method walks the DTO tree from root to leaf (depth-first) and:
      *
      * <ul>
-     *   <li>If existsInDb=true: Loads existing entity using entityManager.find()
+     *   <li>If existsInDb=true: Loads existing entity using DiscoveryNode.findById()
      *   <li>If existsInDb=false: Creates new DiscoveryNode() entity
      *   <li>Builds parent-child relationships bidirectionally
      *   <li>Ensures the topmost new node links to the namespace node
@@ -1319,10 +1319,10 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         DiscoveryNode entity;
 
         if (dto.existsInDb()) {
-            // Load existing entity from database
+            // Load existing entity from database using Panache
             logger.debugv(
                     "Loading existing node from DB: {0} (id: {1})", dto.name(), dto.existingId());
-            entity = entityManager.find(DiscoveryNode.class, dto.existingId());
+            entity = DiscoveryNode.findById(dto.existingId());
 
             if (entity == null) {
                 logger.warnv(

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1002,9 +1002,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
         List<DiscoveryNode> nodeChain = collectNodeChain(targetNode, nsNode);
 
-        target.persist();
-
         // Persist nodes from parent to child (top to bottom)
+        // This ensures all nodes exist before we persist the Target
         for (int i = nodeChain.size() - 1; i >= 0; i--) {
             DiscoveryNode node = nodeChain.get(i);
 
@@ -1046,6 +1045,12 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                         existingNode.children.add(child);
                     }
                 }
+
+                // Special case: if this is the targetNode (EndpointSlice), update the target
+                // reference
+                if (node == targetNode) {
+                    target.discoveryNode = existingNode;
+                }
             } else {
                 logger.debugv("Persisting new node: {0} (type: {1})", node.name, node.nodeType);
 
@@ -1073,6 +1078,10 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
         entityManager.flush();
         nsNode.persist();
+
+        // Now that all nodes are persisted, persist the Target
+        // The targetNode should now have an ID from the database
+        target.persist();
 
         logger.debugv("Node chain persistence complete for target: {0}", target.connectUrl);
     }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1348,14 +1348,9 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     entity.children.stream()
                             .anyMatch(
                                     existing ->
-                                            existing.name.equals(childEntity.name)
-                                                    && existing.nodeType.equals(
-                                                            childEntity.nodeType)
-                                                    && Objects.equals(
-                                                            existing.labels.get(
-                                                                    DISCOVERY_NAMESPACE_LABEL_KEY),
-                                                            childEntity.labels.get(
-                                                                    DISCOVERY_NAMESPACE_LABEL_KEY)));
+                                            existing == childEntity
+                                                    || (existing.id != null
+                                                            && existing.id.equals(childEntity.id)));
             if (!childExists) {
                 entity.children.add(childEntity);
             }

--- a/src/main/java/io/cryostat/targets/TargetUpdateJob.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateJob.java
@@ -99,8 +99,6 @@ public class TargetUpdateJob implements Job {
                                         target.connectUrl, target.alias, t.jvmId);
                                 return true;
                             } catch (PersistenceException e) {
-                                t.jvmId = null;
-                                t.persist();
                                 logger.warn(e);
                                 return false;
                             } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,20 @@ quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.window=1
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.type=smooth
 
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".bulkhead.value=5
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".bulkhead.waiting-task-queue=10
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".timeout.unit=seconds
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".timeout.value=5
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.max-retries=3
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.delay-unit=seconds
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.delay=1
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.jitter-unit=millis
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.jitter=500
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.value=60
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.window-unit=minutes
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.window=1
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.type=smooth
+
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".bulkhead.value=5
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".bulkhead.waiting-task-queue=10
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".timeout.unit=seconds

--- a/src/main/resources/db/migration/V4.2.0__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.0__cryostat.sql
@@ -669,4 +669,11 @@ WHERE JOB_GROUP = 'discovery.startup';
 DELETE FROM QRTZ_JOB_DETAILS
 WHERE JOB_GROUP = 'discovery.startup';
 
+DELETE FROM Target WHERE discoveryNode IS NOT NULL;
+UPDATE DiscoveryNode SET parentNode = NULL;
+DELETE FROM DiscoveryNode
+WHERE id NOT IN (
+    SELECT realm_id FROM DiscoveryPlugin WHERE builtin = true
+);
+
 COMMIT;

--- a/src/main/resources/db/migration/V4.2.0__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.0__cryostat.sql
@@ -669,19 +669,4 @@ WHERE JOB_GROUP = 'discovery.startup';
 DELETE FROM QRTZ_JOB_DETAILS
 WHERE JOB_GROUP = 'discovery.startup';
 
--- Delete all discovered Targets (those with a discoveryNode reference)
-DELETE FROM Target WHERE discoveryNode IS NOT NULL;
-
--- Clear all parent references to avoid foreign key constraint issues during deletion
-UPDATE DiscoveryNode SET parentNode = NULL;
-
--- Delete all DiscoveryNodes EXCEPT:
--- 1. The Universe node (nodeType = 'Universe')
--- 2. Realm nodes that are referenced by builtin DiscoveryPlugins
-DELETE FROM DiscoveryNode
-WHERE nodeType != 'Universe'
-  AND id NOT IN (
-    SELECT realm_id FROM DiscoveryPlugin WHERE builtin = true
-);
-
 COMMIT;

--- a/src/main/resources/db/migration/V4.2.0__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.0__cryostat.sql
@@ -669,10 +669,18 @@ WHERE JOB_GROUP = 'discovery.startup';
 DELETE FROM QRTZ_JOB_DETAILS
 WHERE JOB_GROUP = 'discovery.startup';
 
+-- Delete all discovered Targets (those with a discoveryNode reference)
 DELETE FROM Target WHERE discoveryNode IS NOT NULL;
+
+-- Clear all parent references to avoid foreign key constraint issues during deletion
 UPDATE DiscoveryNode SET parentNode = NULL;
+
+-- Delete all DiscoveryNodes EXCEPT:
+-- 1. The Universe node (nodeType = 'Universe')
+-- 2. Realm nodes that are referenced by builtin DiscoveryPlugins
 DELETE FROM DiscoveryNode
-WHERE id NOT IN (
+WHERE nodeType != 'Universe'
+  AND id NOT IN (
     SELECT realm_id FROM DiscoveryPlugin WHERE builtin = true
 );
 

--- a/src/main/resources/db/migration/V4.2.0__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.0__cryostat.sql
@@ -669,4 +669,19 @@ WHERE JOB_GROUP = 'discovery.startup';
 DELETE FROM QRTZ_JOB_DETAILS
 WHERE JOB_GROUP = 'discovery.startup';
 
+-- Delete all discovered Targets (those with a discoveryNode reference)
+DELETE FROM Target WHERE discoveryNode IS NOT NULL;
+
+-- Clear all parent references to avoid foreign key constraint issues during deletion
+UPDATE DiscoveryNode SET parentNode = NULL;
+
+-- Delete all DiscoveryNodes EXCEPT:
+-- 1. The Universe node (nodeType = 'Universe')
+-- 2. Realm nodes that are referenced by builtin DiscoveryPlugins
+DELETE FROM DiscoveryNode
+WHERE nodeType != 'Universe'
+  AND id NOT IN (
+    SELECT realm_id FROM DiscoveryPlugin WHERE builtin = true
+);
+
 COMMIT;

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -18,11 +18,14 @@ package io.cryostat.discovery;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.targets.Target;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectReference;
@@ -44,12 +47,16 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.quarkus.panache.common.Parameters;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.MockitoConfig;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -75,6 +82,8 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
     EventBus bus;
 
     @Inject KubeEndpointSlicesDiscovery discovery;
+
+    @Inject EntityManager entityManager;
 
     @Test
     void testGetTargetTuplesFromReturnsEmptyListWhenPortsAreNull() {
@@ -620,5 +629,299 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                 "test-namespace",
                 result.labels.get(KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY));
         assertNull(result.parent);
+    }
+
+    @Test
+    @Transactional
+    @SuppressWarnings("unchecked")
+    void testQueryForNodeReadOnlyDoesNotPersist() throws Exception {
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getOwnerReferences()).thenReturn(List.of());
+        when(podMeta.getNamespace()).thenReturn("test-namespace");
+        when(podMeta.getLabels()).thenReturn(Map.of("app", "test-app"));
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource = mock(PodResource.class);
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("test-pod")).thenReturn(podResource);
+        when(podResource.get()).thenReturn(pod);
+
+        long nodeCountBefore = DiscoveryNode.count();
+
+        var result = discovery.queryForNodeReadOnly("test-namespace", "test-pod", "Pod");
+
+        long nodeCountAfter = DiscoveryNode.count();
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals(
+                nodeCountBefore,
+                nodeCountAfter,
+                "queryForNodeReadOnly should not create any database records");
+
+        @SuppressWarnings("unchecked")
+        Pair<?, ?> resultPair = (Pair<?, ?>) result;
+        assertNotNull(resultPair.getLeft(), "Kubernetes object should be returned");
+        assertNull(resultPair.getRight(), "DiscoveryNode should be null since nothing in DB");
+    }
+
+    @Test
+    @Transactional
+    void testFindOrCreateNodeInMemoryReusesExisting() throws Exception {
+        // Get the existing Realm node (created by the discovery plugin)
+        DiscoveryNode realmNode =
+                DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM).orElseThrow();
+
+        // Create the existing Pod node with proper parent chain
+        DiscoveryNode existingNode = new DiscoveryNode();
+        existingNode.name = "test-pod";
+        existingNode.nodeType = "Pod";
+        existingNode.labels = new HashMap<>();
+        existingNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        existingNode.parent = realmNode;
+        existingNode.children = new ArrayList<>();
+        existingNode.persist();
+
+        realmNode.children.add(existingNode);
+        realmNode.persist();
+
+        long nodeCountBefore = DiscoveryNode.count();
+
+        Map<String, String> labels = Map.of("app", "test-app");
+        var result =
+                discovery.findOrCreateNodeInMemory("test-namespace", "test-pod", "Pod", labels);
+
+        long nodeCountAfter = DiscoveryNode.count();
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals(
+                nodeCountBefore,
+                nodeCountAfter,
+                "findOrCreateNodeInMemory should not create duplicate nodes");
+
+        DiscoveryNode returnedNode = (DiscoveryNode) result;
+        assertEquals(
+                existingNode.id, returnedNode.id, "Should return the existing node from database");
+        assertEquals("test-pod", returnedNode.name);
+        assertEquals("Pod", returnedNode.nodeType);
+    }
+
+    @Test
+    @Transactional
+    void testFindOrCreateNodeInMemoryCreatesNewNode() throws Exception {
+        long nodeCountBefore = DiscoveryNode.count();
+
+        Map<String, String> labels = Map.of("app", "test-app", "realm", "KubernetesApi");
+        var result = discovery.findOrCreateNodeInMemory("test-namespace", "new-pod", "Pod", labels);
+
+        long nodeCountAfter = DiscoveryNode.count();
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals(
+                nodeCountBefore,
+                nodeCountAfter,
+                "findOrCreateNodeInMemory should NOT persist the new node to database");
+
+        DiscoveryNode newNode = (DiscoveryNode) result;
+        assertNull(newNode.id, "New node should not have an ID (not persisted)");
+        assertEquals("new-pod", newNode.name, "Node should have correct name");
+        assertEquals("Pod", newNode.nodeType, "Node should have correct type");
+        assertEquals(
+                "test-namespace",
+                newNode.labels.get(KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY),
+                "Node should have namespace label");
+        assertTrue(
+                newNode.labels.containsKey("app"),
+                "Node should have app label from provided labels");
+    }
+
+    @Test
+    @Transactional
+    void testFindOrphanedNodesDetectsOrphans() throws Exception {
+        DiscoveryNode nsNode = new DiscoveryNode();
+        nsNode.name = "test-namespace";
+        nsNode.nodeType = "Namespace";
+        nsNode.labels = new HashMap<>();
+        nsNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        nsNode.labels.put("realm", "KubernetesApi");
+        nsNode.children = new ArrayList<>();
+        nsNode.persist();
+
+        DiscoveryNode orphanPod1 = new DiscoveryNode();
+        orphanPod1.name = "orphan-pod-1";
+        orphanPod1.nodeType = "Pod";
+        orphanPod1.labels = new HashMap<>();
+        orphanPod1.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        orphanPod1.labels.put("realm", "KubernetesApi");
+        orphanPod1.children = new ArrayList<>();
+        orphanPod1.parent = nsNode;
+        orphanPod1.persist();
+
+        DiscoveryNode orphanPod2 = new DiscoveryNode();
+        orphanPod2.name = "orphan-pod-2";
+        orphanPod2.nodeType = "Pod";
+        orphanPod2.labels = new HashMap<>();
+        orphanPod2.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        orphanPod2.labels.put("realm", "KubernetesApi");
+        orphanPod2.children = new ArrayList<>();
+        orphanPod2.parent = nsNode;
+        orphanPod2.persist();
+
+        DiscoveryNode validPod = new DiscoveryNode();
+        validPod.name = "valid-pod";
+        validPod.nodeType = "Pod";
+        validPod.labels = new HashMap<>();
+        validPod.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        validPod.labels.put("realm", "KubernetesApi");
+        validPod.children = new ArrayList<>();
+        validPod.parent = nsNode;
+        validPod.persist();
+
+        DiscoveryNode endpointNode = new DiscoveryNode();
+        endpointNode.name = "valid-endpoint";
+        endpointNode.nodeType = "Endpoint";
+        endpointNode.labels = new HashMap<>();
+        endpointNode.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        endpointNode.labels.put("realm", "KubernetesApi");
+        endpointNode.children = new ArrayList<>();
+        endpointNode.parent = validPod;
+        endpointNode.persist();
+        validPod.children.add(endpointNode);
+
+        Target target = new Target();
+        target.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://192.168.1.100:9091/jmxrmi");
+        target.alias = "valid-target";
+        target.discoveryNode = endpointNode;
+        target.persist();
+
+        List<DiscoveryNode> orphans = discovery.findOrphanedNodesInNamespace("test-namespace");
+
+        assertNotNull(orphans, "Result should not be null");
+        assertEquals(2, orphans.size(), "Should find exactly 2 orphaned nodes");
+
+        List<String> orphanNames = orphans.stream().map(n -> n.name).toList();
+        assertTrue(
+                orphanNames.contains("orphan-pod-1"),
+                "Should include orphan-pod-1 in orphaned nodes");
+        assertTrue(
+                orphanNames.contains("orphan-pod-2"),
+                "Should include orphan-pod-2 in orphaned nodes");
+        assertFalse(
+                orphanNames.contains("valid-pod"),
+                "Should NOT include valid-pod (has children) in orphaned nodes");
+        assertFalse(
+                orphanNames.contains("valid-endpoint"),
+                "Should NOT include valid-endpoint (has Target) in orphaned nodes");
+    }
+
+    @Test
+    @Transactional
+    void testNodesNotCreatedWithoutValidInformerSetup() {
+        // This test verifies that nodes are NOT persisted when there's no valid
+        // EndpointSlice informer setup. This is the correct behavior - we should only
+        // persist nodes that have valid EndpointSlice descendants.
+
+        var event = KubeEndpointSlicesDiscovery.NamespaceQueryEvent.from("test-namespace");
+        long nodeCountBefore = DiscoveryNode.count();
+
+        // This will fail internally due to missing informer, but should not crash
+        try {
+            discovery.handleQueryEvent(event);
+        } catch (Exception e) {
+            // Expected - informer not set up
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        long nodeCountAfter = DiscoveryNode.count();
+
+        assertEquals(
+                nodeCountBefore,
+                nodeCountAfter,
+                "Should not create any nodes without valid informer setup");
+    }
+
+    @Test
+    @Transactional
+    @SuppressWarnings("unchecked")
+    void testNonJmxPodsDoNotCreateNodes() {
+        EndpointSlice slice = mock(EndpointSlice.class);
+        ObjectMeta sliceMeta = mock(ObjectMeta.class);
+        when(sliceMeta.getNamespace()).thenReturn("test-namespace");
+        when(sliceMeta.getName()).thenReturn("non-jmx-slice");
+        when(slice.getMetadata()).thenReturn(sliceMeta);
+        when(slice.getAddressType()).thenReturn("ipv4");
+
+        EndpointPort port = mock(EndpointPort.class);
+        when(port.getName()).thenReturn("http");
+        when(port.getPort()).thenReturn(8080);
+        when(slice.getPorts()).thenReturn(List.of(port));
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getAddresses()).thenReturn(List.of("192.168.1.200"));
+
+        ObjectReference targetRef = mock(ObjectReference.class);
+        when(targetRef.getNamespace()).thenReturn("test-namespace");
+        when(targetRef.getName()).thenReturn("non-jmx-pod");
+        when(targetRef.getKind()).thenReturn("Pod");
+        when(endpoint.getTargetRef()).thenReturn(targetRef);
+
+        EndpointConditions conditions = mock(EndpointConditions.class);
+        when(conditions.getReady()).thenReturn(true);
+        when(conditions.getServing()).thenReturn(true);
+        when(conditions.getTerminating()).thenReturn(false);
+        when(endpoint.getConditions()).thenReturn(conditions);
+
+        when(slice.getEndpoints()).thenReturn(List.of(endpoint));
+
+        Pod pod = mock(Pod.class);
+        ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(podMeta.getOwnerReferences()).thenReturn(List.of());
+        when(podMeta.getNamespace()).thenReturn("test-namespace");
+        when(podMeta.getLabels()).thenReturn(Map.of("app", "non-jmx-app"));
+        when(pod.getMetadata()).thenReturn(podMeta);
+
+        MixedOperation<Pod, PodList, PodResource> podOp = mock(MixedOperation.class);
+        NonNamespaceOperation<Pod, PodList, PodResource> nsOp = mock(NonNamespaceOperation.class);
+        PodResource podResource = mock(PodResource.class);
+        when(client.pods()).thenReturn(podOp);
+        when(podOp.inNamespace("test-namespace")).thenReturn(nsOp);
+        when(nsOp.withName("non-jmx-pod")).thenReturn(podResource);
+        when(podResource.get()).thenReturn(pod);
+
+        long nodeCountBefore = DiscoveryNode.count();
+        long targetCountBefore = Target.count();
+
+        discovery.onAdd(slice);
+        entityManager.flush();
+        entityManager.clear();
+
+        long nodeCountAfter = DiscoveryNode.count();
+        long targetCountAfter = Target.count();
+
+        assertEquals(
+                nodeCountBefore,
+                nodeCountAfter,
+                "No DiscoveryNodes should be created for non-JMX Pods");
+        assertEquals(
+                targetCountBefore,
+                targetCountAfter,
+                "No Targets should be created for non-JMX Pods");
+
+        long podNodeCount =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "#DiscoveryNode.byTypeWithName",
+                                Parameters.with("nodeType", "Pod").and("name", "non-jmx-pod"))
+                        .count();
+        assertEquals(0, podNodeCount, "No Pod node should exist for non-JMX pod");
     }
 }

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -670,73 +670,116 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
 
     @Test
     @Transactional
-    void testFindOrCreateNodeInMemoryReusesExisting() throws Exception {
-        // Get the existing Realm node (created by the discovery plugin)
-        DiscoveryNode realmNode =
-                DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM).orElseThrow();
-
-        // Create the existing Pod node with proper parent chain
-        DiscoveryNode existingNode = new DiscoveryNode();
-        existingNode.name = "test-pod";
-        existingNode.nodeType = "Pod";
-        existingNode.labels = new HashMap<>();
-        existingNode.labels.put(
+    void testFindExistingNodeIdWithJsonbQuery() throws Exception {
+        // Create a node with labels including the namespace label
+        DiscoveryNode node = new DiscoveryNode();
+        node.name = "test-pod";
+        node.nodeType = "Pod";
+        node.labels = new HashMap<>();
+        node.labels.put("app", "test-app");
+        node.labels.put(
                 KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
-        existingNode.parent = realmNode;
-        existingNode.children = new ArrayList<>();
-        existingNode.persist();
+        node.children = new ArrayList<>();
+        node.persist();
 
-        realmNode.children.add(existingNode);
-        realmNode.persist();
+        // Flush to ensure the node is in the database
+        entityManager.flush();
+        entityManager.clear();
 
-        long nodeCountBefore = DiscoveryNode.count();
+        // Test the SQL query directly using the same query string as the implementation
+        String query =
+                "SELECT n.id FROM DiscoveryNode n"
+                        + " WHERE n.name = :name AND"
+                        + " n.nodeType = :nodeType AND"
+                        + " n.labels->>'discovery.cryostat.io/namespace' = :namespace";
 
-        Map<String, String> labels = Map.of("app", "test-app");
-        var result =
-                discovery.findOrCreateNodeInMemory("test-namespace", "test-pod", "Pod", labels);
+        Long foundId =
+                ((Number)
+                                entityManager
+                                        .createNativeQuery(query)
+                                        .setParameter("name", "test-pod")
+                                        .setParameter("nodeType", "Pod")
+                                        .setParameter("namespace", "test-namespace")
+                                        .getResultStream()
+                                        .findFirst()
+                                        .orElse(null))
+                        .longValue();
 
-        long nodeCountAfter = DiscoveryNode.count();
-
-        assertNotNull(result, "Result should not be null");
-        assertEquals(
-                nodeCountBefore,
-                nodeCountAfter,
-                "findOrCreateNodeInMemory should not create duplicate nodes");
-
-        DiscoveryNode returnedNode = (DiscoveryNode) result;
-        assertEquals(
-                existingNode.id, returnedNode.id, "Should return the existing node from database");
-        assertEquals("test-pod", returnedNode.name);
-        assertEquals("Pod", returnedNode.nodeType);
+        assertNotNull(foundId, "Should find the node using JSONB operator");
+        assertEquals(node.id, foundId, "Found ID should match the created node's ID");
     }
 
     @Test
     @Transactional
-    void testFindOrCreateNodeInMemoryCreatesNewNode() throws Exception {
-        long nodeCountBefore = DiscoveryNode.count();
+    void testFindExistingNodeIdReturnsNullWhenNotFound() throws Exception {
+        // Test that the query returns null when no matching node exists
+        String query =
+                "SELECT n.id FROM DiscoveryNode n"
+                        + " WHERE n.name = :name AND"
+                        + " n.nodeType = :nodeType AND"
+                        + " n.labels->>'discovery.cryostat.io/namespace' = :namespace";
 
-        Map<String, String> labels = Map.of("app", "test-app", "realm", "KubernetesApi");
-        var result = discovery.findOrCreateNodeInMemory("test-namespace", "new-pod", "Pod", labels);
+        Object result =
+                entityManager
+                        .createNativeQuery(query)
+                        .setParameter("name", "nonexistent-pod")
+                        .setParameter("nodeType", "Pod")
+                        .setParameter("namespace", "nonexistent-namespace")
+                        .getResultStream()
+                        .findFirst()
+                        .orElse(null);
 
-        long nodeCountAfter = DiscoveryNode.count();
+        assertNull(result, "Should return null when node doesn't exist");
+    }
 
-        assertNotNull(result, "Result should not be null");
-        assertEquals(
-                nodeCountBefore,
-                nodeCountAfter,
-                "findOrCreateNodeInMemory should NOT persist the new node to database");
+    @Test
+    @Transactional
+    void testFindExistingNodeIdWithDuplicates() throws Exception {
+        // Create multiple nodes with the same name/type/namespace to test duplicate handling
+        DiscoveryNode node1 = new DiscoveryNode();
+        node1.name = "duplicate-pod";
+        node1.nodeType = "Pod";
+        node1.labels = new HashMap<>();
+        node1.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        node1.children = new ArrayList<>();
+        node1.persist();
 
-        DiscoveryNode newNode = (DiscoveryNode) result;
-        assertNull(newNode.id, "New node should not have an ID (not persisted)");
-        assertEquals("new-pod", newNode.name, "Node should have correct name");
-        assertEquals("Pod", newNode.nodeType, "Node should have correct type");
-        assertEquals(
-                "test-namespace",
-                newNode.labels.get(KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY),
-                "Node should have namespace label");
+        DiscoveryNode node2 = new DiscoveryNode();
+        node2.name = "duplicate-pod";
+        node2.nodeType = "Pod";
+        node2.labels = new HashMap<>();
+        node2.labels.put(
+                KubeEndpointSlicesDiscovery.DISCOVERY_NAMESPACE_LABEL_KEY, "test-namespace");
+        node2.children = new ArrayList<>();
+        node2.persist();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Test that getResultStream().findFirst() returns one of the duplicates
+        String query =
+                "SELECT n.id FROM DiscoveryNode n"
+                        + " WHERE n.name = :name AND"
+                        + " n.nodeType = :nodeType AND"
+                        + " n.labels->>'discovery.cryostat.io/namespace' = :namespace";
+
+        Long foundId =
+                ((Number)
+                                entityManager
+                                        .createNativeQuery(query)
+                                        .setParameter("name", "duplicate-pod")
+                                        .setParameter("nodeType", "Pod")
+                                        .setParameter("namespace", "test-namespace")
+                                        .getResultStream()
+                                        .findFirst()
+                                        .orElse(null))
+                        .longValue();
+
+        assertNotNull(foundId, "Should find one of the duplicate nodes");
         assertTrue(
-                newNode.labels.containsKey("app"),
-                "Node should have app label from provided labels");
+                foundId.equals(node1.id) || foundId.equals(node2.id),
+                "Found ID should match one of the duplicate nodes");
     }
 
     @Test


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1526

## Description of the change:
See #1482 and #1486 . Corrects work done there to ensure a proper, cleaner separation between building the tree and creating database entities to persist it. The algorithm is like this:
1. Receive an event from k8s API server via Informer
2a. If event is a target loss, delete the Target and its associated (EndpointSlice) leaf DiscoveryNode, then walk up the ancestor lineage chain and delete each node if it has no other children - ie prune the leafless branches of the tree.
2b. Most importantly if event is an addition, we need to create a new Target and associated EndpointSlice leaf DiscoveryNode, then create the owner chain/ancestor lineage and link that back up to either an already existing common ancestor (ex. a ReplicaSet or its parent Deployment) or directly to the Namespace. We should build this tree branch using in-memory structures and the k8s API, and once we have the full shape of the new branch then we can begin a database transaction and commit all of the new entities.

In #1482 or #1486 the discovery mechanism tried to do better about handling database transaction boundaries to ensure atomic updates and minimize the number of transactions, but there was an unfortunate bug introduced where intermediate nodes (ex. ReplicaSet, Deployment) would be created and persisted outside of the expected tree structure. These aren't normally visible because they are not targets (so they don't appear in GET /api/v4/targets) and they aren't on any path from root node to leaf node (so they don't appear in GET /api/v4/discovery). But by enabling DEBUG logging on Cryostat, Hibernate's entity printer logs all entities that are being persisted and the pollution of disconnected intermediate nodes becomes apparent. Over time as the EndpointSlice discovery mechanism runs and emits new events or re-synchronizes, more and more of these nodes would be created, putting extra strain on Hibernate memory usage as well as database size, eventually slowing Cryostat's performance to a crawl or causing resource exhaustions.

Additionally, also does some cleanup on Credentials cleanup and Discovery Plugin (Agent) registration to better handle some failure cases.

## How to manually test:
1. Check out and build PR, tag like `quay.io/$myuser/cryostat:fix-1526-1` and push
2. Deploy in Kubernetes/OpenShift environment with Cryostat DEBUG logging enabled, ie `make cert_manager && oc project cryostat-operator && CORE_IMG=quay.io/$myuser/cryostat:fix-1526-1 make deploy && oc project cryostat && TARGET_NAMESPACES="apps1 apps2" make create_cryostat_cr`
3. Deploy EndpointSlice-discovered target application instances, ex. `oc project apps1 && make sample_app && oc scale deployment quarkus-test --replicas=12`
4. Check out Cryostat's logs, look for EntityPrinter `Listing entities:` and ensure that once all targets are discovered, over the next several minutes there are not new nodes being continuously created
