### PR TITLE
chore(archive): use TransferManager to archive active recording streams

### DIFF
--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -126,7 +126,6 @@ import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.plugins.interrupt.JobInterruptMonitorPlugin;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -145,6 +144,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 
 /**
  * Utility class for all things relating to Flight Recording operations. This class is used to
@@ -167,7 +167,6 @@ public class RecordingHelper {
     public static final String DATASOURCE_FILENAME = "cryostat-analysis.jfr";
 
     @Inject S3Client storage;
-    @Inject S3AsyncClient storageAsync;
     @Inject S3TransferManager transferManager;
     final ExecutorService partUploader = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -1022,10 +1021,15 @@ public class RecordingHelper {
                 default:
                     throw new IllegalStateException();
             }
-            storageAsync
-                    .putObject(
-                            builder.build(),
-                            AsyncRequestBody.fromInputStream(stream, null, partUploader))
+            transferManager
+                    .upload(
+                            UploadRequest.builder()
+                                    .putObjectRequest(builder.build())
+                                    .requestBody(
+                                            AsyncRequestBody.fromInputStream(
+                                                    stream, null, partUploader))
+                                    .build())
+                    .completionFuture()
                     .join();
         }
         ArchivedRecording archivedRecording =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1594
See #1596
See #1215

## Description of the change:
Fixes a missed piece from #1215, removing the last direct usage of S3AsyncClient and using S3TransferManager where applicable instead. S3SyncClient is still directly used in cases like file metadata management rather than direct file storage.
