### PR TITLE
fix(tx): remove unnecessary Transactional annotation, do not mix with reactive Uni execution

### DIFF
--- a/src/main/java/io/cryostat/recordings/Snapshots.java
+++ b/src/main/java/io/cryostat/recordings/Snapshots.java
@@ -15,16 +15,20 @@
  */
 package io.cryostat.recordings;
 
+import java.time.Duration;
+
+import io.cryostat.ConfigProperties;
 import io.cryostat.recordings.ActiveRecordings.LinkedRecordingDescriptor;
 import io.cryostat.recordings.RecordingHelper.SnapshotCreationException;
 import io.cryostat.targets.Target;
 
-import io.smallrye.mutiny.Uni;
+import io.smallrye.common.annotation.Blocking;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
@@ -37,11 +41,15 @@ public class Snapshots {
     @Inject RecordingHelper recordingHelper;
     @Inject Logger logger;
 
+    @ConfigProperty(name = ConfigProperties.CONNECTIONS_FAILED_TIMEOUT)
+    Duration connectionFailedTimeout;
+
     @POST
+    @Blocking
     @Transactional
     @RolesAllowed("write")
     @Operation(summary = "Create a JFR Snapshot on the specified target")
-    public Uni<RestResponse<LinkedRecordingDescriptor>> createSnapshotUsingTargetId(
+    public RestResponse<LinkedRecordingDescriptor> createSnapshotUsingTargetId(
             @RestPath long targetId) throws Exception {
         return recordingHelper
                 .createSnapshot(Target.find("id", targetId).singleResult())
@@ -51,6 +59,8 @@ public class Snapshots {
                                 ResponseBuilder.ok(recordingHelper.toExternalForm(recording))
                                         .build())
                 .onFailure(SnapshotCreationException.class)
-                .recoverWithItem(ResponseBuilder.<LinkedRecordingDescriptor>accepted().build());
+                .recoverWithItem(ResponseBuilder.<LinkedRecordingDescriptor>accepted().build())
+                .await()
+                .atMost(connectionFailedTimeout);
     }
 }

--- a/src/main/java/io/cryostat/reports/AnalysisReportAggregator.java
+++ b/src/main/java/io/cryostat/reports/AnalysisReportAggregator.java
@@ -50,7 +50,6 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -211,7 +210,6 @@ public class AnalysisReportAggregator {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @RolesAllowed("read")
-    @Transactional
     @Operation(
             summary = "Retrieve the latest aggregate report data",
             description =
@@ -245,7 +243,6 @@ public class AnalysisReportAggregator {
     @Path("/{jvmId}")
     @Produces(MediaType.TEXT_PLAIN)
     @RolesAllowed("read")
-    @Transactional
     @Operation(
             summary = "Retrieve the latest aggregate report data for the specified target",
             description =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1594
See #1596

## Description of the change:
Potential issues discovered while experimenting with Quarkus 3.36. These are not flagged currently in Quarkus 3.33, but the build fails with 3.36 due to the use of Transactional on reactive methods (those returning `Uni` or `Multi`). In the case of the automated analysis report cache there is no need for any transaction at all so the annotation is simply removed. In the case of snapshot creation, this does need to be transactional and should be executed on a worker thread (not the event loop), so the `Uni` is `await()`ed, the method returns a non-reactive type, and the method is marked as Blocking to ensure it's run on a worker.
