### PR TITLE
fix(async): do not use await().indefinitely(), always cap at connection timeout

### DIFF
--- a/src/main/java/io/cryostat/graphql/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ActiveRecordings.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.discovery.DiscoveryNode;
 import io.cryostat.graphql.RootNode.DiscoveryNodeFilter;
 import io.cryostat.graphql.TargetNodes.RecordingAggregateInfo;
@@ -44,6 +45,7 @@ import io.smallrye.graphql.api.Nullable;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jdk.jfr.RecordingState;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
@@ -56,6 +58,9 @@ public class ActiveRecordings {
 
     @Inject RecordingHelper recordingHelper;
     @Inject Logger logger;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
 
     @Transactional
     @Mutation
@@ -205,7 +210,8 @@ public class ActiveRecordings {
                         .toList();
         var snapshots = new ArrayList<ActiveRecording>();
         for (var t : targets) {
-            snapshots.add(recordingHelper.createSnapshot(t).await().indefinitely());
+            snapshots.add(
+                    recordingHelper.createSnapshot(t).await().atMost(connectionFailedTimeout));
         }
         return snapshots;
     }
@@ -229,28 +235,28 @@ public class ActiveRecordings {
                         recording.asOptions(),
                         Optional.ofNullable(recording.metadata).map(s -> s.labels).orElse(Map.of()))
                 .await()
-                .indefinitely();
+                .atMost(connectionFailedTimeout);
     }
 
     @Transactional
     @Description("Create a new Flight Recorder Snapshot on the specified Target")
     public ActiveRecording doSnapshot(@Source Target target) {
         var fTarget = Target.getTargetById(target.id);
-        return recordingHelper.createSnapshot(fTarget).await().indefinitely();
+        return recordingHelper.createSnapshot(fTarget).await().atMost(connectionFailedTimeout);
     }
 
     @Transactional
     @Description("Stop the specified Flight Recording")
     public ActiveRecording doStop(@Source ActiveRecording recording) throws Exception {
         var ar = ActiveRecording.<ActiveRecording>find("id", recording.id).singleResult();
-        return recordingHelper.stopRecording(ar).await().indefinitely();
+        return recordingHelper.stopRecording(ar).await().atMost(connectionFailedTimeout);
     }
 
     @Transactional
     @Description("Delete the specified Flight Recording")
     public ActiveRecording doDelete(@Source ActiveRecording recording) {
         var ar = ActiveRecording.<ActiveRecording>find("id", recording.id).singleResult();
-        return recordingHelper.deleteRecording(ar).await().indefinitely();
+        return recordingHelper.deleteRecording(ar).await().atMost(connectionFailedTimeout);
     }
 
     @Description("Archive the specified Flight Recording")

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.libcryostat.templates.Template;
 import io.cryostat.libcryostat.templates.TemplateType;
 import io.cryostat.recordings.LongRunningRequestGenerator.ArchiveRequest;
@@ -54,6 +55,7 @@ import jakarta.ws.rs.core.UriInfo;
 import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.logging.Logger;
@@ -70,6 +72,9 @@ public class ActiveRecordings {
     @Inject LongRunningRequestGenerator generator;
     @Inject EventBus bus;
     @Inject Logger logger;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
 
     @GET
     @Blocking
@@ -144,7 +149,10 @@ public class ActiveRecordings {
         ActiveRecording activeRecording = recording.get();
         switch (body.strip().toLowerCase()) {
             case "stop":
-                recordingHelper.stopRecording(activeRecording).await().indefinitely();
+                recordingHelper
+                        .stopRecording(activeRecording)
+                        .await()
+                        .atMost(connectionFailedTimeout);
                 return null;
             case "save":
                 ArchiveRequest request =
@@ -260,7 +268,7 @@ public class ActiveRecordings {
         if (recording == null) {
             throw new NotFoundException();
         }
-        recordingHelper.deleteRecording(recording).await().indefinitely();
+        recordingHelper.deleteRecording(recording).await().atMost(connectionFailedTimeout);
     }
 
     @POST

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -99,6 +99,9 @@ public class LongRunningRequestGenerator {
     @ConfigProperty(name = ConfigProperties.CONNECTIONS_UPLOAD_TIMEOUT)
     Duration uploadFailedTimeout;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     public LongRunningRequestGenerator() {}
 
     @ConsumeEvent(value = THREAD_DUMP_ADDRESS, blocking = true)
@@ -162,7 +165,7 @@ public class LongRunningRequestGenerator {
                             new ArchiveRecordingSuccessPayload(
                                     request.id(), rec.name(), rec.reportUrl(), rec.downloadUrl())));
             if (request.deleteOnCompletion) {
-                recordingHelper.deleteRecording(recording).await().indefinitely();
+                recordingHelper.deleteRecording(recording).await().atMost(connectionFailedTimeout);
             }
             return rec;
         } catch (Exception e) {

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -476,7 +476,7 @@ public class RecordingHelper {
             throw new EntityExistsException("Recording", recordingName);
         }
         getActiveRecording(lockedTarget, r -> r.name.equals(recordingName))
-                .ifPresent(r -> this.deleteRecording(r).await().indefinitely());
+                .ifPresent(r -> this.deleteRecording(r).await().atMost(connectionFailedTimeout));
 
         IRecordingDescriptor desc;
         try {
@@ -1610,6 +1610,9 @@ public class RecordingHelper {
         @Inject RecordingHelper recordingHelper;
         @Inject Logger logger;
 
+        @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+        Duration connectionFailedTimeout;
+
         @Override
         @Transactional
         public void execute(JobExecutionContext ctx) throws JobExecutionException {
@@ -1617,7 +1620,7 @@ public class RecordingHelper {
                 ActiveRecording recording =
                         ActiveRecording.find("id", ctx.getMergedJobDataMap().get("recordingId"))
                                 .singleResult();
-                recordingHelper.stopRecording(recording).await().indefinitely();
+                recordingHelper.stopRecording(recording).await().atMost(connectionFailedTimeout);
             } catch (Exception e) {
                 var jee = new JobExecutionException(e);
                 jee.setUnscheduleFiringTrigger(true);

--- a/src/main/java/io/cryostat/reports/Reports.java
+++ b/src/main/java/io/cryostat/reports/Reports.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.reports;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
@@ -71,6 +72,9 @@ public class Reports {
     @ConfigProperty(name = ConfigProperties.REPORTS_STORAGE_CACHE_ENABLED)
     boolean storageCacheEnabled;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     @ConfigProperty(name = ConfigProperties.ARCHIVED_REPORTS_STORAGE_CACHE_NAME)
     String bucket;
 
@@ -121,7 +125,7 @@ public class Reports {
                             reportsService
                                     .reportFor(pair.getKey(), pair.getValue())
                                     .await()
-                                    .indefinitely(),
+                                    .atMost(connectionFailedTimeout),
                             MediaType.APPLICATION_JSON)
                     .status(200)
                     .build();
@@ -265,7 +269,10 @@ public class Reports {
         // Check if we've already cached a result for this report, return it if so
         if (reportsService.keyExists(recording)) {
             return Response.ok(
-                            reportsService.reportFor(recording).await().indefinitely(),
+                            reportsService
+                                    .reportFor(recording)
+                                    .await()
+                                    .atMost(connectionFailedTimeout),
                             MediaType.APPLICATION_JSON)
                     .status(Response.Status.OK)
                     .build();

--- a/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
+++ b/src/main/java/io/cryostat/reports/StorageCachingReportsService.java
@@ -75,6 +75,9 @@ class StorageCachingReportsService implements ReportsService {
     @ConfigProperty(name = ConfigProperties.ARCHIVED_REPORTS_EXPIRY_DURATION)
     Duration expiry;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     @Inject S3Client storage;
     @Inject S3TransferManager transferManager;
     @Inject ObjectMapper mapper;
@@ -198,13 +201,13 @@ class StorageCachingReportsService implements ReportsService {
     @Override
     public boolean keyExists(ActiveRecording recording) {
         String key = ReportsService.key(recording);
-        return enabled && checkStorage(key).await().indefinitely();
+        return enabled && checkStorage(key).await().atMost(connectionFailedTimeout);
     }
 
     @Override
     public boolean keyExists(String jvmId, String filename) {
         String key = RecordingHelper.archivedRecordingKey(jvmId, filename);
-        return enabled && checkStorage(key).await().indefinitely();
+        return enabled && checkStorage(key).await().atMost(connectionFailedTimeout);
     }
 
     private String suffixKey(String key) {

--- a/src/main/java/io/cryostat/rules/RecordingCleanupJob.java
+++ b/src/main/java/io/cryostat/rules/RecordingCleanupJob.java
@@ -15,7 +15,12 @@
  */
 package io.cryostat.rules;
 
+import java.time.Duration;
+
+import io.cryostat.ConfigProperties;
+
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
@@ -37,6 +42,9 @@ public class RecordingCleanupJob implements Job {
     @Inject Logger logger;
     @Inject RuleService ruleService;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     @Override
     public void execute(JobExecutionContext ctx) throws JobExecutionException {
         String ruleName = ctx.getMergedJobDataMap().getString("ruleName");
@@ -48,7 +56,10 @@ public class RecordingCleanupJob implements Job {
                 ruleName, jvmId, recordingName);
 
         try {
-            ruleService.cleanupRecording(ruleName, jvmId, recordingName).await().indefinitely();
+            ruleService
+                    .cleanupRecording(ruleName, jvmId, recordingName)
+                    .await()
+                    .atMost(connectionFailedTimeout);
             logger.debugv("Recording cleanup completed: rule={0} jvmId={1}", ruleName, jvmId);
             ctx.getScheduler().unscheduleJob(ctx.getTrigger().getKey());
         } catch (Exception e) {

--- a/src/main/java/io/cryostat/rules/RuleActivationJob.java
+++ b/src/main/java/io/cryostat/rules/RuleActivationJob.java
@@ -15,7 +15,12 @@
  */
 package io.cryostat.rules;
 
+import java.time.Duration;
+
+import io.cryostat.ConfigProperties;
+
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
@@ -37,6 +42,9 @@ public class RuleActivationJob implements Job {
     @Inject Logger logger;
     @Inject RuleService ruleService;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     @Override
     public void execute(JobExecutionContext ctx) throws JobExecutionException {
         String ruleName = ctx.getMergedJobDataMap().getString("ruleName");
@@ -45,7 +53,7 @@ public class RuleActivationJob implements Job {
         logger.debugv("Executing rule activation job: rule={0} jvmId={1}", ruleName, jvmId);
 
         try {
-            ruleService.activateRule(ruleName, jvmId).await().indefinitely();
+            ruleService.activateRule(ruleName, jvmId).await().atMost(connectionFailedTimeout);
             logger.debugv("Rule activation completed: rule={0} jvmId={1}", ruleName, jvmId);
             ctx.getScheduler().unscheduleJob(ctx.getTrigger().getKey());
         } catch (Exception e) {

--- a/src/main/java/io/cryostat/rules/RuleExecutor.java
+++ b/src/main/java/io/cryostat/rules/RuleExecutor.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.rules;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.expressions.MatchExpressionEvaluator;
 import io.cryostat.libcryostat.templates.Template;
 import io.cryostat.libcryostat.templates.TemplateType;
@@ -45,6 +47,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -76,6 +79,9 @@ public class RuleExecutor {
     @Inject RecordingHelper recordingHelper;
     @Inject MatchExpressionEvaluator evaluator;
     @Inject Scheduler quartz;
+
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
 
     void onStop(@Observes ShutdownEvent evt) throws SchedulerException {
         quartz.shutdown();
@@ -147,7 +153,10 @@ public class RuleExecutor {
                     recordingHelper.getActiveRecording(
                             target, r -> Objects.equals(r.name, rule.getRecordingName()));
             if (priorRecording.isPresent()) {
-                recordingHelper.stopRecording(priorRecording.get()).await().indefinitely();
+                recordingHelper
+                        .stopRecording(priorRecording.get())
+                        .await()
+                        .atMost(connectionFailedTimeout);
             }
             var labels = new HashMap<>(rule.metadata.labels());
             labels.put(RULE_LABEL_KEY, rule.name);
@@ -162,7 +171,7 @@ public class RuleExecutor {
                                         createRecordingOptions(rule),
                                         labels)
                                 .await()
-                                .atMost(java.time.Duration.ofSeconds(30));
+                                .atMost(connectionFailedTimeout);
             } catch (EntityExistsException eee) {
                 logger.debugv(
                         "Recording \"{0}\" already exists on target {1}, fetching existing"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1546
See #1067

## Description of the change:
Replaces calls to `.await().indefinitely()` on `Uni`s with `.await().atMost(connectionFailedTimeout)`. This is an injected configuration property which defaults to 10 seconds.

## Motivation for the change:
Each of the source `Uni`s being awaited here is not expected to actually take much time. Some are to do with Automated Analysis Report caching, which is tiered with in-memory cache (should be very fast) and object storage cache (should not exceed 10 seconds to retrieve a report JSON document). Others are to do with creating snapshot Flight Recordings, stopping running recordings, or deleting active recordings - all of which are also operations which should execute quite quickly, unless the prerequisite network connection fails or times out.

Error handling on the source `Uni`s should result in error emissions and propagation through the chain, including upstream failures for scenarios like connection timeouts, but in case the upstream error handling is incomplete or has a bug, it's best to apply the same kind of await timeout to the downstream subscriber as well to ensure that threads aren't blocked indefinitely.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -Or -t quarkus-cryostat-agent`
3. Click around and exercise various functionalities, ensure everything works as expected
