### PR TITLE
fix(discovery): Agent fill algorithm includes k8s labels and annotations

### DIFF
--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -43,6 +43,7 @@ import io.cryostat.discovery.DiscoveryPlugin.PluginCallback;
 import io.cryostat.discovery.DiscoveryPlugin.PluginCleanupHelper;
 import io.cryostat.discovery.KubeEndpointSlicesDiscovery.KubeDiscoveryNodeType;
 import io.cryostat.discovery.NodeType.BaseNodeType;
+import io.cryostat.targets.Target.Annotations;
 import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.util.URIUtil;
 
@@ -608,8 +609,9 @@ public class Discovery {
 
                             DiscoveryNode lineage =
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
-                            Map<String, String> kubernetesLabels =
-                                    k8sDiscovery.getKubernetesLabels(namespace, name, nodeType);
+
+                            KubeEndpointSlicesDiscovery.KubernetesMetadata k8sMetadata =
+                                    k8sDiscovery.getKubernetesMetadata(namespace, name, nodeType);
 
                             DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
 
@@ -621,16 +623,37 @@ public class Discovery {
                                                 DISCOVERY_PLUGIN_ID_LABEL_KEY,
                                                 plugin.id.toString());
 
-                                        if (n.target != null && !kubernetesLabels.isEmpty()) {
-                                            if (n.target.labels == null) {
-                                                n.target.labels = new HashMap<>();
+                                        if (n.target != null) {
+                                            if (!k8sMetadata.labels().isEmpty()) {
+                                                if (n.target.labels == null) {
+                                                    n.target.labels = new HashMap<>();
+                                                }
+                                                k8sMetadata
+                                                        .labels()
+                                                        .forEach(
+                                                                (k, v) ->
+                                                                        n.target.labels.putIfAbsent(
+                                                                                k, v));
                                             }
-                                            kubernetesLabels.forEach(
-                                                    (k, v) -> n.target.labels.putIfAbsent(k, v));
-                                            logger.debugv(
-                                                    "Enriched target {0} with {1} Kubernetes"
-                                                            + " labels",
-                                                    n.target.connectUrl, kubernetesLabels.size());
+
+                                            if (!k8sMetadata.annotations().isEmpty()) {
+                                                if (n.target.annotations == null) {
+                                                    n.target.annotations = new Annotations();
+                                                }
+                                                Map<String, String> platformAnnotations =
+                                                        new HashMap<>(
+                                                                n.target.annotations.platform());
+                                                k8sMetadata
+                                                        .annotations()
+                                                        .forEach(
+                                                                (k, v) ->
+                                                                        platformAnnotations
+                                                                                .putIfAbsent(k, v));
+                                                n.target.annotations =
+                                                        new Annotations(
+                                                                platformAnnotations,
+                                                                n.target.annotations.cryostat());
+                                            }
                                         }
 
                                         n.persist();

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -608,9 +608,9 @@ public class Discovery {
 
                             DiscoveryNode lineage =
                                     k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
+                            Map<String, String> kubernetesLabels =
+                                    k8sDiscovery.getKubernetesLabels(namespace, name, nodeType);
 
-                            // Merge the lineage into the existing tree, reusing nodes where
-                            // possible
                             DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
 
                             innermost.children.addAll(body.nodes);
@@ -620,18 +620,28 @@ public class Discovery {
                                         n.labels.put(
                                                 DISCOVERY_PLUGIN_ID_LABEL_KEY,
                                                 plugin.id.toString());
+
+                                        if (n.target != null && !kubernetesLabels.isEmpty()) {
+                                            if (n.target.labels == null) {
+                                                n.target.labels = new HashMap<>();
+                                            }
+                                            kubernetesLabels.forEach(
+                                                    (k, v) -> n.target.labels.putIfAbsent(k, v));
+                                            logger.debugv(
+                                                    "Enriched target {0} with {1} Kubernetes"
+                                                            + " labels",
+                                                    n.target.connectUrl, kubernetesLabels.size());
+                                        }
+
                                         n.persist();
                                     });
 
-                            // Persist the k8s lineage hierarchy under KubernetesApi Realm
                             DiscoveryNode current = innermost;
                             while (current != null && current != nsNode) {
                                 current.persist();
                                 current = current.parent;
                             }
                             nsNode.persist();
-                            // Agent Realm remains empty - targets are under KubernetesApi. Labels
-                            // are used for cleanup when the plugin goes offline.
                             break;
                         default:
                             replacementChildren.addAll(body.nodes);
@@ -914,7 +924,6 @@ public class Discovery {
 
             if (existingNode != null) {
                 // Reuse the existing node
-                // Merge labels from the new lineage into the existing node
                 if (lineageNode.labels != null) {
                     existingNode.labels.putAll(lineageNode.labels);
                 }
@@ -926,7 +935,6 @@ public class Discovery {
                 currentParent = lineageNode;
             }
 
-            // Move to the next level in the lineage
             if (lineageNode.children == null || lineageNode.children.isEmpty()) {
                 // Reached the leaf node
                 return currentParent;

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -179,13 +179,10 @@ public class DiscoveryPlugin extends PanacheEntityBase {
                 try {
                     DiscoveryNode parent = node.parent;
                     if (parent != null) {
-                        // Remove node from parent's collection before deleting
-                        // This ensures parent.hasChildren() will be accurate
                         parent.children.remove(node);
                         node.parent = null;
                     }
                     node.delete();
-                    // Recursively prune empty parent nodes up the tree
                     pruneEmptyAncestors(parent);
                 } catch (Exception e) {
                     logger.warn(e);
@@ -195,7 +192,6 @@ public class DiscoveryPlugin extends PanacheEntityBase {
 
         void pruneEmptyAncestors(DiscoveryNode child) {
             // Walk up the hierarchy, removing childless nodes from their parents
-            // Follow the same pattern as KubeEndpointSlicesDiscovery.pruneOwnerChain()
             while (child != null) {
                 DiscoveryNode parent = child.parent;
 
@@ -206,7 +202,7 @@ public class DiscoveryPlugin extends PanacheEntityBase {
                     break;
                 }
 
-                entityManager.refresh(parent); // Reload from DB with current children
+                entityManager.refresh(parent);
 
                 // Remove child from parent's collection - orphan removal will delete it
                 parent.children.remove(child);
@@ -222,18 +218,12 @@ public class DiscoveryPlugin extends PanacheEntityBase {
                                 + " isRealm={5}",
                         parent.name, parent.id, parent.nodeType, hasChildren, isNamespace, isRealm);
 
-                // Stop pruning if:
-                // 1. Parent is a Realm (always preserve Realms)
-                // 2. Parent has children (preserve non-empty nodes)
-                // Note: Empty Namespaces should be pruned, so we don't stop just because it's a
-                // Namespace
                 if (isRealm || hasChildren) {
                     logger.debugv("Stopping pruning at parent node {0}", parent.name);
                     break;
                 }
 
                 logger.debugv("Continuing to prune parent node {0}", parent.name);
-                // Move up to check the parent too
                 child = parent;
             }
         }

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1260,6 +1260,34 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     /**
+     * Retrieves Kubernetes labels for a given resource.
+     *
+     * @param namespace Kubernetes namespace
+     * @param name Resource name
+     * @param nodeType Resource type (e.g., "Pod", "Deployment")
+     * @return Map of Kubernetes labels, or empty map if resource not found or has no labels
+     */
+    public Map<String, String> getKubernetesLabels(String namespace, String name, String nodeType) {
+        Map<String, String> labels = new HashMap<>();
+        try {
+            Pair<HasMetadata, DiscoveryNode> kubeResource =
+                    queryForNodeReadOnly(namespace, name, nodeType);
+            if (kubeResource != null
+                    && kubeResource.getLeft() != null
+                    && kubeResource.getLeft().getMetadata() != null
+                    && kubeResource.getLeft().getMetadata().getLabels() != null) {
+                labels.putAll(kubeResource.getLeft().getMetadata().getLabels());
+                logger.debugv(
+                        "Retrieved {0} Kubernetes labels for {1}/{2}",
+                        labels.size(), namespace, name);
+            }
+        } catch (Exception e) {
+            logger.warnv(e, "Failed to retrieve Kubernetes labels for {0}/{1}", namespace, name);
+        }
+        return labels;
+    }
+
+    /**
      * Queries the database to find an existing DiscoveryNode by composite ID. A DiscoveryNode is
      * uniquely identified by: name + nodeType + namespace label.
      *

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1639,7 +1640,12 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
      * @param annotations Kubernetes annotations
      */
     public static record KubernetesMetadata(
-            Map<String, String> labels, Map<String, String> annotations) {}
+            Map<String, String> labels, Map<String, String> annotations) {
+        public KubernetesMetadata(Map<String, String> labels, Map<String, String> annotations) {
+            this.labels = Collections.unmodifiableMap(new HashMap<>(labels));
+            this.annotations = Collections.unmodifiableMap(new HashMap<>(annotations));
+        }
+    }
 
     static record NamespaceQueryEvent(Collection<String> namespaces) {
         static NamespaceQueryEvent from(Collection<String> namespaces) {

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -1268,23 +1268,43 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
      * @return Map of Kubernetes labels, or empty map if resource not found or has no labels
      */
     public Map<String, String> getKubernetesLabels(String namespace, String name, String nodeType) {
+        return getKubernetesMetadata(namespace, name, nodeType).labels();
+    }
+
+    /**
+     * Retrieves Kubernetes metadata (labels and annotations) for a given resource.
+     *
+     * @param namespace Kubernetes namespace
+     * @param name Resource name
+     * @param nodeType Resource type (e.g., "Pod", "Deployment")
+     * @return KubernetesMetadata containing labels and annotations, or empty maps if resource not
+     *     found
+     */
+    public KubernetesMetadata getKubernetesMetadata(
+            String namespace, String name, String nodeType) {
         Map<String, String> labels = new HashMap<>();
+        Map<String, String> annotations = new HashMap<>();
         try {
             Pair<HasMetadata, DiscoveryNode> kubeResource =
                     queryForNodeReadOnly(namespace, name, nodeType);
-            if (kubeResource != null
-                    && kubeResource.getLeft() != null
-                    && kubeResource.getLeft().getMetadata() != null
-                    && kubeResource.getLeft().getMetadata().getLabels() != null) {
-                labels.putAll(kubeResource.getLeft().getMetadata().getLabels());
-                logger.debugv(
-                        "Retrieved {0} Kubernetes labels for {1}/{2}",
-                        labels.size(), namespace, name);
+            if (kubeResource != null && kubeResource.getLeft() != null) {
+                HasMetadata metadata = kubeResource.getLeft();
+                if (metadata.getMetadata() != null) {
+                    if (metadata.getMetadata().getLabels() != null) {
+                        labels.putAll(metadata.getMetadata().getLabels());
+                    }
+                    if (metadata.getMetadata().getAnnotations() != null) {
+                        annotations.putAll(metadata.getMetadata().getAnnotations());
+                    }
+                    logger.debugv(
+                            "Retrieved {0} labels and {1} annotations for {2}/{3}",
+                            labels.size(), annotations.size(), namespace, name);
+                }
             }
         } catch (Exception e) {
-            logger.warnv(e, "Failed to retrieve Kubernetes labels for {0}/{1}", namespace, name);
+            logger.warnv(e, "Failed to retrieve Kubernetes metadata for {0}/{1}", namespace, name);
         }
-        return labels;
+        return new KubernetesMetadata(labels, annotations);
     }
 
     /**
@@ -1611,6 +1631,15 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             return StringUtils.isNotBlank(serviceHost.orElse(""));
         }
     }
+
+    /**
+     * Container for Kubernetes metadata (labels and annotations).
+     *
+     * @param labels Kubernetes labels
+     * @param annotations Kubernetes annotations
+     */
+    public static record KubernetesMetadata(
+            Map<String, String> labels, Map<String, String> annotations) {}
 
     static record NamespaceQueryEvent(Collection<String> namespaces) {
         static NamespaceQueryEvent from(Collection<String> namespaces) {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1573
Depends on #1572
Based on #1572

## Description of the change:
Include k8s object metadata (labels and annotations) from the Pod to the new Target entity.

## Motivation for the change:
This makes Agent registration/publication with the fill algorithm feel more complete and equivalent to the older Endpoints/EndpointSlice-based discovery and how "Kubernetes native" the data model feels when deployed in a k8s context.

## How to manually test:
1. Check out and build PR
2. Use Cryostat Operator to deploy with this PR, ex. `CORE_IMG=quay.io/$myuser/cryostat:pr-1574 make deploy`
3. Create a Cryostat CR
4. `make sample_app` to deploy an EndpointSlice-discovered target
5. `make sample_app_agent_injected` to deploy an Agent with fill algorithm
6. Go to Topology view, compare the metadata of the two targets

<img width="1451" height="817" alt="image" src="https://github.com/user-attachments/assets/ba1c6010-c645-42b4-a104-434268d049e6" />

<img width="1451" height="817" alt="image" src="https://github.com/user-attachments/assets/49a9c376-7559-4126-a84f-036680382fd5" />
