### PR TITLE
ci(podman): use user-local config for service timeout

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -126,7 +126,7 @@ jobs:
           blocked = true
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: /etc/containers/containers.conf
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
         write-mode: overwrite
         contents: |
           [engine]
@@ -217,7 +217,7 @@ jobs:
           blocked = true
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: /etc/containers/containers.conf
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
         write-mode: overwrite
         contents: |
           [engine]

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -59,7 +59,7 @@ jobs:
           blocked = true
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: /etc/containers/containers.conf
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
         write-mode: overwrite
         contents: |
           [engine]
@@ -139,7 +139,7 @@ jobs:
           blocked = true
     - uses: DamianReeves/write-file-action@v1.3
       with:
-        path: /etc/containers/containers.conf
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
         write-mode: overwrite
         contents: |
           [engine]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ For ease and convenience, it is suggested to use `podman` with the following con
 ```bash
 $ systemctl --user enable --now podman.socket
 $ # hack to work around testcontainers/podman "Broken pipe" issue
-$ sudo bash -c 'echo -e "[engine]\nservice_timeout=0" >> /etc/containers/containers.conf'
+$ mkdir -p $HOME/.config/containers/containers.conf.d
+$ echo -e "[engine]\nservice_timeout=0" > $HOME/.config/containers/containers.conf.d/999-service-timeout.conf
 ```
 
 `$HOME/.bashrc` (or equivalent shell configuration)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1589
