### PR TITLE
fix(liveness): perform self-check JMX request on probe

### DIFF
--- a/schema-generator/dependency-reduced-pom.xml
+++ b/schema-generator/dependency-reduced-pom.xml
@@ -103,7 +103,7 @@
   </build>
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
-    <com.diffplug.spotless.maven.plugin.version>3.4.0</com.diffplug.spotless.maven.plugin.version>
+    <com.diffplug.spotless.maven.plugin.version>3.5.1</com.diffplug.spotless.maven.plugin.version>
     <maven.compiler.source>21</maven.compiler.source>
     <com.mycila.license.maven.plugin.version>5.0.0</com.mycila.license.maven.plugin.version>
     <maven.compiler.target>21</maven.compiler.target>

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -3690,16 +3690,17 @@ paths:
   /health/liveness:
     get:
       description: |
-        Performs a no-op on a worker thread. This is a simply check to determine if
-        the application has available threads to service requests. HTTP 204 No Content
-        is the only expected response. If the application is not live and no worker
-        threads are available, then the client will never receive a response.
+        Performs a simple target connection request on a worker thread.
+        This is a simply check to determine if the application has available threads
+        to service requests. HTTP 204 No Content is the only expected response.
+        If the application is not live and no worker threads are available,
+        then the client will never receive a response.
       responses:
         "204":
           description: No Content
       summary: Check if the application is able to accept and respond to requests.
       tags:
-        - Health
+        - Liveness
 tags:
   - description: |
       Endpoints for Discovery Plugins to register with a Cryostat instance, refresh their registration

--- a/src/main/java/io/cryostat/Health.java
+++ b/src/main/java/io/cryostat/Health.java
@@ -125,26 +125,6 @@ class Health {
     }
 
     @GET
-    // This does not actually block, but we force it to execute on the worker pool so that the
-    // status check reports not only that the event loop dispatch thread is alive and responsive,
-    // but that the worker pool is also actively servicing requests. If we don't force this then
-    // this handler only checks if the event loop is alive, but the worker pool may be blocked or
-    // otherwise unresponsive and the application as a whole will not be usable.
-    @Blocking
-    @Path("/health/liveness")
-    @PermitAll
-    @Operation(
-            summary = "Check if the application is able to accept and respond to requests.",
-            description =
-                    """
-                    Performs a no-op on a worker thread. This is a simply check to determine if
-                    the application has available threads to service requests. HTTP 204 No Content
-                    is the only expected response. If the application is not live and no worker
-                    threads are available, then the client will never receive a response.
-                    """)
-    public void liveness() {}
-
-    @GET
     @Path("/api/v4/grafana_dashboard_url")
     @PermitAll
     @Produces({MediaType.APPLICATION_JSON})

--- a/src/main/java/io/cryostat/Liveness.java
+++ b/src/main/java/io/cryostat/Liveness.java
@@ -15,8 +15,16 @@
  */
 package io.cryostat;
 
+import java.net.URI;
+import java.util.Optional;
+
+import io.cryostat.targets.Target;
+import io.cryostat.targets.TargetConnectionManager;
+
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
 import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -24,12 +32,9 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 @Path("")
 class Liveness {
 
+    @Inject TargetConnectionManager tcm;
+
     @GET
-    // This does not actually block, but we force it to execute on the worker pool so that the
-    // status check reports not only that the event loop dispatch thread is alive and responsive,
-    // but that the worker pool is also actively servicing requests. If we don't force this then
-    // this handler only checks if the event loop is alive, but the worker pool may be blocked or
-    // otherwise unresponsive and the application as a whole will not be usable.
     @Blocking
     @Path("/health/liveness")
     @PermitAll
@@ -37,10 +42,15 @@ class Liveness {
             summary = "Check if the application is able to accept and respond to requests.",
             description =
                     """
-                    Performs a no-op on a worker thread. This is a simply check to determine if
-                    the application has available threads to service requests. HTTP 204 No Content
-                    is the only expected response. If the application is not live and no worker
-                    threads are available, then the client will never receive a response.
+                    Performs a simple target connection request on a worker thread.
+                    This is a simply check to determine if the application has available threads
+                    to service requests. HTTP 204 No Content is the only expected response.
+                    If the application is not live and no worker threads are available,
+                    then the client will never receive a response.
                     """)
-    public void liveness() {}
+    public Uni<Void> liveness() {
+        Target self = new Target();
+        self.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
+        return tcm.executeDirect(self, Optional.empty(), conn -> null);
+    }
 }

--- a/src/main/java/io/cryostat/Liveness.java
+++ b/src/main/java/io/cryostat/Liveness.java
@@ -34,6 +34,13 @@ class Liveness {
 
     @Inject TargetConnectionManager tcm;
 
+    static final Target SELF;
+
+    static {
+        SELF = new Target();
+        SELF.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
+    }
+
     @GET
     @Blocking
     @Path("/health/liveness")
@@ -49,10 +56,8 @@ class Liveness {
                     then the client will never receive a response.
                     """)
     public Uni<Void> liveness() {
-        Target self = new Target();
-        self.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
         return tcm.executeDirect(
-                self,
+                SELF,
                 Optional.empty(),
                 conn -> {
                     conn.getJvmIdentifier();

--- a/src/main/java/io/cryostat/Liveness.java
+++ b/src/main/java/io/cryostat/Liveness.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+@Path("")
+class Liveness {
+
+    @GET
+    // This does not actually block, but we force it to execute on the worker pool so that the
+    // status check reports not only that the event loop dispatch thread is alive and responsive,
+    // but that the worker pool is also actively servicing requests. If we don't force this then
+    // this handler only checks if the event loop is alive, but the worker pool may be blocked or
+    // otherwise unresponsive and the application as a whole will not be usable.
+    @Blocking
+    @Path("/health/liveness")
+    @PermitAll
+    @Operation(
+            summary = "Check if the application is able to accept and respond to requests.",
+            description =
+                    """
+                    Performs a no-op on a worker thread. This is a simply check to determine if
+                    the application has available threads to service requests. HTTP 204 No Content
+                    is the only expected response. If the application is not live and no worker
+                    threads are available, then the client will never receive a response.
+                    """)
+    public void liveness() {}
+}

--- a/src/main/java/io/cryostat/Liveness.java
+++ b/src/main/java/io/cryostat/Liveness.java
@@ -51,6 +51,12 @@ class Liveness {
     public Uni<Void> liveness() {
         Target self = new Target();
         self.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi");
-        return tcm.executeDirect(self, Optional.empty(), conn -> null);
+        return tcm.executeDirect(
+                self,
+                Optional.empty(),
+                conn -> {
+                    conn.getJvmIdentifier();
+                    return null;
+                });
     }
 }

--- a/src/test/java/io/cryostat/HealthTest.java
+++ b/src/test/java/io/cryostat/HealthTest.java
@@ -58,11 +58,6 @@ public class HealthTest {
     }
 
     @Test
-    public void testHealthLiveness() {
-        when().get("/health/liveness").then().statusCode(204);
-    }
-
-    @Test
     public void testGrafanaDashboardUrl() {
         when().get("/api/v4/grafana_dashboard_url")
                 .then()

--- a/src/test/java/io/cryostat/LivenessTest.java
+++ b/src/test/java/io/cryostat/LivenessTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat;
+
+import static io.restassured.RestAssured.when;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestHTTPEndpoint(Liveness.class)
+public class LivenessTest {
+
+    @Test
+    public void testHealthLiveness() {
+        when().get("/health/liveness").then().statusCode(204);
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1546

## Description of the change:
Rather than simply executing a no-op request on a worker thread to check Cryostat's liveness, this patch causes Cryostat to try to open a `localhost:0` self-connection using JMX and to compute its own hash ID - then return `null`, which is mapped to an HTTP 204 response, same as before.

## Motivation for the change:
See #1546 . Opening a `localhost:0` JMX connection and doing some minimal work using that connection helps ensure that Cryostat is actually able to open new target connections and perform meaningful work. `localhost:0` should always be an available, connectable, low-latency "target connection", so the probe should still execute quickly. If the connection fails or takes too long and times out, then the container platform which is running Cryostat and probing the endpoint (ex. Kubernetes/OpenShift or Docker/Podman) can detect that Cryostat is in a degraded state and restart it, hopefully restoring functionality.