### PR TITLE
fix(discovery): Agent fill algo reuses existing Namespace nodes, GraphQL handles nullable filters

### DIFF
--- a/src/main/java/io/cryostat/credentials/Credential.java
+++ b/src/main/java/io/cryostat/credentials/Credential.java
@@ -119,11 +119,7 @@ public class Credential extends PanacheEntity {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String password;
 
-    @OneToOne(
-            optional = true,
-            fetch = FetchType.LAZY,
-            mappedBy = "credential",
-            cascade = CascadeType.REMOVE)
+    @OneToOne(optional = true, fetch = FetchType.LAZY, mappedBy = "credential")
     @JoinColumn(name = "discoveryPlugin_id")
     @JsonIgnore
     @Nullable

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -562,6 +562,15 @@ public class Discovery {
                                         new IllegalArgumentException(
                                                 String.format("%s cannot be blank", key)));
                             }
+
+                            DiscoveryNode k8sRealm =
+                                    DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new IllegalStateException(
+                                                                    "KubernetesApi realm not"
+                                                                            + " found"));
+
                             DiscoveryNode nsNode =
                                     DiscoveryNode.<DiscoveryNode>find(
                                                     "#DiscoveryNode.byTypeWithName",
@@ -581,24 +590,19 @@ public class Discovery {
                                                         newNs.labels = new HashMap<>();
                                                         newNs.children = new ArrayList<>();
                                                         newNs.target = null;
-                                                        newNs.parent = realm;
+                                                        newNs.parent = k8sRealm;
                                                         newNs.persist();
                                                         return newNs;
                                                     });
 
-                            if (nsNode.parent == null) {
-                                nsNode.parent = realm;
+                            if (nsNode.parent == null || !nsNode.parent.equals(k8sRealm)) {
+                                nsNode.parent = k8sRealm;
                             }
 
                             DiscoveryNode lineage =
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
                             DiscoveryNode innermost = innermostNode(lineage);
                             innermost.children.addAll(body.nodes);
-                            body.nodes.forEach(
-                                    n -> {
-                                        n.parent = innermost;
-                                        n.persist();
-                                    });
 
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);
@@ -610,9 +614,17 @@ public class Discovery {
                                 current.persist();
                                 current = current.parent;
                             }
-
                             nsNode.persist();
-                            replacementChildren.add(nsNode);
+
+                            body.nodes.forEach(
+                                    n -> {
+                                        n.parent = realm;
+                                        n.labels.put("discovery.cryostat.io/pod", innermost.name);
+                                        n.labels.put("discovery.cryostat.io/namespace", namespace);
+                                        n.persist();
+                                    });
+
+                            replacementChildren.addAll(body.nodes);
                             break;
                         default:
                             replacementChildren.addAll(body.nodes);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -700,10 +700,14 @@ public class Discovery {
     }
 
     private static void cleanupPluginNodes(DiscoveryPlugin plugin) {
+        cleanupPluginNodes(plugin.id);
+    }
+
+    private static void cleanupPluginNodes(UUID pluginId) {
         // Clean up target nodes that belong to this plugin
         // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with plugin ID
         // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is deleted
-        List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(plugin.id.toString());
+        List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
         for (DiscoveryNode node : pluginNodes) {
             node.delete();
         }
@@ -1002,6 +1006,13 @@ public class Discovery {
                     logger.warnv(
                             "Unscheduled job for unknown discovery plugin: {0}",
                             context.getMergedJobDataMap().get(PLUGIN_ID_MAP_KEY));
+
+                    // Clean up any orphaned nodes before unscheduling
+                    if (noSuchPlugin) {
+                        QuarkusTransaction.joiningExisting()
+                                .run(() -> cleanupPluginNodes(pluginId));
+                    }
+
                     var ex = new JobExecutionException(e);
                     ex.setUnscheduleFiringTrigger(true);
                     throw ex;

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import io.cryostat.ConfigProperties;
 import io.cryostat.credentials.Credential;
 import io.cryostat.discovery.DiscoveryPlugin.PluginCallback;
+import io.cryostat.discovery.DiscoveryPlugin.PluginCleanupHelper;
 import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType;
 import io.cryostat.discovery.NodeType.BaseNodeType;
 import io.cryostat.targets.TargetConnectionManager;
@@ -60,7 +61,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -671,23 +671,15 @@ public class Discovery {
             @RestPath UUID id,
             @RestHeader("Cryostat-Discovery-Authentication") String token)
             throws SchedulerException {
-        DiscoveryPlugin plugin;
-        try {
-            plugin = DiscoveryPlugin.find("id", id).singleResult();
-        } catch (NoResultException e) {
-            cleanupHelper.cleanupPluginNodes(id);
-            Set<JobKey> jobKeys = new HashSet<>();
-            jobKeys.addAll(scheduler.getJobKeys(GroupMatcher.jobGroupEquals(JOB_PERIODIC)));
-            for (var key : jobKeys) {
-                if (Objects.equals(id.toString(), key.getName())) {
-                    scheduler.deleteJob(key);
-                }
-            }
-
+        DiscoveryPlugin plugin = DiscoveryPlugin.findById(id);
+        if (plugin == null) {
+            logger.debugv("Could not find registered plugin with ID {0}", id);
             throw new NotFoundException();
         }
 
         if (plugin.builtin) {
+            logger.debugv(
+                    "Refusing to delete built-in plugin with ID {0} ({1})", id, plugin.realm.name);
             throw new ForbiddenException();
         }
         try {
@@ -698,6 +690,7 @@ public class Discovery {
                 | SocketException
                 | JOSEException
                 | ParseException e) {
+            logger.debugv("Refusing to delete plugin ID {0} due to invalid JWT", id);
             throw new BadRequestException(e);
         }
 
@@ -710,7 +703,6 @@ public class Discovery {
             scheduler.deleteJob(key);
         }
 
-        cleanupHelper.cleanupPluginNodes(plugin);
         plugin.delete();
     }
 
@@ -872,18 +864,6 @@ public class Discovery {
         return mergedRoot;
     }
 
-    /**
-     * Get the innermost node of a hierarchical lineage. This assumes that the ancestor node passed
-     * in is the root of a tree where each node has either 0 or 1 children.
-     */
-    private DiscoveryNode innermostNode(DiscoveryNode ancestor) {
-        DiscoveryNode node = ancestor;
-        while (node.hasChildren()) {
-            node = node.children.get(0);
-        }
-        return node;
-    }
-
     private DiscoveryNode copyNode(DiscoveryNode source) {
         var copy = new DiscoveryNode();
         copy.id = source.id;
@@ -959,94 +939,6 @@ public class Discovery {
 
     private static record NodeContext(
             DiscoveryNode node, DiscoveryNode parent, boolean fromBuiltin) {}
-
-    /**
-     * Helper class for plugin cleanup operations. This is separate to allow reuse from both
-     * instance methods and static inner classes.
-     */
-    @ApplicationScoped
-    static class PluginCleanupHelper {
-
-        @Inject EntityManager entityManager;
-        @Inject Logger logger;
-
-        void cleanupPluginNodes(DiscoveryPlugin plugin) {
-            cleanupPluginNodes(plugin.id);
-        }
-
-        void cleanupPluginNodes(UUID pluginId) {
-            // Clean up target nodes that belong to this plugin
-            // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with
-            // plugin ID
-            // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is
-            // deleted
-            List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
-            if (pluginNodes == null || pluginNodes.isEmpty()) {
-                return;
-            }
-            for (DiscoveryNode node : pluginNodes) {
-                try {
-                    DiscoveryNode parent = node.parent;
-                    if (parent != null) {
-                        // Remove node from parent's collection before deleting
-                        // This ensures parent.hasChildren() will be accurate
-                        parent.children.remove(node);
-                        node.parent = null;
-                    }
-                    node.delete();
-                    // Recursively prune empty parent nodes up the tree
-                    pruneEmptyAncestors(parent);
-                } catch (Exception e) {
-                    logger.warn(e);
-                }
-            }
-        }
-
-        void pruneEmptyAncestors(DiscoveryNode child) {
-            // Walk up the hierarchy, removing childless nodes from their parents
-            // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
-            while (child != null) {
-                DiscoveryNode parent = child.parent;
-
-                if (parent == null) {
-                    logger.debugv(
-                            "Reached orphaned node {0} (id={1}), relying on orphan removal",
-                            child.name, child.id);
-                    break;
-                }
-
-                entityManager.refresh(parent); // Reload from DB with current children
-
-                // Remove child from parent's collection - orphan removal will delete it
-                parent.children.remove(child);
-                child.parent = null;
-
-                boolean hasChildren = parent.hasChildren();
-                boolean isNamespace =
-                        parent.nodeType.equals(KubeDiscoveryNodeType.NAMESPACE.getKind());
-                boolean isRealm = parent.nodeType.equals("Realm");
-
-                logger.debugv(
-                        "Parent node {0} (id={1}, type={2}): hasChildren={3}, isNamespace={4},"
-                                + " isRealm={5}",
-                        parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
-
-                // Stop pruning if:
-                // 1. Parent is a Realm (always preserve Realms)
-                // 2. Parent has children (preserve non-empty nodes)
-                // Note: Empty Namespaces should be pruned, so we don't stop just because it's a
-                // Namespace
-                if (isRealm || hasChildren) {
-                    logger.debugv("Stopping pruning at parent node {0}", parent.name);
-                    break;
-                }
-
-                logger.debugv("Continuing to prune parent node {0}", parent.name);
-                // Move up to check the parent too
-                child = parent;
-            }
-        }
-    }
 
     /**
      * Check that discovery plugins are still alive/reachable and prompt them to regenerate expiring
@@ -1194,7 +1086,6 @@ public class Discovery {
                                                     p.consecutiveFailures,
                                                     p.realm.name,
                                                     p.callback);
-                                            cleanupHelper.cleanupPluginNodes(p);
                                             p.delete();
                                         } else {
                                             logger.warnv(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -572,6 +572,8 @@ public class Discovery {
                                         n.persist();
                                     });
 
+                            entityManager.flush();
+
                             DiscoveryNode nsNode =
                                     DiscoveryNode.<DiscoveryNode>find(
                                                     "#DiscoveryNode.byTypeWithName",

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -75,6 +75,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -674,12 +675,7 @@ public class Discovery {
         try {
             plugin = DiscoveryPlugin.find("id", id).singleResult();
         } catch (NoResultException e) {
-            // Plugin already deleted, but we should still clean up any orphaned nodes
-            logger.warnv(
-                    "Plugin {0} not found during deregistration, cleaning up orphaned nodes", id);
             cleanupHelper.cleanupPluginNodes(id);
-
-            // Also try to delete the scheduled job
             Set<JobKey> jobKeys = new HashSet<>();
             jobKeys.addAll(scheduler.getJobKeys(GroupMatcher.jobGroupEquals(JOB_PERIODIC)));
             for (var key : jobKeys) {
@@ -687,7 +683,8 @@ public class Discovery {
                     scheduler.deleteJob(key);
                 }
             }
-            return;
+
+            throw new NotFoundException();
         }
 
         if (plugin.builtin) {

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -121,6 +121,10 @@ public class Discovery {
     private static final String PLUGIN_ID_MAP_KEY = "pluginId";
     private static final String REFRESH_MAP_KEY = "refresh";
 
+    public static final String DISCOVERY_PLUGIN_LABEL_PREFIX = "discovery.cryostat.io/";
+    public static final String DISCOVERY_PLUGIN_ID_LABEL_KEY =
+            DISCOVERY_PLUGIN_LABEL_PREFIX + "plugin-id";
+
     @ConfigProperty(name = ConfigProperties.DISCOVERY_PLUGINS_PING_PERIOD)
     Duration discoveryPingPeriod;
 
@@ -602,29 +606,32 @@ public class Discovery {
                             DiscoveryNode lineage =
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
                             DiscoveryNode innermost = innermostNode(lineage);
-                            innermost.children.addAll(body.nodes);
 
+                            // Add lineage to Namespace if not already present
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);
                             }
                             lineage.parent = nsNode;
 
+                            innermost.children.addAll(body.nodes);
+                            body.nodes.forEach(
+                                    n -> {
+                                        n.parent = innermost;
+                                        n.labels.put(
+                                                DISCOVERY_PLUGIN_ID_LABEL_KEY,
+                                                plugin.id.toString());
+                                        n.persist();
+                                    });
+
+                            // Persist the k8s lineage hierarchy under KubernetesApi Realm
                             DiscoveryNode current = innermost;
                             while (current != null && current != nsNode) {
                                 current.persist();
                                 current = current.parent;
                             }
                             nsNode.persist();
-
-                            body.nodes.forEach(
-                                    n -> {
-                                        n.parent = realm;
-                                        n.labels.put("discovery.cryostat.io/pod", innermost.name);
-                                        n.labels.put("discovery.cryostat.io/namespace", namespace);
-                                        n.persist();
-                                    });
-
-                            replacementChildren.addAll(body.nodes);
+                            // Agent Realm remains empty - targets are under KubernetesApi. Labels
+                            // are used for cleanup when the plugin goes offline.
                             break;
                         default:
                             replacementChildren.addAll(body.nodes);
@@ -687,7 +694,19 @@ public class Discovery {
             }
             scheduler.deleteJob(key);
         }
+
+        cleanupPluginNodes(plugin);
         plugin.delete();
+    }
+
+    private static void cleanupPluginNodes(DiscoveryPlugin plugin) {
+        // Clean up target nodes that belong to this plugin
+        // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with plugin ID
+        // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is deleted
+        List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(plugin.id.toString());
+        for (DiscoveryNode node : pluginNodes) {
+            node.delete();
+        }
     }
 
     @GET
@@ -1025,6 +1044,7 @@ public class Discovery {
                                                     p.consecutiveFailures,
                                                     p.realm.name,
                                                     p.callback);
+                                            cleanupPluginNodes(p);
                                             p.delete();
                                         } else {
                                             logger.warnv(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -562,18 +562,6 @@ public class Discovery {
                                         new IllegalArgumentException(
                                                 String.format("%s cannot be blank", key)));
                             }
-                            DiscoveryNode lineage =
-                                    k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
-                            DiscoveryNode innermost = innermostNode(lineage);
-                            innermost.children.addAll(body.nodes);
-                            body.nodes.forEach(
-                                    n -> {
-                                        n.parent = innermost;
-                                        n.persist();
-                                    });
-
-                            entityManager.flush();
-
                             DiscoveryNode nsNode =
                                     DiscoveryNode.<DiscoveryNode>find(
                                                     "#DiscoveryNode.byTypeWithName",
@@ -593,29 +581,26 @@ public class Discovery {
                                                         newNs.labels = new HashMap<>();
                                                         newNs.children = new ArrayList<>();
                                                         newNs.target = null;
+                                                        newNs.parent = realm;
+                                                        newNs.persist();
                                                         return newNs;
                                                     });
 
-                            // Set parent relationship for new namespace nodes
                             if (nsNode.parent == null) {
                                 nsNode.parent = realm;
                             }
+
+                            DiscoveryNode lineage =
+                                    k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
+                            DiscoveryNode innermost = innermostNode(lineage);
+                            innermost.children.addAll(body.nodes);
+                            body.nodes.forEach(n -> n.parent = innermost);
 
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);
                             }
                             lineage.parent = nsNode;
 
-                            DiscoveryNode current = innermost;
-                            while (true) {
-                                current.persist();
-                                current = current.parent;
-                                if (current == null) {
-                                    break;
-                                }
-                            }
-
-                            nsNode.persist();
                             replacementChildren.add(nsNode);
                             break;
                         default:

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -591,6 +591,7 @@ public class Discovery {
                                                         newNs.labels = new HashMap<>();
                                                         newNs.children = new ArrayList<>();
                                                         newNs.target = null;
+                                                        newNs.persist();
                                                         return newNs;
                                                     });
 

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -695,21 +695,73 @@ public class Discovery {
             scheduler.deleteJob(key);
         }
 
-        cleanupPluginNodes(plugin);
+        cleanupPluginNodes(entityManager, logger, plugin);
         plugin.delete();
     }
 
-    private static void cleanupPluginNodes(DiscoveryPlugin plugin) {
-        cleanupPluginNodes(plugin.id);
+    private static void cleanupPluginNodes(
+            EntityManager entityManager, Logger logger, DiscoveryPlugin plugin) {
+        cleanupPluginNodes(entityManager, logger, plugin.id);
     }
 
-    private static void cleanupPluginNodes(UUID pluginId) {
+    private static void cleanupPluginNodes(
+            EntityManager entityManager, Logger logger, UUID pluginId) {
         // Clean up target nodes that belong to this plugin
         // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with plugin ID
         // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is deleted
         List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
+        if (pluginNodes == null || pluginNodes.isEmpty()) {
+            return;
+        }
         for (DiscoveryNode node : pluginNodes) {
-            node.delete();
+            try {
+                DiscoveryNode parent = node.parent;
+                node.delete();
+                // Recursively prune empty parent nodes up the tree
+                pruneEmptyAncestors(entityManager, logger, parent);
+            } catch (Exception e) {
+                logger.warn(e);
+            }
+        }
+    }
+
+    private static void pruneEmptyAncestors(
+            EntityManager entityManager, Logger logger, DiscoveryNode child) {
+        // Walk up the hierarchy, removing childless nodes from their parents
+        // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
+        while (child != null) {
+            DiscoveryNode parent = child.parent;
+
+            if (parent == null) {
+                logger.debugv(
+                        "Reached orphaned node {0} (id={1}), relying on orphan removal",
+                        child.name, child.id);
+                break;
+            }
+
+            entityManager.refresh(parent); // Reload from DB with current children
+
+            // Remove child from parent's collection - orphan removal will delete it
+            parent.children.remove(child);
+            child.parent = null;
+
+            boolean hasChildren = parent.hasChildren();
+            boolean isNamespace = parent.nodeType.equals(KubeDiscoveryNodeType.NAMESPACE.getKind());
+            boolean isRealm = parent.nodeType.equals("Realm");
+
+            logger.debugv(
+                    "Parent node {0} (id={1}, type={2}): hasChildren={3}, isNamespace={4},"
+                            + " isRealm={5}",
+                    parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
+
+            if (hasChildren || isNamespace || isRealm) {
+                logger.debugv("Stopping pruning at parent node {0}", parent.name);
+                break;
+            }
+
+            logger.debugv("Continuing to prune parent node {0}", parent.name);
+            // Move up to check the parent too
+            child = parent;
         }
     }
 
@@ -1010,7 +1062,7 @@ public class Discovery {
                     // Clean up any orphaned nodes before unscheduling
                     if (noSuchPlugin) {
                         QuarkusTransaction.joiningExisting()
-                                .run(() -> cleanupPluginNodes(pluginId));
+                                .run(() -> cleanupPluginNodes(entityManager, logger, pluginId));
                     }
 
                     var ex = new JobExecutionException(e);
@@ -1055,7 +1107,7 @@ public class Discovery {
                                                     p.consecutiveFailures,
                                                     p.realm.name,
                                                     p.callback);
-                                            cleanupPluginNodes(p);
+                                            cleanupPluginNodes(entityManager, logger, p);
                                             p.delete();
                                         } else {
                                             logger.warnv(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -51,6 +51,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.proc.BadJWTException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.panache.common.Parameters;
 import io.quarkus.runtime.ShutdownEvent;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.faulttolerance.api.RateLimit;
@@ -571,14 +572,31 @@ public class Discovery {
                                         n.persist();
                                     });
 
-                            DiscoveryNode nsNode = new DiscoveryNode();
-                            nsNode.name = namespace;
-                            nsNode.nodeType = KubeDiscoveryNodeType.NAMESPACE.getKind();
-                            nsNode.labels = new HashMap<>();
-                            nsNode.children = new ArrayList<>();
-                            nsNode.target = null;
+                            DiscoveryNode nsNode =
+                                    DiscoveryNode.<DiscoveryNode>find(
+                                                    "#DiscoveryNode.byTypeWithName",
+                                                    Parameters.with(
+                                                                    "nodeType",
+                                                                    KubeDiscoveryNodeType.NAMESPACE
+                                                                            .getKind())
+                                                            .and("name", namespace))
+                                            .firstResultOptional()
+                                            .orElseGet(
+                                                    () -> {
+                                                        DiscoveryNode newNs = new DiscoveryNode();
+                                                        newNs.name = namespace;
+                                                        newNs.nodeType =
+                                                                KubeDiscoveryNodeType.NAMESPACE
+                                                                        .getKind();
+                                                        newNs.labels = new HashMap<>();
+                                                        newNs.children = new ArrayList<>();
+                                                        newNs.target = null;
+                                                        return newNs;
+                                                    });
 
-                            nsNode.children.add(lineage);
+                            if (!nsNode.children.contains(lineage)) {
+                                nsNode.children.add(lineage);
+                            }
                             lineage.parent = nsNode;
 
                             DiscoveryNode current = innermost;

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -607,13 +607,10 @@ public class Discovery {
 
                             DiscoveryNode lineage =
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
-                            DiscoveryNode innermost = innermostNode(lineage);
 
-                            // Add lineage to Namespace if not already present
-                            if (!nsNode.children.contains(lineage)) {
-                                nsNode.children.add(lineage);
-                            }
-                            lineage.parent = nsNode;
+                            // Merge the lineage into the existing tree, reusing nodes where
+                            // possible
+                            DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
 
                             innermost.children.addAll(body.nodes);
                             body.nodes.forEach(
@@ -911,6 +908,56 @@ public class Discovery {
         if (source.target != null) {
             target.target = source.target;
         }
+    }
+
+    /**
+     * Merges a lineage chain into an existing tree, reusing nodes where possible. This walks down
+     * the lineage chain and at each level checks if a node with the same name and type already
+     * exists as a child of the parent. If it does, reuses that node; if not, adds the new node.
+     *
+     * @param parent The parent node to merge the lineage into (typically a Namespace node)
+     * @param lineage The root of the lineage chain to merge (typically a Deployment node)
+     * @return The innermost (leaf) node of the merged lineage
+     */
+    private DiscoveryNode mergeLineageIntoTree(DiscoveryNode parent, DiscoveryNode lineage) {
+        DiscoveryNode currentParent = parent;
+        DiscoveryNode currentLineage = lineage;
+
+        while (currentLineage != null) {
+            // Check if a node with the same name and type already exists as a child
+            final DiscoveryNode lineageNode = currentLineage;
+            DiscoveryNode existingNode =
+                    currentParent.children.stream()
+                            .filter(
+                                    child ->
+                                            child.name.equals(lineageNode.name)
+                                                    && child.nodeType.equals(lineageNode.nodeType))
+                            .findFirst()
+                            .orElse(null);
+
+            if (existingNode != null) {
+                // Reuse the existing node
+                // Merge labels from the new lineage into the existing node
+                if (lineageNode.labels != null) {
+                    existingNode.labels.putAll(lineageNode.labels);
+                }
+                currentParent = existingNode;
+            } else {
+                // Add the new node to the parent
+                lineageNode.parent = currentParent;
+                currentParent.children.add(lineageNode);
+                currentParent = lineageNode;
+            }
+
+            // Move to the next level in the lineage
+            if (lineageNode.children == null || lineageNode.children.isEmpty()) {
+                // Reached the leaf node
+                return currentParent;
+            }
+            currentLineage = lineageNode.children.get(0);
+        }
+
+        return currentParent;
     }
 
     private static record NodeContext(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -60,6 +60,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -144,6 +145,7 @@ public class Discovery {
     @Inject URIUtil uriUtil;
     @Inject KubeEndpointSlicesDiscovery k8sDiscovery;
     @Inject PluginCallbackFactory callbackFactory;
+    @Inject PluginCleanupHelper cleanupHelper;
     @Inject EntityManager entityManager;
 
     void onStop(@Observes ShutdownEvent evt) throws SchedulerException {
@@ -671,7 +673,26 @@ public class Discovery {
             @RestPath UUID id,
             @RestHeader("Cryostat-Discovery-Authentication") String token)
             throws SchedulerException {
-        DiscoveryPlugin plugin = DiscoveryPlugin.find("id", id).singleResult();
+        DiscoveryPlugin plugin;
+        try {
+            plugin = DiscoveryPlugin.find("id", id).singleResult();
+        } catch (NoResultException e) {
+            // Plugin already deleted, but we should still clean up any orphaned nodes
+            logger.warnv(
+                    "Plugin {0} not found during deregistration, cleaning up orphaned nodes", id);
+            cleanupHelper.cleanupPluginNodes(id);
+
+            // Also try to delete the scheduled job
+            Set<JobKey> jobKeys = new HashSet<>();
+            jobKeys.addAll(scheduler.getJobKeys(GroupMatcher.jobGroupEquals(JOB_PERIODIC)));
+            for (var key : jobKeys) {
+                if (Objects.equals(id.toString(), key.getName())) {
+                    scheduler.deleteJob(key);
+                }
+            }
+            return;
+        }
+
         if (plugin.builtin) {
             throw new ForbiddenException();
         }
@@ -695,74 +716,8 @@ public class Discovery {
             scheduler.deleteJob(key);
         }
 
-        cleanupPluginNodes(entityManager, logger, plugin);
+        cleanupHelper.cleanupPluginNodes(plugin);
         plugin.delete();
-    }
-
-    private static void cleanupPluginNodes(
-            EntityManager entityManager, Logger logger, DiscoveryPlugin plugin) {
-        cleanupPluginNodes(entityManager, logger, plugin.id);
-    }
-
-    private static void cleanupPluginNodes(
-            EntityManager entityManager, Logger logger, UUID pluginId) {
-        // Clean up target nodes that belong to this plugin
-        // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with plugin ID
-        // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is deleted
-        List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
-        if (pluginNodes == null || pluginNodes.isEmpty()) {
-            return;
-        }
-        for (DiscoveryNode node : pluginNodes) {
-            try {
-                DiscoveryNode parent = node.parent;
-                node.delete();
-                // Recursively prune empty parent nodes up the tree
-                pruneEmptyAncestors(entityManager, logger, parent);
-            } catch (Exception e) {
-                logger.warn(e);
-            }
-        }
-    }
-
-    private static void pruneEmptyAncestors(
-            EntityManager entityManager, Logger logger, DiscoveryNode child) {
-        // Walk up the hierarchy, removing childless nodes from their parents
-        // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
-        while (child != null) {
-            DiscoveryNode parent = child.parent;
-
-            if (parent == null) {
-                logger.debugv(
-                        "Reached orphaned node {0} (id={1}), relying on orphan removal",
-                        child.name, child.id);
-                break;
-            }
-
-            entityManager.refresh(parent); // Reload from DB with current children
-
-            // Remove child from parent's collection - orphan removal will delete it
-            parent.children.remove(child);
-            child.parent = null;
-
-            boolean hasChildren = parent.hasChildren();
-            boolean isNamespace = parent.nodeType.equals(KubeDiscoveryNodeType.NAMESPACE.getKind());
-            boolean isRealm = parent.nodeType.equals("Realm");
-
-            logger.debugv(
-                    "Parent node {0} (id={1}, type={2}): hasChildren={3}, isNamespace={4},"
-                            + " isRealm={5}",
-                    parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
-
-            if (hasChildren || isNamespace || isRealm) {
-                logger.debugv("Stopping pruning at parent node {0}", parent.name);
-                break;
-            }
-
-            logger.debugv("Continuing to prune parent node {0}", parent.name);
-            // Move up to check the parent too
-            child = parent;
-        }
     }
 
     @GET
@@ -962,6 +917,94 @@ public class Discovery {
             DiscoveryNode node, DiscoveryNode parent, boolean fromBuiltin) {}
 
     /**
+     * Helper class for plugin cleanup operations. This is separate to allow reuse from both
+     * instance methods and static inner classes.
+     */
+    @ApplicationScoped
+    static class PluginCleanupHelper {
+
+        @Inject EntityManager entityManager;
+        @Inject Logger logger;
+
+        void cleanupPluginNodes(DiscoveryPlugin plugin) {
+            cleanupPluginNodes(plugin.id);
+        }
+
+        void cleanupPluginNodes(UUID pluginId) {
+            // Clean up target nodes that belong to this plugin
+            // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with
+            // plugin ID
+            // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is
+            // deleted
+            List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
+            if (pluginNodes == null || pluginNodes.isEmpty()) {
+                return;
+            }
+            for (DiscoveryNode node : pluginNodes) {
+                try {
+                    DiscoveryNode parent = node.parent;
+                    if (parent != null) {
+                        // Remove node from parent's collection before deleting
+                        // This ensures parent.hasChildren() will be accurate
+                        parent.children.remove(node);
+                        node.parent = null;
+                    }
+                    node.delete();
+                    // Recursively prune empty parent nodes up the tree
+                    pruneEmptyAncestors(parent);
+                } catch (Exception e) {
+                    logger.warn(e);
+                }
+            }
+        }
+
+        void pruneEmptyAncestors(DiscoveryNode child) {
+            // Walk up the hierarchy, removing childless nodes from their parents
+            // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
+            while (child != null) {
+                DiscoveryNode parent = child.parent;
+
+                if (parent == null) {
+                    logger.debugv(
+                            "Reached orphaned node {0} (id={1}), relying on orphan removal",
+                            child.name, child.id);
+                    break;
+                }
+
+                entityManager.refresh(parent); // Reload from DB with current children
+
+                // Remove child from parent's collection - orphan removal will delete it
+                parent.children.remove(child);
+                child.parent = null;
+
+                boolean hasChildren = parent.hasChildren();
+                boolean isNamespace =
+                        parent.nodeType.equals(KubeDiscoveryNodeType.NAMESPACE.getKind());
+                boolean isRealm = parent.nodeType.equals("Realm");
+
+                logger.debugv(
+                        "Parent node {0} (id={1}, type={2}): hasChildren={3}, isNamespace={4},"
+                                + " isRealm={5}",
+                        parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
+
+                // Stop pruning if:
+                // 1. Parent is a Realm (always preserve Realms)
+                // 2. Parent has children (preserve non-empty nodes)
+                // Note: Empty Namespaces should be pruned, so we don't stop just because it's a
+                // Namespace
+                if (isRealm || hasChildren) {
+                    logger.debugv("Stopping pruning at parent node {0}", parent.name);
+                    break;
+                }
+
+                logger.debugv("Continuing to prune parent node {0}", parent.name);
+                // Move up to check the parent too
+                child = parent;
+            }
+        }
+    }
+
+    /**
      * Check that discovery plugins are still alive/reachable and prompt them to regenerate expiring
      * tokens. Plugins are issued short-lived tokens at registration time. Cryostat periodically
      * pings plugins to ensure they are still alive/reachable and to prompt them to request a fresh
@@ -982,7 +1025,7 @@ public class Discovery {
 
         @Inject PluginCallbackFactory callbackFactory;
 
-        @Inject EntityManager entityManager;
+        @Inject PluginCleanupHelper cleanupHelper;
 
         @Override
         public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -1062,7 +1105,7 @@ public class Discovery {
                     // Clean up any orphaned nodes before unscheduling
                     if (noSuchPlugin) {
                         QuarkusTransaction.joiningExisting()
-                                .run(() -> cleanupPluginNodes(entityManager, logger, pluginId));
+                                .run(() -> cleanupHelper.cleanupPluginNodes(pluginId));
                     }
 
                     var ex = new JobExecutionException(e);
@@ -1107,7 +1150,7 @@ public class Discovery {
                                                     p.consecutiveFailures,
                                                     p.realm.name,
                                                     p.callback);
-                                            cleanupPluginNodes(entityManager, logger, p);
+                                            cleanupHelper.cleanupPluginNodes(p);
                                             p.delete();
                                         } else {
                                             logger.warnv(

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -591,10 +591,13 @@ public class Discovery {
                                                         newNs.labels = new HashMap<>();
                                                         newNs.children = new ArrayList<>();
                                                         newNs.target = null;
-                                                        newNs.parent = realm;
-                                                        newNs.persist();
                                                         return newNs;
                                                     });
+
+                            // Set parent relationship for new namespace nodes
+                            if (nsNode.parent == null) {
+                                nsNode.parent = realm;
+                            }
 
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -594,10 +594,11 @@ public class Discovery {
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
                             DiscoveryNode innermost = innermostNode(lineage);
                             innermost.children.addAll(body.nodes);
-                            body.nodes.forEach(n -> {
-                                n.parent = innermost;
-                                n.persist();
-                            });
+                            body.nodes.forEach(
+                                    n -> {
+                                        n.parent = innermost;
+                                        n.persist();
+                                    });
 
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -594,13 +594,23 @@ public class Discovery {
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
                             DiscoveryNode innermost = innermostNode(lineage);
                             innermost.children.addAll(body.nodes);
-                            body.nodes.forEach(n -> n.parent = innermost);
+                            body.nodes.forEach(n -> {
+                                n.parent = innermost;
+                                n.persist();
+                            });
 
                             if (!nsNode.children.contains(lineage)) {
                                 nsNode.children.add(lineage);
                             }
                             lineage.parent = nsNode;
 
+                            DiscoveryNode current = innermost;
+                            while (current != null && current != nsNode) {
+                                current.persist();
+                                current = current.parent;
+                            }
+
+                            nsNode.persist();
                             replacementChildren.add(nsNode);
                             break;
                         default:

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -591,6 +591,7 @@ public class Discovery {
                                                         newNs.labels = new HashMap<>();
                                                         newNs.children = new ArrayList<>();
                                                         newNs.target = null;
+                                                        newNs.parent = realm;
                                                         newNs.persist();
                                                         return newNs;
                                                     });

--- a/src/main/java/io/cryostat/discovery/DiscoveryNode.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryNode.java
@@ -80,7 +80,12 @@ import org.jboss.logging.Logger;
 @NamedQueries({
     @NamedQuery(
             name = "DiscoveryNode.byTypeWithName",
-            query = "from DiscoveryNode where nodeType = :nodeType and name = :name")
+            query = "from DiscoveryNode where nodeType = :nodeType and name = :name"),
+    @NamedQuery(
+            name = "DiscoveryNode.byPluginId",
+            query =
+                    "SELECT n FROM DiscoveryNode n WHERE jsonb_extract_path_text(n.labels,"
+                            + " 'discovery.cryostat.io/plugin-id') = :pluginId")
 })
 @Table(indexes = {@Index(columnList = "nodeType"), @Index(columnList = "nodeType, name")})
 public class DiscoveryNode extends PanacheEntity {
@@ -198,6 +203,12 @@ public class DiscoveryNode extends PanacheEntity {
                     n.labels.putAll(target.labels);
                     customizer.accept(n);
                 });
+    }
+
+    public static List<DiscoveryNode> getByPluginId(String pluginId) {
+        return DiscoveryNode.<DiscoveryNode>find(
+                        "#DiscoveryNode.byPluginId", Parameters.with("pluginId", pluginId))
+                .list();
     }
 
     @Override

--- a/src/main/java/io/cryostat/discovery/DiscoveryNode.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryNode.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -205,9 +206,10 @@ public class DiscoveryNode extends PanacheEntity {
                 });
     }
 
-    public static List<DiscoveryNode> getByPluginId(String pluginId) {
+    public static List<DiscoveryNode> getByPluginId(UUID pluginId) {
         return DiscoveryNode.<DiscoveryNode>find(
-                        "#DiscoveryNode.byPluginId", Parameters.with("pluginId", pluginId))
+                        "#DiscoveryNode.byPluginId",
+                        Parameters.with("pluginId", pluginId.toString()))
                 .list();
     }
 

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -107,7 +107,8 @@ public class DiscoveryPlugin extends PanacheEntityBase {
     @OneToOne(
             optional = true, // only nullable for builtins
             fetch = FetchType.LAZY,
-            cascade = CascadeType.REMOVE)
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true)
     @JsonIgnore
     @Nullable
     @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -18,11 +18,13 @@ package io.cryostat.discovery;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
 import io.cryostat.credentials.Credential;
+import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,6 +42,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -47,6 +50,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.GET;
@@ -147,11 +151,100 @@ public class DiscoveryPlugin extends PanacheEntityBase {
                 .singleResultOptional();
     }
 
+    /**
+     * Helper class for plugin cleanup operations in cases where nodes are not under the plugin's
+     * Realm, such as Agent instances using the publication fill algorithm.
+     */
+    @ApplicationScoped
+    static class PluginCleanupHelper {
+
+        @Inject EntityManager entityManager;
+        @Inject Logger logger;
+
+        void cleanupPluginNodes(DiscoveryPlugin plugin) {
+            cleanupPluginNodes(plugin.id);
+        }
+
+        void cleanupPluginNodes(UUID pluginId) {
+            // Clean up target nodes that belong to this plugin
+            // For KUBERNETES fill strategy, these are under KubernetesApi Realm, tagged with
+            // plugin ID
+            // For NONE fill strategy, cascade deletion handles cleanup when Agent Realm is
+            // deleted
+            List<DiscoveryNode> pluginNodes = DiscoveryNode.getByPluginId(pluginId);
+            if (pluginNodes == null || pluginNodes.isEmpty()) {
+                return;
+            }
+            for (DiscoveryNode node : pluginNodes) {
+                try {
+                    DiscoveryNode parent = node.parent;
+                    if (parent != null) {
+                        // Remove node from parent's collection before deleting
+                        // This ensures parent.hasChildren() will be accurate
+                        parent.children.remove(node);
+                        node.parent = null;
+                    }
+                    node.delete();
+                    // Recursively prune empty parent nodes up the tree
+                    pruneEmptyAncestors(parent);
+                } catch (Exception e) {
+                    logger.warn(e);
+                }
+            }
+        }
+
+        void pruneEmptyAncestors(DiscoveryNode child) {
+            // Walk up the hierarchy, removing childless nodes from their parents
+            // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
+            while (child != null) {
+                DiscoveryNode parent = child.parent;
+
+                if (parent == null) {
+                    logger.debugv(
+                            "Reached orphaned node {0} (id={1}), relying on orphan removal",
+                            child.name, child.id);
+                    break;
+                }
+
+                entityManager.refresh(parent); // Reload from DB with current children
+
+                // Remove child from parent's collection - orphan removal will delete it
+                parent.children.remove(child);
+                child.parent = null;
+
+                boolean hasChildren = parent.hasChildren();
+                boolean isNamespace =
+                        parent.nodeType.equals(KubeDiscoveryNodeType.NAMESPACE.getKind());
+                boolean isRealm = parent.nodeType.equals("Realm");
+
+                logger.debugv(
+                        "Parent node {0} (id={1}, type={2}): hasChildren={3}, isNamespace={4},"
+                                + " isRealm={5}",
+                        parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
+
+                // Stop pruning if:
+                // 1. Parent is a Realm (always preserve Realms)
+                // 2. Parent has children (preserve non-empty nodes)
+                // Note: Empty Namespaces should be pruned, so we don't stop just because it's a
+                // Namespace
+                if (isRealm || hasChildren) {
+                    logger.debugv("Stopping pruning at parent node {0}", parent.name);
+                    break;
+                }
+
+                logger.debugv("Continuing to prune parent node {0}", parent.name);
+                // Move up to check the parent too
+                child = parent;
+            }
+        }
+    }
+
     @ApplicationScoped
     static class Listener {
 
         @Inject Logger logger;
         @Inject PluginCallbackFactory callbackFactory;
+        @Inject PluginCleanupHelper cleanupHelper;
 
         @PrePersist
         @Transactional
@@ -189,6 +282,17 @@ public class DiscoveryPlugin extends PanacheEntityBase {
             } catch (Exception e) {
                 logger.error("Discovery Plugin ping failed", e);
                 throw e;
+            }
+        }
+
+        @PreRemove
+        @Transactional
+        public void preRemove(DiscoveryPlugin plugin) {
+            logger.debugv("PreRemove lifecycle hook triggered for plugin ID {0}", plugin.id);
+            try {
+                cleanupHelper.cleanupPluginNodes(plugin);
+            } catch (Exception e) {
+                logger.warn("Error during plugin cleanup", e);
             }
         }
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -115,17 +115,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                     + "AND NOT EXISTS ("
                     + "  SELECT 1 FROM Target t WHERE t.discoveryNode = n.id"
                     + ")";
+
     // SQL query to find existing DiscoveryNode entities by name/nodeType within a particular
     // namespace
     private static final String FIND_NAMESPACED_NODE_SQL =
-            String.format(
-                    """
-                    SELECT n.id FROM DiscoveryNode n
-                      WHERE n.name = :name AND
-                      n.nodeType = :nodeType AND
-                      n.labels->>'%s' = :namespace
-                    """,
-                    DISCOVERY_NAMESPACE_LABEL_KEY);
+            """
+            SELECT n.id FROM DiscoveryNode n %n\
+            WHERE n.name = :name AND %n\
+            n.nodeType = :nodeType AND %n\
+            n.labels->>'%s' = :namespace\
+            """
+                    .formatted(DISCOVERY_NAMESPACE_LABEL_KEY);
 
     private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -102,7 +102,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
     public static final String REALM = "KubernetesApi";
 
-    public static final String DISCOVERY_NAMESPACE_LABEL_KEY = "discovery.cryostat.io/namespace";
+    public static final String DISCOVERY_NAMESPACE_LABEL_KEY =
+            Discovery.DISCOVERY_PLUGIN_LABEL_PREFIX + "namespace";
 
     // SQL query to find orphaned nodes - nodes with no children and no associated Target
     // Uses native SQL to access JSONB map keys/values which HQL doesn't support well
@@ -117,10 +118,14 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     // SQL query to find existing DiscoveryNode entities by name/nodeType within a particular
     // namespace
     private static final String FIND_NAMESPACED_NODE_SQL =
-            "SELECT n.id FROM DiscoveryNode n"
-                    + " WHERE n.name = :name AND"
-                    + " n.nodeType = :nodeType AND"
-                    + " n.labels->>'discovery.cryostat.io/namespace' = :namespace";
+            String.format(
+                    """
+                    SELECT n.id FROM DiscoveryNode n
+                      WHERE n.name = :name AND
+                      n.nodeType = :nodeType AND
+                      n.labels->>'%s' = :namespace
+                    """,
+                    DISCOVERY_NAMESPACE_LABEL_KEY);
 
     private static final List<String> EMPTY_PORT_NAMES = new ArrayList<>();
 

--- a/src/main/java/io/cryostat/graphql/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ActiveRecordings.java
@@ -67,7 +67,7 @@ public class ActiveRecordings {
             throws QuantityConversionException {
         var list =
                 DiscoveryNode.<DiscoveryNode>listAll().stream()
-                        .filter(nodes)
+                        .filter(n -> nodes == null ? true : nodes.test(n))
                         .flatMap(
                                 node ->
                                         RootNode.recurseChildren(node, n -> n.target != null)
@@ -108,7 +108,7 @@ public class ActiveRecordings {
             throws Exception {
         var list =
                 DiscoveryNode.<DiscoveryNode>listAll().stream()
-                        .filter(nodes)
+                        .filter(n -> nodes == null ? true : nodes.test(n))
                         .flatMap(
                                 node ->
                                         RootNode.recurseChildren(node, n -> n.target != null)
@@ -139,7 +139,7 @@ public class ActiveRecordings {
             throws Exception {
         var list =
                 DiscoveryNode.<DiscoveryNode>listAll().stream()
-                        .filter(nodes)
+                        .filter(n -> nodes == null ? true : nodes.test(n))
                         .flatMap(
                                 node ->
                                         RootNode.recurseChildren(node, n -> n.target != null)
@@ -168,7 +168,7 @@ public class ActiveRecordings {
             @NonNull DiscoveryNodeFilter nodes, @Nullable ActiveRecordingsFilter recordings) {
         var list =
                 DiscoveryNode.<DiscoveryNode>listAll().stream()
-                        .filter(nodes)
+                        .filter(n -> nodes == null ? true : nodes.test(n))
                         .flatMap(
                                 node ->
                                         RootNode.recurseChildren(node, n -> n.target != null)
@@ -196,7 +196,7 @@ public class ActiveRecordings {
     public List<ActiveRecording> createSnapshot(@NonNull DiscoveryNodeFilter nodes) {
         var targets =
                 DiscoveryNode.<DiscoveryNode>listAll().stream()
-                        .filter(nodes)
+                        .filter(n -> nodes == null ? true : nodes.test(n))
                         .flatMap(
                                 node ->
                                         RootNode.recurseChildren(node, n -> n.target != null)

--- a/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/graphql/ArchivedRecordings.java
@@ -50,7 +50,7 @@ public class ArchivedRecordings {
                 recordingHelper
                         .listArchivedRecordings(filter == null ? null : filter.sourceTarget)
                         .stream()
-                        .filter(filter)
+                        .filter(v -> filter == null ? true : filter.test(v))
                         .toList();
         r.aggregate = RecordingAggregateInfo.fromArchived(r.data);
         return r;

--- a/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
+++ b/src/main/java/io/cryostat/graphql/EnvironmentNodes.java
@@ -33,7 +33,7 @@ public class EnvironmentNodes {
     public List<DiscoveryNode> environmentNodes(@Nullable DiscoveryNodeFilter filter) {
         return RootNode.recurseChildren(DiscoveryNode.getUniverse(), node -> node.target == null)
                 .stream()
-                .filter(filter)
+                .filter(n -> filter == null ? true : filter.test(n))
                 .toList();
     }
 }

--- a/src/main/java/io/cryostat/graphql/HeapDumpGraphQL.java
+++ b/src/main/java/io/cryostat/graphql/HeapDumpGraphQL.java
@@ -47,7 +47,7 @@ public class HeapDumpGraphQL {
         var r = new TargetNodes.HeapDumps();
         r.data =
                 diagnosticsHelper.getHeapDumps(filter == null ? null : filter.sourceTarget).stream()
-                        .filter(filter)
+                        .filter(v -> filter == null ? true : filter.test(v))
                         .toList();
         r.aggregate = HeapDumpAggregateInfo.fromArchived(r.data);
         return r;

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -51,8 +51,13 @@ public class RootNode {
                 .toList();
     }
 
-    static Set<DiscoveryNode> recurseChildren(
-            DiscoveryNode node, Predicate<DiscoveryNode> predicate) {
+    static Set<DiscoveryNode> recurseChildren(DiscoveryNode node, Predicate<DiscoveryNode> p) {
+        Predicate<DiscoveryNode> predicate;
+        if (p == null) {
+            predicate = n -> true;
+        } else {
+            predicate = p;
+        }
         Set<DiscoveryNode> result = new HashSet<>();
         if (predicate.test(node)) {
             result.add(node);

--- a/src/main/java/io/cryostat/graphql/ThreadDumpGraphQL.java
+++ b/src/main/java/io/cryostat/graphql/ThreadDumpGraphQL.java
@@ -49,7 +49,7 @@ public class ThreadDumpGraphQL {
                 diagnosticsHelper
                         .getThreadDumps(filter == null ? null : filter.sourceTarget)
                         .stream()
-                        .filter(filter)
+                        .filter(v -> filter == null ? true : filter.test(v))
                         .toList();
         r.aggregate = ThreadDumpAggregateInfo.fromArchived(r.data);
         return r;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,7 +52,7 @@ quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".retry.jitte
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.value=60
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.window-unit=minutes
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.window=1
-quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.type=smooth
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/create".rate-limit.type=rolling
 
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".bulkhead.value=5
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".bulkhead.waiting-task-queue=10
@@ -66,7 +66,7 @@ quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".retry.jitte
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.value=60
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.window-unit=minutes
 quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.window=1
-quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.type=smooth
+quarkus.fault-tolerance."io.cryostat.credentials.Credentials/delete".rate-limit.type=rolling
 
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".bulkhead.value=5
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".bulkhead.waiting-task-queue=10
@@ -80,7 +80,7 @@ quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".retry.jitter=
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".rate-limit.value=60
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".rate-limit.window-unit=minutes
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".rate-limit.window=1
-quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".rate-limit.type=smooth
+quarkus.fault-tolerance."io.cryostat.discovery.Discovery/register".rate-limit.type=rolling
 
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".bulkhead.value=5
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".bulkhead.waiting-task-queue=10
@@ -94,7 +94,7 @@ quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".retry.jitter=5
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".rate-limit.value=60
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".rate-limit.window-unit=minutes
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".rate-limit.window=1
-quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".rate-limit.type=smooth
+quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publish".rate-limit.type=rolling
 
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".bulkhead.value=5
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".bulkhead.waiting-task-queue=10
@@ -108,7 +108,7 @@ quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".ret
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".rate-limit.value=60
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".rate-limit.window-unit=minutes
 quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".rate-limit.window=1
-quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".rate-limit.type=smooth
+quarkus.fault-tolerance."io.cryostat.discovery.Discovery/publishWithContext".rate-limit.type=rolling
 
 cryostat.discovery.plugins.jwt.secret.algorithm=AES
 cryostat.discovery.plugins.jwt.secret.keysize=256

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -72,4 +72,35 @@ BEGIN
       AND (parentNode IS NULL OR parentNode != k8s_realm_id);
 
     RAISE NOTICE 'Re-parented all Namespace nodes to KubernetesApi Realm (id=%)', k8s_realm_id;
+
+    -- Add plugin-id label to existing CryostatAgent target nodes
+    -- This enables cleanup when plugins are deregistered or pruned
+    -- We identify the plugin by finding the Realm that owns the target's ancestor tree
+    UPDATE DiscoveryNode target_node
+    SET labels = COALESCE(labels, '{}'::jsonb) ||
+                 jsonb_build_object('discovery.cryostat.io/plugin-id', plugin.id::text)
+    FROM DiscoveryPlugin plugin
+    WHERE target_node.nodeType = 'CryostatAgent'
+      AND EXISTS (SELECT 1 FROM Target WHERE discoveryNode = target_node.id)
+      AND NOT (target_node.labels ? 'discovery.cryostat.io/plugin-id')
+      AND EXISTS (
+          -- Find the Realm ancestor of this target node
+          WITH RECURSIVE ancestor_tree AS (
+              SELECT id, parentNode, nodeType
+              FROM DiscoveryNode
+              WHERE id = target_node.id
+
+              UNION ALL
+
+              SELECT dn.id, dn.parentNode, dn.nodeType
+              FROM DiscoveryNode dn
+              INNER JOIN ancestor_tree at ON dn.id = at.parentNode
+          )
+          SELECT 1
+          FROM ancestor_tree
+          WHERE nodeType = 'Realm'
+            AND id = plugin.realm_id
+      );
+
+    RAISE NOTICE 'Added plugin-id labels to existing CryostatAgent target nodes';
 END $$;

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -10,11 +10,12 @@ ALTER TABLE AsyncProfilerRecording ADD CONSTRAINT asyncprofilerrecording_eventty
 ALTER TABLE AsyncProfilerRecording_AUD DROP CONSTRAINT IF EXISTS asyncprofilerrecording_aud_eventtype_check;
 ALTER TABLE AsyncProfilerRecording_AUD ADD CONSTRAINT asyncprofilerrecording_aud_eventtype_check CHECK (char_length(eventType) < 1024);
 
--- Deduplicate Namespace DiscoveryNode instances and re-parent to KubernetesApi Realm
--- This migration fixes two issues:
--- 1. Multiple Namespace nodes with the same name were created, causing GraphQL queries to return incomplete results
--- 2. Namespace nodes were incorrectly parented to Agent Realms instead of KubernetesApi Realm,
+-- Deduplicate k8s lineage DiscoveryNode instances and re-parent to KubernetesApi Realm
+-- This migration fixes issues where:
+-- 1. Multiple nodes with the same name/type were created, causing GraphQL queries to return incomplete results
+-- 2. K8s lineage nodes were incorrectly parented to Agent Realms instead of KubernetesApi Realm,
 --    causing all targets to be lost when that Agent went offline
+-- 3. Deployment, ReplicaSet, and Pod nodes were duplicated instead of being shared across replicas
 
 DO $$
 DECLARE
@@ -22,6 +23,7 @@ DECLARE
     keep_node_id BIGINT;
     delete_node_id BIGINT;
     k8s_realm_id BIGINT;
+    node_type_name TEXT;
 BEGIN
     -- Find the KubernetesApi Realm ID
     SELECT id INTO k8s_realm_id
@@ -32,35 +34,41 @@ BEGIN
         RAISE EXCEPTION 'KubernetesApi Realm not found';
     END IF;
 
-    -- Loop through each namespace name that has duplicates
-    FOR dup_record IN 
-        SELECT name, MIN(id) as keep_id, ARRAY_AGG(id ORDER BY id) as all_ids
-        FROM DiscoveryNode
-        WHERE nodeType = 'Namespace'
-        GROUP BY name
-        HAVING COUNT(*) > 1
+    -- Deduplicate k8s lineage nodes in order: Namespace, Deployment, ReplicaSet, Pod
+    -- This order ensures parent nodes are deduplicated before their children
+    FOREACH node_type_name IN ARRAY ARRAY['Namespace', 'Deployment', 'ReplicaSet', 'Pod']
     LOOP
-        keep_node_id := dup_record.keep_id;
-        
-        -- Loop through each duplicate ID (excluding the one we're keeping)
-        FOREACH delete_node_id IN ARRAY dup_record.all_ids
+        -- Loop through each node name that has duplicates of this type
+        FOR dup_record IN
+            SELECT name, MIN(id) as keep_id, ARRAY_AGG(id ORDER BY id) as all_ids
+            FROM DiscoveryNode
+            WHERE nodeType = node_type_name
+            GROUP BY name
+            HAVING COUNT(*) > 1
         LOOP
-            IF delete_node_id != keep_node_id THEN
-                -- Update child DiscoveryNodes to point to the kept node
-                UPDATE DiscoveryNode
-                SET parentNode = keep_node_id
-                WHERE parentNode = delete_node_id;
-                
-                -- Update Targets to point to the kept node
-                UPDATE Target
-                SET discoveryNode = keep_node_id
-                WHERE discoveryNode = delete_node_id;
-                
-                -- Delete the duplicate node
-                DELETE FROM DiscoveryNode WHERE id = delete_node_id;
-                
-                RAISE NOTICE 'Deleted duplicate Namespace node % (kept node %)', delete_node_id, keep_node_id;
-            END IF;
+            keep_node_id := dup_record.keep_id;
+
+            -- Loop through each duplicate ID (excluding the one we're keeping)
+            FOREACH delete_node_id IN ARRAY dup_record.all_ids
+            LOOP
+                IF delete_node_id != keep_node_id THEN
+                    -- Update child DiscoveryNodes to point to the kept node
+                    UPDATE DiscoveryNode
+                    SET parentNode = keep_node_id
+                    WHERE parentNode = delete_node_id;
+
+                    -- Update Targets to point to the kept node
+                    UPDATE Target
+                    SET discoveryNode = keep_node_id
+                    WHERE discoveryNode = delete_node_id;
+
+                    -- Delete the duplicate node
+                    DELETE FROM DiscoveryNode WHERE id = delete_node_id;
+
+                    RAISE NOTICE 'Deleted duplicate % node "%" (id=%, kept id=%)',
+                        node_type_name, dup_record.name, delete_node_id, keep_node_id;
+                END IF;
+            END LOOP;
         END LOOP;
     END LOOP;
 

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -9,3 +9,49 @@ ALTER TABLE AsyncProfilerRecording ADD CONSTRAINT asyncprofilerrecording_eventty
 -- Update eventType constraint in AsyncProfilerRecording_AUD table from < 50 to < 1024
 ALTER TABLE AsyncProfilerRecording_AUD DROP CONSTRAINT IF EXISTS asyncprofilerrecording_aud_eventtype_check;
 ALTER TABLE AsyncProfilerRecording_AUD ADD CONSTRAINT asyncprofilerrecording_aud_eventtype_check CHECK (char_length(eventType) < 1024);
+
+-- Deduplicate Namespace DiscoveryNode instances
+-- This migration fixes a bug where multiple Namespace nodes with the same name
+-- were created in the database, causing GraphQL queries to return incomplete results.
+
+-- For each namespace name that has duplicates, keep only the one with the lowest ID
+-- and delete the rest, after updating all references to point to the kept node.
+
+DO $$
+DECLARE
+    dup_record RECORD;
+    keep_node_id BIGINT;
+    delete_node_id BIGINT;
+BEGIN
+    -- Loop through each namespace name that has duplicates
+    FOR dup_record IN 
+        SELECT name, MIN(id) as keep_id, ARRAY_AGG(id ORDER BY id) as all_ids
+        FROM DiscoveryNode
+        WHERE nodeType = 'Namespace'
+        GROUP BY name
+        HAVING COUNT(*) > 1
+    LOOP
+        keep_node_id := dup_record.keep_id;
+        
+        -- Loop through each duplicate ID (excluding the one we're keeping)
+        FOREACH delete_node_id IN ARRAY dup_record.all_ids
+        LOOP
+            IF delete_node_id != keep_node_id THEN
+                -- Update child DiscoveryNodes to point to the kept node
+                UPDATE DiscoveryNode
+                SET parentNode = keep_node_id
+                WHERE parentNode = delete_node_id;
+                
+                -- Update Targets to point to the kept node
+                UPDATE Target
+                SET discoveryNode = keep_node_id
+                WHERE discoveryNode = delete_node_id;
+                
+                -- Delete the duplicate node
+                DELETE FROM DiscoveryNode WHERE id = delete_node_id;
+                
+                RAISE NOTICE 'Deleted duplicate Namespace node % (kept node %)', delete_node_id, keep_node_id;
+            END IF;
+        END LOOP;
+    END LOOP;
+END $$;

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -10,19 +10,28 @@ ALTER TABLE AsyncProfilerRecording ADD CONSTRAINT asyncprofilerrecording_eventty
 ALTER TABLE AsyncProfilerRecording_AUD DROP CONSTRAINT IF EXISTS asyncprofilerrecording_aud_eventtype_check;
 ALTER TABLE AsyncProfilerRecording_AUD ADD CONSTRAINT asyncprofilerrecording_aud_eventtype_check CHECK (char_length(eventType) < 1024);
 
--- Deduplicate Namespace DiscoveryNode instances
--- This migration fixes a bug where multiple Namespace nodes with the same name
--- were created in the database, causing GraphQL queries to return incomplete results.
-
--- For each namespace name that has duplicates, keep only the one with the lowest ID
--- and delete the rest, after updating all references to point to the kept node.
+-- Deduplicate Namespace DiscoveryNode instances and re-parent to KubernetesApi Realm
+-- This migration fixes two issues:
+-- 1. Multiple Namespace nodes with the same name were created, causing GraphQL queries to return incomplete results
+-- 2. Namespace nodes were incorrectly parented to Agent Realms instead of KubernetesApi Realm,
+--    causing all targets to be lost when that Agent went offline
 
 DO $$
 DECLARE
     dup_record RECORD;
     keep_node_id BIGINT;
     delete_node_id BIGINT;
+    k8s_realm_id BIGINT;
 BEGIN
+    -- Find the KubernetesApi Realm ID
+    SELECT id INTO k8s_realm_id
+    FROM DiscoveryNode
+    WHERE nodeType = 'Realm' AND name = 'KubernetesApi';
+
+    IF k8s_realm_id IS NULL THEN
+        RAISE EXCEPTION 'KubernetesApi Realm not found';
+    END IF;
+
     -- Loop through each namespace name that has duplicates
     FOR dup_record IN 
         SELECT name, MIN(id) as keep_id, ARRAY_AGG(id ORDER BY id) as all_ids
@@ -54,4 +63,13 @@ BEGIN
             END IF;
         END LOOP;
     END LOOP;
+
+    -- Re-parent all Namespace nodes to KubernetesApi Realm
+    -- This ensures k8s lineage is owned by KubernetesApi, not Agent Realms
+    UPDATE DiscoveryNode
+    SET parentNode = k8s_realm_id
+    WHERE nodeType = 'Namespace'
+      AND (parentNode IS NULL OR parentNode != k8s_realm_id);
+
+    RAISE NOTICE 'Re-parented all Namespace nodes to KubernetesApi Realm (id=%)', k8s_realm_id;
 END $$;

--- a/src/test/java/io/cryostat/discovery/Issue1571Test.java
+++ b/src/test/java/io/cryostat/discovery/Issue1571Test.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.discovery;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType;
+import io.cryostat.targets.Target;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for https://github.com/cryostatio/cryostat/issues/1571: GraphQL descendantTargets returns
+ * only one target when querying Namespace nodes.
+ *
+ * <p>This test simulates the bug where multiple Namespace nodes with the same name were created in
+ * the database, causing GraphQL queries to return incomplete results due to Set deduplication based
+ * on equals() method.
+ */
+@QuarkusTest
+public class Issue1571Test {
+
+    @Inject EntityManager entityManager;
+    @Inject Flyway flyway;
+    @Inject UserTransaction userTransaction;
+
+    @Test
+    public void testNamespaceDuplicationAndMigration() throws Exception {
+        // Step 0: Set up database with migrations up to V4.2.0 (before the fix)
+        flyway.clean();
+        Flyway targetFlyway =
+                Flyway.configure()
+                        .configuration(flyway.getConfiguration())
+                        .target(MigrationVersion.fromVersion("4.2.0"))
+                        .load();
+        targetFlyway.migrate();
+        entityManager.clear();
+
+        // Step 1: Simulate the bug by creating duplicate Namespace nodes
+        userTransaction.begin();
+        // This mimics what happened when multiple agents registered with KUBERNETES fill strategy
+
+        // Get the Universe node
+        DiscoveryNode universe = DiscoveryNode.getUniverse();
+        Assertions.assertNotNull(universe, "Universe node should exist");
+
+        // Create two separate Realm nodes (simulating agent registrations)
+        DiscoveryNode realm1 = new DiscoveryNode();
+        realm1.name = "test-realm-1";
+        realm1.nodeType = "Realm";
+        realm1.labels = new HashMap<>();
+        realm1.children = new ArrayList<>();
+        realm1.parent = universe;
+        realm1.persist();
+
+        DiscoveryNode realm2 = new DiscoveryNode();
+        realm2.name = "test-realm-2";
+        realm2.nodeType = "Realm";
+        realm2.labels = new HashMap<>();
+        realm2.children = new ArrayList<>();
+        realm2.parent = universe;
+        realm2.persist();
+
+        // Create DUPLICATE Namespace nodes with the same name (this is the bug)
+        DiscoveryNode namespace1 = new DiscoveryNode();
+        namespace1.name = "test-namespace";
+        namespace1.nodeType = KubeDiscoveryNodeType.NAMESPACE.getKind();
+        namespace1.labels = new HashMap<>();
+        namespace1.children = new ArrayList<>();
+        namespace1.parent = realm1;
+        namespace1.persist();
+
+        DiscoveryNode namespace2 = new DiscoveryNode();
+        namespace2.name = "test-namespace"; // Same name!
+        namespace2.nodeType = KubeDiscoveryNodeType.NAMESPACE.getKind();
+        namespace2.labels = new HashMap<>();
+        namespace2.children = new ArrayList<>();
+        namespace2.parent = realm2;
+        namespace2.persist();
+
+        // Create Pod nodes under each namespace
+        DiscoveryNode pod1 = new DiscoveryNode();
+        pod1.name = "test-pod-1";
+        pod1.nodeType = KubeDiscoveryNodeType.POD.getKind();
+        pod1.labels = new HashMap<>();
+        pod1.children = new ArrayList<>();
+        pod1.parent = namespace1;
+        pod1.persist();
+
+        DiscoveryNode pod2 = new DiscoveryNode();
+        pod2.name = "test-pod-2";
+        pod2.nodeType = KubeDiscoveryNodeType.POD.getKind();
+        pod2.labels = new HashMap<>();
+        pod2.children = new ArrayList<>();
+        pod2.parent = namespace2;
+        pod2.persist();
+
+        // Create target nodes under each pod
+        Target target1 = new Target();
+        target1.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:9091/jmxrmi");
+        target1.alias = "target1";
+        target1.labels = new HashMap<>();
+        target1.annotations = new Target.Annotations();
+
+        DiscoveryNode targetNode1 = new DiscoveryNode();
+        targetNode1.name = "target-node-1";
+        targetNode1.nodeType = "JVM";
+        targetNode1.labels = new HashMap<>();
+        targetNode1.children = new ArrayList<>();
+        targetNode1.parent = pod1;
+        targetNode1.target = target1;
+        target1.discoveryNode = targetNode1;
+        targetNode1.persist();
+        target1.persist();
+
+        Target target2 = new Target();
+        target2.connectUrl = URI.create("service:jmx:rmi:///jndi/rmi://localhost:9092/jmxrmi");
+        target2.alias = "target2";
+        target2.labels = new HashMap<>();
+        target2.annotations = new Target.Annotations();
+
+        DiscoveryNode targetNode2 = new DiscoveryNode();
+        targetNode2.name = "target-node-2";
+        targetNode2.nodeType = "JVM";
+        targetNode2.labels = new HashMap<>();
+        targetNode2.children = new ArrayList<>();
+        targetNode2.parent = pod2;
+        targetNode2.target = target2;
+        target2.discoveryNode = targetNode2;
+        targetNode2.persist();
+        target2.persist();
+
+        entityManager.flush();
+        userTransaction.commit();
+        entityManager.clear();
+
+        // Step 2: Verify the bug exists - we have duplicate Namespace nodes
+        userTransaction.begin();
+        List<DiscoveryNode> namespacesBefore =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "nodeType = ?1 and name = ?2",
+                                KubeDiscoveryNodeType.NAMESPACE.getKind(),
+                                "test-namespace")
+                        .list();
+
+        Assertions.assertEquals(
+                2,
+                namespacesBefore.size(),
+                "Should have 2 duplicate Namespace nodes before migration");
+
+        Long namespace1Id = namespace1.id;
+        Long namespace2Id = namespace2.id;
+        Long keepId = Math.min(namespace1Id, namespace2Id);
+        Long deleteId = Math.max(namespace1Id, namespace2Id);
+
+        // Verify both targets exist
+        List<Target> targetsBefore = Target.listAll();
+        Assertions.assertEquals(2, targetsBefore.size(), "Should have 2 targets before migration");
+
+        // Verify the BUG exists via GraphQL - should only return 1 target due to Set deduplication
+        String graphqlQueryBefore =
+                "query { environmentNodes(filter: { nodeTypes: [\"Namespace\"] }) { name nodeType"
+                        + " descendantTargets { target { alias } } } }";
+
+        JsonPath responseBefore =
+                given().contentType(ContentType.JSON)
+                        .body(Map.of("query", graphqlQueryBefore))
+                        .when()
+                        .post("/api/v4/graphql")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .jsonPath();
+
+        // Before the fix: Even though there are 2 Namespace nodes in the database,
+        // GraphQL's recurseChildren() uses a Set which deduplicates based on equals(),
+        // so only 1 Namespace node is returned (this is the bug)
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> environmentNodesBefore =
+                (List<Map<String, Object>>)
+                        (List<?>) responseBefore.getList("data.environmentNodes", Map.class);
+        Assertions.assertEquals(
+                1,
+                environmentNodesBefore.size(),
+                "GraphQL returns only 1 Namespace node before migration due to Set deduplication"
+                        + " (the bug)");
+
+        // Count total targets across all namespace nodes
+        int totalTargetsBefore = 0;
+        for (Map<String, Object> node : environmentNodesBefore) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> descendants =
+                    (List<Map<String, Object>>) node.get("descendantTargets");
+            if (descendants != null) {
+                totalTargetsBefore += descendants.size();
+            }
+        }
+
+        // This demonstrates the bug: even though 2 targets exist in the database,
+        // GraphQL only returns 1 due to Set deduplication of duplicate Namespace nodes
+        Assertions.assertEquals(
+                1,
+                totalTargetsBefore,
+                "GraphQL should return only 1 target before migration (demonstrates the bug)");
+
+        userTransaction.commit();
+
+        // Step 3: Run the V4.2.1 migration
+        flyway.migrate();
+
+        // Clear the EntityManager cache to ensure we're reading fresh data from the database
+        // after the migration has run
+        entityManager.clear();
+
+        // Also clear the Hibernate second-level cache if it exists
+        entityManager.getEntityManagerFactory().getCache().evictAll();
+
+        // Step 4: Verify the migration worked correctly
+        userTransaction.begin();
+
+        // Should now have only ONE Namespace node
+        List<DiscoveryNode> namespacesAfter =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "nodeType = ?1 and name = ?2",
+                                KubeDiscoveryNodeType.NAMESPACE.getKind(),
+                                "test-namespace")
+                        .list();
+
+        Assertions.assertEquals(
+                1, namespacesAfter.size(), "Should have only 1 Namespace node after migration");
+
+        DiscoveryNode keptNamespace = namespacesAfter.get(0);
+        Assertions.assertEquals(
+                keepId, keptNamespace.id, "Should keep the Namespace with the lowest ID");
+
+        // Verify the deleted namespace no longer exists
+        DiscoveryNode deletedNamespace = DiscoveryNode.findById(deleteId);
+        Assertions.assertNull(
+                deletedNamespace, "Duplicate Namespace node should have been deleted");
+
+        // Verify both targets still exist
+        List<Target> targetsAfter = Target.listAll();
+        Assertions.assertEquals(
+                2, targetsAfter.size(), "Should still have 2 targets after migration");
+
+        // Verify both target nodes now point to the kept namespace (through their pod parents)
+        DiscoveryNode targetNode1After = DiscoveryNode.findById(targetNode1.id);
+        DiscoveryNode targetNode2After = DiscoveryNode.findById(targetNode2.id);
+
+        Assertions.assertNotNull(targetNode1After, "Target node 1 should still exist");
+        Assertions.assertNotNull(targetNode2After, "Target node 2 should still exist");
+
+        // Both pods should now be children of the kept namespace
+        DiscoveryNode pod1After = DiscoveryNode.findById(pod1.id);
+        DiscoveryNode pod2After = DiscoveryNode.findById(pod2.id);
+
+        Assertions.assertNotNull(pod1After, "Pod 1 should still exist");
+        Assertions.assertNotNull(pod2After, "Pod 2 should still exist");
+        Assertions.assertEquals(
+                keepId, pod1After.parent.id, "Pod 1 should now be under the kept namespace");
+        Assertions.assertEquals(
+                keepId, pod2After.parent.id, "Pod 2 should now be under the kept namespace");
+
+        // Verify the kept namespace has both pods as children
+        DiscoveryNode keptNamespaceWithChildren = DiscoveryNode.findById(keepId);
+        Assertions.assertEquals(
+                2,
+                keptNamespaceWithChildren.children.size(),
+                "Kept namespace should have 2 children (both pods)");
+
+        // Verify we can query all descendant targets through the single namespace
+        List<DiscoveryNode> descendantTargets =
+                keptNamespaceWithChildren.children.stream()
+                        .flatMap(pod -> pod.children.stream())
+                        .filter(node -> node.target != null)
+                        .toList();
+
+        Assertions.assertEquals(
+                2,
+                descendantTargets.size(),
+                "Should be able to find both targets through the single namespace");
+
+        // Step 5: Verify GraphQL API also returns both targets
+        // This tests the actual API that users would call
+        String graphqlQuery =
+                "query { environmentNodes(filter: { nodeTypes: [\"Namespace\"] }) { name nodeType"
+                        + " descendantTargets { target { alias } } } }";
+
+        JsonPath response =
+                given().contentType(ContentType.JSON)
+                        .body(Map.of("query", graphqlQuery))
+                        .when()
+                        .post("/api/v4/graphql")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .jsonPath();
+
+        // Verify we get exactly one Namespace node
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> environmentNodes =
+                (List<Map<String, Object>>)
+                        (List<?>) response.getList("data.environmentNodes", Map.class);
+        Assertions.assertEquals(
+                1, environmentNodes.size(), "GraphQL should return exactly 1 Namespace node");
+
+        Map<String, Object> namespaceNode = environmentNodes.get(0);
+        Assertions.assertEquals(
+                "test-namespace", namespaceNode.get("name"), "Namespace name should match");
+        Assertions.assertEquals(
+                "Namespace", namespaceNode.get("nodeType"), "Node type should be Namespace");
+
+        // Verify we get both targets through descendantTargets
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> descendantTargetsFromGraphQL =
+                (List<Map<String, Object>>) namespaceNode.get("descendantTargets");
+        Assertions.assertEquals(
+                2,
+                descendantTargetsFromGraphQL.size(),
+                "GraphQL should return both targets through descendantTargets");
+
+        // Verify the target aliases
+        List<String> aliases =
+                descendantTargetsFromGraphQL.stream()
+                        .map(dt -> (Map<String, Object>) dt.get("target"))
+                        .map(t -> (String) t.get("alias"))
+                        .sorted()
+                        .toList();
+
+        Assertions.assertEquals(
+                List.of("target1", "target2"),
+                aliases,
+                "Should have both target aliases in GraphQL response");
+
+        userTransaction.commit();
+    }
+}

--- a/src/test/java/io/cryostat/discovery/Issue1571Test.java
+++ b/src/test/java/io/cryostat/discovery/Issue1571Test.java
@@ -121,13 +121,47 @@ public class Issue1571Test {
         namespace2.parent = realm2;
         namespace2.persist();
 
-        // Create Pod nodes under each namespace
+        // Create DUPLICATE Deployment nodes with the same name under each namespace
+        DiscoveryNode deployment1 = new DiscoveryNode();
+        deployment1.name = "test-deployment";
+        deployment1.nodeType = KubeDiscoveryNodeType.DEPLOYMENT.getKind();
+        deployment1.labels = new HashMap<>();
+        deployment1.children = new ArrayList<>();
+        deployment1.parent = namespace1;
+        deployment1.persist();
+
+        DiscoveryNode deployment2 = new DiscoveryNode();
+        deployment2.name = deployment1.name; // Same name!
+        deployment2.nodeType = KubeDiscoveryNodeType.DEPLOYMENT.getKind();
+        deployment2.labels = new HashMap<>();
+        deployment2.children = new ArrayList<>();
+        deployment2.parent = namespace2;
+        deployment2.persist();
+
+        // Create DUPLICATE ReplicaSet nodes with the same name under each deployment
+        DiscoveryNode replicaSet1 = new DiscoveryNode();
+        replicaSet1.name = "test-replicaset";
+        replicaSet1.nodeType = KubeDiscoveryNodeType.REPLICASET.getKind();
+        replicaSet1.labels = new HashMap<>();
+        replicaSet1.children = new ArrayList<>();
+        replicaSet1.parent = deployment1;
+        replicaSet1.persist();
+
+        DiscoveryNode replicaSet2 = new DiscoveryNode();
+        replicaSet2.name = replicaSet1.name; // Same name!
+        replicaSet2.nodeType = KubeDiscoveryNodeType.REPLICASET.getKind();
+        replicaSet2.labels = new HashMap<>();
+        replicaSet2.children = new ArrayList<>();
+        replicaSet2.parent = deployment2;
+        replicaSet2.persist();
+
+        // Create Pod nodes under each replicaset (different names since they're replicas)
         DiscoveryNode pod1 = new DiscoveryNode();
         pod1.name = "test-pod-1";
         pod1.nodeType = KubeDiscoveryNodeType.POD.getKind();
         pod1.labels = new HashMap<>();
         pod1.children = new ArrayList<>();
-        pod1.parent = namespace1;
+        pod1.parent = replicaSet1;
         pod1.persist();
 
         DiscoveryNode pod2 = new DiscoveryNode();
@@ -135,7 +169,7 @@ public class Issue1571Test {
         pod2.nodeType = KubeDiscoveryNodeType.POD.getKind();
         pod2.labels = new HashMap<>();
         pod2.children = new ArrayList<>();
-        pod2.parent = namespace2;
+        pod2.parent = replicaSet2;
         pod2.persist();
 
         // Create target nodes under each pod
@@ -295,28 +329,63 @@ public class Issue1571Test {
         Assertions.assertNotNull(targetNode1After, "Target node 1 should still exist");
         Assertions.assertNotNull(targetNode2After, "Target node 2 should still exist");
 
-        // Both pods should now be children of the kept namespace
+        // Verify Deployment deduplication
+        List<DiscoveryNode> deploymentsAfter =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "nodeType = ?1 and name = ?2",
+                                KubeDiscoveryNodeType.DEPLOYMENT.getKind(),
+                                "test-deployment")
+                        .list();
+        Assertions.assertEquals(
+                1, deploymentsAfter.size(), "Should have only 1 Deployment node after migration");
+        DiscoveryNode keptDeployment = deploymentsAfter.get(0);
+        Assertions.assertEquals(
+                keepId, keptDeployment.parent.id, "Deployment should be under the kept namespace");
+
+        // Verify ReplicaSet deduplication
+        List<DiscoveryNode> replicaSetsAfter =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "nodeType = ?1 and name = ?2",
+                                KubeDiscoveryNodeType.REPLICASET.getKind(),
+                                "test-replicaset")
+                        .list();
+        Assertions.assertEquals(
+                1, replicaSetsAfter.size(), "Should have only 1 ReplicaSet node after migration");
+        DiscoveryNode keptReplicaSet = replicaSetsAfter.get(0);
+        Assertions.assertEquals(
+                keptDeployment.id,
+                keptReplicaSet.parent.id,
+                "ReplicaSet should be under the kept deployment");
+
+        // Both pods should now be children of the kept replicaset
         DiscoveryNode pod1After = DiscoveryNode.findById(pod1.id);
         DiscoveryNode pod2After = DiscoveryNode.findById(pod2.id);
 
         Assertions.assertNotNull(pod1After, "Pod 1 should still exist");
         Assertions.assertNotNull(pod2After, "Pod 2 should still exist");
         Assertions.assertEquals(
-                keepId, pod1After.parent.id, "Pod 1 should now be under the kept namespace");
+                keptReplicaSet.id,
+                pod1After.parent.id,
+                "Pod 1 should now be under the kept replicaset");
         Assertions.assertEquals(
-                keepId, pod2After.parent.id, "Pod 2 should now be under the kept namespace");
+                keptReplicaSet.id,
+                pod2After.parent.id,
+                "Pod 2 should now be under the kept replicaset");
 
-        // Verify the kept namespace has both pods as children
-        DiscoveryNode keptNamespaceWithChildren = DiscoveryNode.findById(keepId);
+        // Verify the kept replicaset has both pods as children
+        DiscoveryNode keptReplicaSetWithChildren = DiscoveryNode.findById(keptReplicaSet.id);
         Assertions.assertEquals(
                 2,
-                keptNamespaceWithChildren.children.size(),
-                "Kept namespace should have 2 children (both pods)");
+                keptReplicaSetWithChildren.children.size(),
+                "Kept replicaset should have 2 children (both pods)");
 
         // Verify we can query all descendant targets through the single namespace
+        DiscoveryNode keptNamespaceWithChildren = DiscoveryNode.findById(keepId);
         List<DiscoveryNode> descendantTargets =
-                keptNamespaceWithChildren.children.stream()
-                        .flatMap(pod -> pod.children.stream())
+                keptNamespaceWithChildren.children.stream() // Deployments
+                        .flatMap(deployment -> deployment.children.stream()) // ReplicaSets
+                        .flatMap(replicaSet -> replicaSet.children.stream()) // Pods
+                        .flatMap(pod -> pod.children.stream()) // Target nodes
                         .filter(node -> node.target != null)
                         .toList();
 

--- a/src/test/java/io/cryostat/discovery/Issue1571Test.java
+++ b/src/test/java/io/cryostat/discovery/Issue1571Test.java
@@ -48,6 +48,21 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class Issue1571Test {
 
+    private static final String GRAPHQL_QUERY =
+            """
+            query {
+              environmentNodes(filter: { nodeTypes: ["Namespace"]} ) {
+                name
+                nodeType
+                descendantTargets {
+                  target {
+                    alias
+                  }
+                }
+              }
+            }
+            """;
+
     @Inject EntityManager entityManager;
     @Inject Flyway flyway;
     @Inject UserTransaction userTransaction;
@@ -99,7 +114,7 @@ public class Issue1571Test {
         namespace1.persist();
 
         DiscoveryNode namespace2 = new DiscoveryNode();
-        namespace2.name = "test-namespace"; // Same name!
+        namespace2.name = namespace1.name; // Same name!
         namespace2.nodeType = KubeDiscoveryNodeType.NAMESPACE.getKind();
         namespace2.labels = new HashMap<>();
         namespace2.children = new ArrayList<>();
@@ -185,14 +200,10 @@ public class Issue1571Test {
         List<Target> targetsBefore = Target.listAll();
         Assertions.assertEquals(2, targetsBefore.size(), "Should have 2 targets before migration");
 
-        // Verify the BUG exists via GraphQL - should only return 1 target due to Set deduplication
-        String graphqlQueryBefore =
-                "query { environmentNodes(filter: { nodeTypes: [\"Namespace\"] }) { name nodeType"
-                        + " descendantTargets { target { alias } } } }";
-
+        // Verify the bug exists via GraphQL - should only return 1 target due to Set deduplication
         JsonPath responseBefore =
                 given().contentType(ContentType.JSON)
-                        .body(Map.of("query", graphqlQueryBefore))
+                        .body(Map.of("query", GRAPHQL_QUERY))
                         .when()
                         .post("/api/v4/graphql")
                         .then()
@@ -200,9 +211,6 @@ public class Issue1571Test {
                         .extract()
                         .jsonPath();
 
-        // Before the fix: Even though there are 2 Namespace nodes in the database,
-        // GraphQL's recurseChildren() uses a Set which deduplicates based on equals(),
-        // so only 1 Namespace node is returned (this is the bug)
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> environmentNodesBefore =
                 (List<Map<String, Object>>)
@@ -224,22 +232,18 @@ public class Issue1571Test {
             }
         }
 
-        // This demonstrates the bug: even though 2 targets exist in the database,
-        // GraphQL only returns 1 due to Set deduplication of duplicate Namespace nodes
         Assertions.assertEquals(
                 1,
                 totalTargetsBefore,
-                "GraphQL should return only 1 target before migration (demonstrates the bug)");
+                "GraphQL should return only 1 target before migration (bug)");
 
         userTransaction.commit();
 
         // Step 3: Run the V4.2.1 migration
         flyway.migrate();
-
         // Clear the EntityManager cache to ensure we're reading fresh data from the database
         // after the migration has run
         entityManager.clear();
-
         // Also clear the Hibernate second-level cache if it exists
         entityManager.getEntityManagerFactory().getCache().evictAll();
 
@@ -261,12 +265,10 @@ public class Issue1571Test {
         Assertions.assertEquals(
                 keepId, keptNamespace.id, "Should keep the Namespace with the lowest ID");
 
-        // Verify the deleted namespace no longer exists
         DiscoveryNode deletedNamespace = DiscoveryNode.findById(deleteId);
         Assertions.assertNull(
                 deletedNamespace, "Duplicate Namespace node should have been deleted");
 
-        // Verify both targets still exist
         List<Target> targetsAfter = Target.listAll();
         Assertions.assertEquals(
                 2, targetsAfter.size(), "Should still have 2 targets after migration");
@@ -309,14 +311,10 @@ public class Issue1571Test {
                 "Should be able to find both targets through the single namespace");
 
         // Step 5: Verify GraphQL API also returns both targets
-        // This tests the actual API that users would call
-        String graphqlQuery =
-                "query { environmentNodes(filter: { nodeTypes: [\"Namespace\"] }) { name nodeType"
-                        + " descendantTargets { target { alias } } } }";
-
+        // This tests the actual API that users would call;
         JsonPath response =
                 given().contentType(ContentType.JSON)
-                        .body(Map.of("query", graphqlQuery))
+                        .body(Map.of("query", GRAPHQL_QUERY))
                         .when()
                         .post("/api/v4/graphql")
                         .then()

--- a/src/test/java/io/cryostat/discovery/Issue1571Test.java
+++ b/src/test/java/io/cryostat/discovery/Issue1571Test.java
@@ -265,6 +265,21 @@ public class Issue1571Test {
         Assertions.assertEquals(
                 keepId, keptNamespace.id, "Should keep the Namespace with the lowest ID");
 
+        // Verify the Namespace is now parented to KubernetesApi Realm
+        DiscoveryNode k8sRealm =
+                DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "KubernetesApi realm should exist after"
+                                                        + " migration"));
+        Assertions.assertNotNull(
+                keptNamespace.parent, "Namespace should have a parent after migration");
+        Assertions.assertEquals(
+                k8sRealm.id,
+                keptNamespace.parent.id,
+                "Namespace should be parented to KubernetesApi Realm after migration");
+
         DiscoveryNode deletedNamespace = DiscoveryNode.findById(deleteId);
         Assertions.assertNull(
                 deletedNamespace, "Duplicate Namespace node should have been deleted");

--- a/src/test/java/io/cryostat/graphql/RootNodeTest.java
+++ b/src/test/java/io/cryostat/graphql/RootNodeTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.graphql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import io.cryostat.discovery.DiscoveryNode;
+import io.cryostat.targets.Target;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RootNodeTest {
+
+    private DiscoveryNode rootNode;
+    private DiscoveryNode childNode1;
+    private DiscoveryNode childNode2;
+    private DiscoveryNode grandchildNode1;
+    private DiscoveryNode grandchildNode2;
+    private DiscoveryNode grandchildNode3;
+    private Target target1;
+    private Target target2;
+    private Target target3;
+
+    @BeforeEach
+    void setup() {
+        // Create test targets
+        target1 = createTarget("target1", "service:jmx:rmi:///jndi/rmi://target1:9091/jmxrmi");
+        target2 = createTarget("target2", "service:jmx:rmi:///jndi/rmi://target2:9091/jmxrmi");
+        target3 = createTarget("target3", "service:jmx:rmi:///jndi/rmi://target3:9091/jmxrmi");
+
+        // Create a tree structure:
+        //        root
+        //       /    \
+        //   child1   child2
+        //    /  \       \
+        // gc1  gc2      gc3
+        rootNode = createNode("root", "Universe", null);
+        childNode1 = createNode("child1", "Realm", null);
+        childNode2 = createNode("child2", "Realm", null);
+        grandchildNode1 = createNode("grandchild1", "JVM", target1);
+        grandchildNode2 = createNode("grandchild2", "JVM", target2);
+        grandchildNode3 = createNode("grandchild3", "JVM", target3);
+
+        // Build the tree
+        rootNode.children = new ArrayList<>(List.of(childNode1, childNode2));
+        childNode1.children = new ArrayList<>(List.of(grandchildNode1, grandchildNode2));
+        childNode2.children = new ArrayList<>(List.of(grandchildNode3));
+        grandchildNode1.children = new ArrayList<>();
+        grandchildNode2.children = new ArrayList<>();
+        grandchildNode3.children = new ArrayList<>();
+    }
+
+    @Test
+    void testRecurseChildren_withNullPredicate_returnsAllNodes() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(rootNode, null);
+
+        assertEquals(6, result.size());
+        assertTrue(result.contains(rootNode));
+        assertTrue(result.contains(childNode1));
+        assertTrue(result.contains(childNode2));
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode2));
+        assertTrue(result.contains(grandchildNode3));
+    }
+
+    @Test
+    void testRecurseChildren_withAlwaysTruePredicate_returnsAllNodes() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(rootNode, n -> true);
+
+        assertEquals(6, result.size());
+        assertTrue(result.contains(rootNode));
+        assertTrue(result.contains(childNode1));
+        assertTrue(result.contains(childNode2));
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode2));
+        assertTrue(result.contains(grandchildNode3));
+    }
+
+    @Test
+    void testRecurseChildren_withAlwaysFalsePredicate_returnsEmptySet() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(rootNode, n -> false);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testRecurseChildren_filterByTargetNotNull_returnsOnlyTargetNodes() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(rootNode, n -> n.target != null);
+
+        assertEquals(3, result.size());
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode2));
+        assertTrue(result.contains(grandchildNode3));
+        assertFalse(result.contains(rootNode));
+        assertFalse(result.contains(childNode1));
+        assertFalse(result.contains(childNode2));
+    }
+
+    @Test
+    void testRecurseChildren_filterByNodeType_returnsMatchingNodes() {
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(rootNode, n -> "Realm".equals(n.nodeType));
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains(childNode1));
+        assertTrue(result.contains(childNode2));
+        assertFalse(result.contains(rootNode));
+        assertFalse(result.contains(grandchildNode1));
+    }
+
+    @Test
+    void testRecurseChildren_filterByName_returnsMatchingNode() {
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(rootNode, n -> "child1".equals(n.name));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(childNode1));
+    }
+
+    @Test
+    void testRecurseChildren_fromChildNode_returnsSubtree() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(childNode1, null);
+
+        assertEquals(3, result.size());
+        assertTrue(result.contains(childNode1));
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode2));
+        assertFalse(result.contains(rootNode));
+        assertFalse(result.contains(childNode2));
+        assertFalse(result.contains(grandchildNode3));
+    }
+
+    @Test
+    void testRecurseChildren_fromLeafNode_returnsSingleNode() {
+        Set<DiscoveryNode> result = RootNode.recurseChildren(grandchildNode1, null);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(grandchildNode1));
+    }
+
+    @Test
+    void testRecurseChildren_fromLeafNodeWithPredicate_returnsNodeIfMatches() {
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(grandchildNode1, n -> n.target != null);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(grandchildNode1));
+    }
+
+    @Test
+    void testRecurseChildren_fromLeafNodeWithFailingPredicate_returnsEmpty() {
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(grandchildNode1, n -> n.target == null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testRecurseChildren_withNodeHavingNoChildren_returnsOnlyThatNode() {
+        DiscoveryNode singleNode = createNode("single", "JVM", target1);
+        singleNode.children = new ArrayList<>();
+
+        Set<DiscoveryNode> result = RootNode.recurseChildren(singleNode, null);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(singleNode));
+    }
+
+    @Test
+    void testRecurseChildren_withNodeHavingNullChildren_returnsOnlyThatNode() {
+        DiscoveryNode singleNode = createNode("single", "JVM", target1);
+        singleNode.children = null;
+
+        Set<DiscoveryNode> result = RootNode.recurseChildren(singleNode, null);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(singleNode));
+    }
+
+    @Test
+    void testRecurseChildren_complexPredicate_returnsMatchingNodes() {
+        // Filter for nodes that are either the root or have targets
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(rootNode, n -> "root".equals(n.name) || n.target != null);
+
+        assertEquals(4, result.size());
+        assertTrue(result.contains(rootNode));
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode2));
+        assertTrue(result.contains(grandchildNode3));
+        assertFalse(result.contains(childNode1));
+        assertFalse(result.contains(childNode2));
+    }
+
+    @Test
+    void testRecurseChildren_deepTree_returnsAllNodes() {
+        // Create a deeper tree: root -> level1 -> level2 -> level3 -> level4
+        DiscoveryNode level1 = createNode("level1", "Type1", null);
+        DiscoveryNode level2 = createNode("level2", "Type2", null);
+        DiscoveryNode level3 = createNode("level3", "Type3", null);
+        DiscoveryNode level4 = createNode("level4", "Type4", target1);
+
+        level1.children = new ArrayList<>(List.of(level2));
+        level2.children = new ArrayList<>(List.of(level3));
+        level3.children = new ArrayList<>(List.of(level4));
+        level4.children = new ArrayList<>();
+
+        Set<DiscoveryNode> result = RootNode.recurseChildren(level1, null);
+
+        assertEquals(4, result.size());
+        assertTrue(result.contains(level1));
+        assertTrue(result.contains(level2));
+        assertTrue(result.contains(level3));
+        assertTrue(result.contains(level4));
+    }
+
+    @Test
+    void testRecurseChildren_wideTree_returnsAllNodes() {
+        // Create a wide tree with many children at one level
+        DiscoveryNode parent = createNode("parent", "Parent", null);
+        List<DiscoveryNode> children = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            DiscoveryNode child = createNode("child" + i, "Child", null);
+            child.children = new ArrayList<>();
+            children.add(child);
+        }
+        parent.children = children;
+
+        Set<DiscoveryNode> result = RootNode.recurseChildren(parent, null);
+
+        assertEquals(11, result.size()); // parent + 10 children
+        assertTrue(result.contains(parent));
+        children.forEach(child -> assertTrue(result.contains(child)));
+    }
+
+    @Test
+    void testRecurseChildren_filterByTargetJvmId_returnsMatchingTargetNodes() {
+        target1.jvmId = "jvm-123";
+        target2.jvmId = "jvm-456";
+        target3.jvmId = "jvm-123";
+
+        Set<DiscoveryNode> result =
+                RootNode.recurseChildren(
+                        rootNode, n -> n.target != null && "jvm-123".equals(n.target.jvmId));
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains(grandchildNode1));
+        assertTrue(result.contains(grandchildNode3));
+        assertFalse(result.contains(grandchildNode2));
+    }
+
+    private DiscoveryNode createNode(String name, String nodeType, Target target) {
+        DiscoveryNode node = new DiscoveryNode();
+        node.name = name;
+        node.nodeType = nodeType;
+        node.labels = new HashMap<>();
+        node.target = target;
+        node.children = new ArrayList<>();
+        return node;
+    }
+
+    private Target createTarget(String alias, String connectUrl) {
+        Target target = new Target();
+        target.alias = alias;
+        target.connectUrl = URI.create(connectUrl);
+        target.labels = new HashMap<>();
+        target.annotations = new Target.Annotations();
+        return target;
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1571

## Description of the change:
1. Fixes up GraphQL implementation to not simply call `.filter(filter)` when `filter` is a nullable filter input object. If no filter is provided then this should be an 'accept all' filter.
2. Fixes a bug in Agent publication using the Kubernetes fill algorithm: Cryostat would create a new Namespace node for each Agent that registered this way, with identical name/nodeType/labels. These nodes would then cause issues later on in GraphQL querying because their `hashCode/equals` implementation would make them look equivalent when they actually aren't, because their descendant nodes would differ. Then, it would create an ownership lineage from the contextual Pod to the Namespace, filling in the ReplicaSet and Deployment - and creating duplicates of these as well, rather than reusing existing nodes. The discovery model should not have duplicate nodes like this. The new implementation reuses existing nodes on publication, and also uses a Flyway migration to correct existing hierarchies in the database. Since these nodes are also likely to share at least the Namespace nodes with the KubeEndpointSlicesDiscovery mechanism and KubernetesApi Realm, this change also does something new: it uses a cross-Realm reference between nodes. This was previously never done because each discovery plugin was its own individual silo of target information from distinct sources, but the discovery plugin fill algorithm intentionally bridges that gap. Since there is always one KubernetesApi Realm, and when using the fill algorithm the filled nodes are populated by the KubeEndpointSlicesDiscovery mechanism and represent Kubernetes entities, and we don't want to have any DiscoveryNodes with duplicate `<nodeType, name>` in the tree, it only makes sense for those singleton nodes to live within the KubernetesApi Realm and have each filled lineage from *n* plugin (Agent) instances refer to those cross-Realm. This means that the plugins' own Realms will remain empty when the fill algorithm is used on publication, since all of the lineage as well as the target entity will all be placed under the Kubernetes Realm subtree, so there is an additional label-based tagging system that tracks the plugin's registration ID so that the cross-Realm nodes belonging to a plugin can be cleaned up when that plugin goes offline.
3. Changes the relationship between DiscoveryPlugin and Credential. Previously, their OneToOne relationship also included symmetric cascading deletions. This has been updated so that DiscoveryPlugin deletion cascades to deleting the associated Credential, but *not* the reverse.
4. Changes the rate-limit configuration from using a `smooth` limit to a `rolling` limit: https://smallrye.io/docs/smallrye-fault-tolerance/6.2.1/reference/rate-limit.html#_type . The `smooth` type would result in Agents receiving an HTTP 429 response fairly often during the registration and deregistration process since the limit ended up being 1 request per second with no allowance for any burstiness. The `rolling` limit does allow for short bursts of more rapid activity, but will begin rate-limiting requests after sustained activity.

## How to manually test:
1. Check out and build PR, then deploy as a custom Cryostat `CORE_IMG` via the Operator
2. Set up a Cryostat instance monitoring an `apps` namespace, and in that Namespace `make sample_app_agent_injected` pointing at the Cryostat instance. Edit the deployment to configure Agent Harvester autoconfig. Scale this sample app deployment to 2+ replicas.

```yaml
          cryostat.io/harvester-max-files: "2"
          cryostat.io/harvester-period: 1m
          cryostat.io/harvester-template: default
          cryostat.io/log-level: debug
          cryostat.io/name: cryostat
          cryostat.io/namespace: cryostat
```

3. Use an HTTP client like httpie to issue GraphQL requests:

```
https -v --pretty=format --auth-type=bearer --auth=$(oc whoami -t) https://cryostat-cryostat.apps-crc.testing/api/v4/graphql query='{ environmentNodes(filter: { nodeTypes: ["Namespace"], names: ["apps2"] }) { descendantTargets(filter: { nodeTypes: ["CryostatAgent"]}) { name nodeType target { alias id jvmId activeRecordings { aggregate { count } data { name state } } archivedRecordings { aggregate { count } data { name size } } } } } }'
```

```
https -v --pretty=format --auth-type=bearer --auth=$(oc whoami -t) https://cryostat-cryostat.apps-crc.testing/api/v4/graphql query='{ environmentNodes(filter: { nodeTypes: ["Pod"] }) { labels(key: "discovery.cryostat.io/namespace") { value } descendantTargets(filter: { nodeTypes: ["CryostatAgent"]}) { name nodeType target { alias id jvmId activeRecordings { aggregate { count } data { name state } } archivedRecordings { aggregate { count } data { name size } } } } } }'
```

and compare the results to

```
https -v --pretty=format --auth-type=bearer --auth=$(oc whoami -t) https://cryostat-cryostat.apps-crc.testing/api/v4/discovery?mergeRealms=true
```

and

```
https -v --pretty=format --auth-type=bearer --auth=$(oc whoami -t) https://cryostat-cryostat.apps-crc.testing/api/v4/discovery
```
