### PR TITLE
fix(graphql): query archivedRecordings without sourceTarget

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -964,15 +964,16 @@ public class RecordingHelper {
                         item -> {
                             String path = item.key().strip();
                             String[] parts = path.split("/");
+                            String effectiveJvmId = parts[0];
                             String filename = parts[1];
                             Metadata metadata =
-                                    getArchivedRecordingMetadata(jvmId, filename)
+                                    getArchivedRecordingMetadata(effectiveJvmId, filename)
                                             .orElseGet(Metadata::empty);
                             return new ArchivedRecording(
-                                    jvmId,
+                                    effectiveJvmId,
                                     filename,
-                                    downloadUrl(jvmId, filename),
-                                    reportUrl(jvmId, filename),
+                                    downloadUrl(effectiveJvmId, filename),
+                                    reportUrl(effectiveJvmId, filename),
                                     metadata,
                                     item.size(),
                                     item.lastModified().getEpochSecond());

--- a/src/test/java/io/cryostat/graphql/GraphQLQueryTest.java
+++ b/src/test/java/io/cryostat/graphql/GraphQLQueryTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -390,6 +391,51 @@ class GraphQLQueryTest extends AbstractGraphQLTestBase {
                 equalTo(retrievedArchivedRecordingsName));
 
         // Delete archived recording
+        deleteRecording();
+    }
+
+    @Test
+    void shouldListArchivedRecordingsWithoutSourceTargetFilter() throws Exception {
+        String recordingName = "shouldListArchivedRecordingsWithoutSourceTargetFilter";
+        JsonObject notificationRecording = createRecording(recordingName);
+        assertThat(notificationRecording.getString("name"), equalTo(recordingName));
+
+        JsonObject archiveMutation = new JsonObject();
+        archiveMutation.put(
+                "query",
+                String.format(
+                        "mutation { archiveRecording (nodes: { annotations: [\"REALM = Custom"
+                            + " Targets\"]}, recordings: { name: \"%s\"}) { name downloadUrl } }",
+                        recordingName));
+
+        given().contentType(ContentType.JSON)
+                .body(archiveMutation.encode())
+                .when()
+                .post("/api/v4/graphql")
+                .then()
+                .statusCode(allOf(greaterThanOrEqualTo(200), lessThan(300)));
+
+        webSocketClient.expectNotification("ArchivedRecordingCreated", Duration.ofSeconds(15));
+
+        JsonPath response =
+                graphql("query { archivedRecordings { aggregate { count } data { name jvmId } } }");
+
+        List<Map<String, Object>> errors = response.getList("errors");
+        assertThat(errors, anyOf(nullValue(), empty()));
+
+        Integer count = response.getInt("data.archivedRecordings.aggregate.count");
+        assertThat(count, notNullValue());
+        assertThat(count, greaterThanOrEqualTo(1));
+
+        List<Map<String, Object>> archivedRecordings =
+                response.getList("data.archivedRecordings.data");
+        assertThat(archivedRecordings, is(not(empty())));
+
+        Map<String, Object> archivedRecording = archivedRecordings.getFirst();
+        assertThat(archivedRecording.get("name").toString(), not(emptyOrNullString()));
+        assertThat(archivedRecording.get("jvmId"), notNullValue());
+        assertThat(archivedRecording.get("jvmId").toString(), not(emptyOrNullString()));
+
         deleteRecording();
     }
 

--- a/src/test/java/io/cryostat/graphql/GraphQLTestModels.java
+++ b/src/test/java/io/cryostat/graphql/GraphQLTestModels.java
@@ -666,6 +666,7 @@ public class GraphQLTestModels {
     }
 
     public static class ArchivedRecording {
+        public String jvmId;
         public String name;
         public String reportUrl;
         public String downloadUrl;
@@ -675,6 +676,14 @@ public class GraphQLTestModels {
         public List<KeyValue> labels;
         private DoPutMetadata doPutMetadata;
         public DeletedRecording doDelete;
+
+        public String getJvmId() {
+            return jvmId;
+        }
+
+        public void setJvmId(String jvmId) {
+            this.jvmId = jvmId;
+        }
 
         public String getName() {
             return name;

--- a/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.resources.S3StorageResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = S3StorageResource.class, restrictToAnnotatedClass = true)
+class RecordingHelperTest extends AbstractTransactionalTestBase {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @Test
+    void shouldListArchivedRecordingsAcrossJvmIdsWhenSourceTargetIsNull() throws Exception {
+        int firstTargetId = defineSelfCustomTarget();
+        assertThat(firstTargetId, greaterThan(0));
+
+        Path firstRecording = Files.createTempFile("recording-helper-first-target", ".jfr");
+        Path secondRecording = Files.createTempFile("recording-helper-second-target", ".jfr");
+        Files.write(firstRecording, new byte[] {1, 2, 3, 4});
+        Files.write(secondRecording, new byte[] {5, 6, 7, 8});
+
+        try {
+            String secondJvmId = "other-jvm-id";
+            ActiveRecordings.Metadata metadata =
+                    new ActiveRecordings.Metadata(Map.of("purpose", "query-all-archives"));
+
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId, new TestFileUpload("first-target.jfr", firstRecording), metadata);
+            recordingHelper.uploadArchivedRecording(
+                    secondJvmId,
+                    new TestFileUpload("second-target.jfr", secondRecording),
+                    metadata);
+
+            List<ArchivedRecordings.ArchivedRecording> archivedRecordings =
+                    recordingHelper.listArchivedRecordings((String) null);
+
+            assertThat(archivedRecordings, hasSize(greaterThanOrEqualTo(2)));
+            assertThat(
+                    archivedRecordings.stream()
+                            .map(ArchivedRecordings.ArchivedRecording::jvmId)
+                            .toList(),
+                    hasItems(selfJvmId, secondJvmId));
+
+            ArchivedRecordings.ArchivedRecording secondTargetRecording =
+                    archivedRecordings.stream()
+                            .filter(r -> "second-target.jfr".equals(r.name()))
+                            .findFirst()
+                            .orElseThrow();
+
+            assertThat(secondTargetRecording.jvmId(), is(secondJvmId));
+        } finally {
+            Files.deleteIfExists(firstRecording);
+            Files.deleteIfExists(secondRecording);
+        }
+    }
+
+    static class TestFileUpload implements FileUpload {
+        private final String fileName;
+        private final Path path;
+
+        TestFileUpload(String fileName, Path path) {
+            this.fileName = fileName;
+            this.path = path;
+        }
+
+        @Override
+        public String name() {
+            return "recording";
+        }
+
+        @Override
+        public Path filePath() {
+            return path;
+        }
+
+        @Override
+        public String fileName() {
+            return fileName;
+        }
+
+        @Override
+        public long size() {
+            try {
+                return Files.size(path);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public String contentType() {
+            return "application/octet-stream";
+        }
+
+        @Override
+        public String charSet() {
+            return "";
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getHeaders() {
+            return new MultivaluedHashMap<>();
+        }
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1575
