### PR TITLE
fix(db): increase max revinfo username and async-profiler recording eventtypes lengths

### DIFF
--- a/src/main/java/io/cryostat/audit/RevisionInfo.java
+++ b/src/main/java/io/cryostat/audit/RevisionInfo.java
@@ -85,7 +85,7 @@ public class RevisionInfo {
     @Column(name = "REVTSTMP")
     private long timestamp;
 
-    @Column(name = "username", length = 64)
+    @Column(name = "username", length = 255)
     private String username;
 
     public int getId() {

--- a/src/main/java/io/cryostat/audit/RevisionInfoListener.java
+++ b/src/main/java/io/cryostat/audit/RevisionInfoListener.java
@@ -24,7 +24,7 @@ import org.jboss.logging.Logger;
 public class RevisionInfoListener implements RevisionListener {
 
     private static final Logger logger = Logger.getLogger(RevisionInfoListener.class);
-    private static final int MAX_USERNAME_LENGTH = 64;
+    private static final int MAX_USERNAME_LENGTH = 255;
 
     @Override
     public void newRevision(Object revisionEntity) {

--- a/src/main/java/io/cryostat/audit/RevisionInfoListener.java
+++ b/src/main/java/io/cryostat/audit/RevisionInfoListener.java
@@ -28,6 +28,10 @@ public class RevisionInfoListener implements RevisionListener {
 
     @Override
     public void newRevision(Object revisionEntity) {
+        if (revisionEntity == null) {
+            logger.debugf("Received null revisionEntity");
+            return;
+        }
         if (!(revisionEntity instanceof RevisionInfo revInfo)) {
             logger.debugf("Expected RevisionInfo but got %s", revisionEntity.getClass().getName());
             return;
@@ -36,7 +40,6 @@ public class RevisionInfoListener implements RevisionListener {
         String username = UserInfoResolver.resolveUsername();
 
         if (StringUtils.isNotBlank(username)) {
-            // Truncate if longer than max length (e.g., JWT tokens)
             if (username.length() >= MAX_USERNAME_LENGTH) {
                 logger.debugf(
                         "Truncating username from %d to %d characters",

--- a/src/main/java/io/cryostat/audit/RevisionInfoListener.java
+++ b/src/main/java/io/cryostat/audit/RevisionInfoListener.java
@@ -37,11 +37,11 @@ public class RevisionInfoListener implements RevisionListener {
 
         if (StringUtils.isNotBlank(username)) {
             // Truncate if longer than max length (e.g., JWT tokens)
-            if (username.length() > MAX_USERNAME_LENGTH) {
+            if (username.length() >= MAX_USERNAME_LENGTH) {
                 logger.debugf(
                         "Truncating username from %d to %d characters",
-                        username.length(), MAX_USERNAME_LENGTH);
-                username = username.substring(0, MAX_USERNAME_LENGTH);
+                        username.length(), MAX_USERNAME_LENGTH - 1);
+                username = username.substring(0, MAX_USERNAME_LENGTH - 1);
             }
             revInfo.setUsername(username);
             logger.debugf("Revision %d created by user: %s", revInfo.getId(), username);

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -1,0 +1,11 @@
+-- Update username constraint in REVINFO table from < 64 to < 255
+ALTER TABLE REVINFO DROP CONSTRAINT IF EXISTS revinfo_username_check;
+ALTER TABLE REVINFO ADD CONSTRAINT revinfo_username_check CHECK (char_length(username) < 255);
+
+-- Update eventType constraint in AsyncProfilerRecording table from < 50 to < 1024
+ALTER TABLE AsyncProfilerRecording DROP CONSTRAINT IF EXISTS asyncprofilerrecording_eventtype_check;
+ALTER TABLE AsyncProfilerRecording ADD CONSTRAINT asyncprofilerrecording_eventtype_check CHECK (char_length(eventType) < 1024);
+
+-- Update eventType constraint in AsyncProfilerRecording_AUD table from < 50 to < 1024
+ALTER TABLE AsyncProfilerRecording_AUD DROP CONSTRAINT IF EXISTS asyncprofilerrecording_aud_eventtype_check;
+ALTER TABLE AsyncProfilerRecording_AUD ADD CONSTRAINT asyncprofilerrecording_aud_eventtype_check CHECK (char_length(eventType) < 1024);

--- a/src/test/java/io/cryostat/audit/RevisionInfoListenerTest.java
+++ b/src/test/java/io/cryostat/audit/RevisionInfoListenerTest.java
@@ -161,7 +161,7 @@ class RevisionInfoListenerTest {
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
                     + "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."
                     + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-                        + "a".repeat(50);
+                        + "a".repeat(300);
         try (MockedStatic<UserInfoResolver> mockedResolver =
                 Mockito.mockStatic(UserInfoResolver.class)) {
             mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(jwtToken);

--- a/src/test/java/io/cryostat/audit/RevisionInfoListenerTest.java
+++ b/src/test/java/io/cryostat/audit/RevisionInfoListenerTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.audit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.cryostat.security.UserInfoResolver;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RevisionInfoListenerTest {
+
+    private RevisionInfoListener listener;
+    private RevisionInfo revisionInfo;
+
+    @BeforeEach
+    void setUp() {
+        listener = new RevisionInfoListener();
+        revisionInfo = new RevisionInfo();
+        revisionInfo.setId(1);
+    }
+
+    @Test
+    void shouldSetUsernameWhenUsernameIsAvailable() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("testuser");
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals("testuser", revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldNotSetUsernameWhenUsernameIsNull() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(null);
+
+            listener.newRevision(revisionInfo);
+
+            assertNull(revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldNotSetUsernameWhenUsernameIsEmpty() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("");
+
+            listener.newRevision(revisionInfo);
+
+            assertNull(revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldNotSetUsernameWhenUsernameIsBlank() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("   ");
+
+            listener.newRevision(revisionInfo);
+
+            assertNull(revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldTruncateUsernameWhenLengthEqualsMaxLength() {
+        String longUsername = "a".repeat(255);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(longUsername);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(254, revisionInfo.getUsername().length());
+            assertEquals("a".repeat(254), revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldTruncateUsernameWhenLengthExceedsMaxLength() {
+        String longUsername = "a".repeat(300);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(longUsername);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(254, revisionInfo.getUsername().length());
+            assertEquals("a".repeat(254), revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldNotTruncateUsernameWhenLengthIsJustBelowMaxLength() {
+        String username = "a".repeat(254);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(254, revisionInfo.getUsername().length());
+            assertEquals(username, revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleUsernameWithSpecialCharacters() {
+        String username = "user@example.com";
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(username, revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleUsernameWithUnicodeCharacters() {
+        String username = "用户名";
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(username, revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleJwtTokenAsUsername() {
+        String jwtToken =
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                    + "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."
+                    + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+                        + "a".repeat(50);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(jwtToken);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(254, revisionInfo.getUsername().length());
+            assertTrue(
+                    revisionInfo.getUsername().startsWith("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"));
+        }
+    }
+
+    @Test
+    void shouldDoNothingWhenRevisionEntityIsNotRevisionInfo() {
+        Object wrongEntity = new Object();
+        assertDoesNotThrow(() -> listener.newRevision(wrongEntity));
+    }
+
+    @Test
+    void shouldHandleNullRevisionEntity() {
+        assertDoesNotThrow(() -> listener.newRevision(null));
+    }
+
+    @Test
+    void shouldPreserveExistingRevisionId() {
+        revisionInfo.setId(42);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("testuser");
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(42, revisionInfo.getId());
+            assertEquals("testuser", revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleMultipleConsecutiveCalls() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("user1");
+
+            RevisionInfo rev1 = new RevisionInfo();
+            rev1.setId(1);
+            listener.newRevision(rev1);
+            assertEquals("user1", rev1.getUsername());
+
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn("user2");
+
+            RevisionInfo rev2 = new RevisionInfo();
+            rev2.setId(2);
+            listener.newRevision(rev2);
+            assertEquals("user2", rev2.getUsername());
+
+            assertEquals("user1", rev1.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleExceptionFromUserInfoResolver() {
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver
+                    .when(UserInfoResolver::resolveUsername)
+                    .thenThrow(new RuntimeException("Test exception"));
+
+            assertThrows(RuntimeException.class, () -> listener.newRevision(revisionInfo));
+        }
+    }
+
+    @Test
+    void shouldTruncateAtExactlyMaxLengthMinusOne() {
+        String username = "a".repeat(255);
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(254, revisionInfo.getUsername().length());
+            assertNotEquals(username, revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleUsernameWithWhitespacePrefix() {
+        String username = "  testuser";
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(username, revisionInfo.getUsername());
+        }
+    }
+
+    @Test
+    void shouldHandleUsernameWithWhitespaceSuffix() {
+        String username = "testuser  ";
+        try (MockedStatic<UserInfoResolver> mockedResolver =
+                Mockito.mockStatic(UserInfoResolver.class)) {
+            mockedResolver.when(UserInfoResolver::resolveUsername).thenReturn(username);
+
+            listener.newRevision(revisionInfo);
+
+            assertEquals(username, revisionInfo.getUsername());
+        }
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1578

## Description of the change:
Two fixes:
1. Increases the constraint lengths for the `revinfo.username` (audit log username) and `AsyncProfilerRecording.eventtype` (async-profiler recording enabled events)
2. Fixes an off-by-one bug in revinfo username handling - these are already supposed to be truncated if they're too long, sidestepping an observed bug in Operator Scorecard testing where the serviceaccount name is too long for the original constraint, but the off-by-one bug resulted in the truncation still being too long by 1 character.
