### PR TITLE
test(smoketest): set up self-signed TLS for db and storage

### DIFF
--- a/compose/db.yml
+++ b/compose/db.yml
@@ -8,10 +8,17 @@ services:
       QUARKUS_HIBERNATE_ORM_SQL_LOAD_SCRIPT: ${SQL_LOAD_SCRIPT:-no-file}
       QUARKUS_DATASOURCE_USERNAME: cryostat
       QUARKUS_DATASOURCE_PASSWORD: cryostat
-      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://db:5432/cryostat
+      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://db:5432/cryostat?ssl=true&sslmode=verify-full&sslcert=&sslrootcert=/truststore/truststore/database.cer
   db:
     image: ${CRYOSTAT_DB_IMAGE:-quay.io/cryostat/cryostat-db:${CRYOSTAT_VERSION:-latest}}
     hostname: db
+    command:
+      - -c
+      - ssl=on
+      - -c
+      - ssl_cert_file=/certs/certificate.pem
+      - -c
+      - ssl_key_file=/certs/private.key
     expose:
       - "5432"
     environment:
@@ -21,6 +28,7 @@ services:
       PG_ENCRYPT_KEY: REPLACEME
     volumes:
       - postgresql:/var/lib/pgsql/data
+      - db_certs:/certs:ro
     restart: always
     healthcheck:
       test: pg_isready -U cryostat -d cryostat || exit 1
@@ -32,3 +40,5 @@ services:
 volumes:
   postgresql:
     driver: local
+  db_certs:
+    external: true

--- a/compose/db_certs/generate.sh
+++ b/compose/db_certs/generate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/sh
+
+set -xe
+
+CERTS_DIR="$(dirname "$(readlink -f "$0")")"
+TRUSTSTORE_DIR="$(dirname "${CERTS_DIR}")"/../truststore
+
+# Generate self-signed certificate for PostgreSQL database server
+openssl req -new -addext "subjectAltName = DNS:db,DNS:localhost,IP:127.0.0.1" -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out "${CERTS_DIR}/certificate.pem" -keyout "${CERTS_DIR}/private.key" -subj "/C=CA/ST=ON/L=Toronto/O=RedHat/OU=JavaMonitoring/CN=db"
+
+# Copy database certificate to truststore directory so Cryostat trusts it
+cp "${CERTS_DIR}/certificate.pem" "${TRUSTSTORE_DIR}/database.cer"

--- a/compose/jfr-datasource.yml
+++ b/compose/jfr-datasource.yml
@@ -27,6 +27,8 @@ services:
         -Dcom.sun.management.jmxremote.authenticate=false
         -Dcom.sun.management.jmxremote.ssl=false
         -Dcom.sun.management.jmxremote.local.only=false
+      CRYOSTAT_STORAGE_IGNORE_TLS: "true"
+      CRYOSTAT_STORAGE_VERIFY_HOSTNAME: "true"
     healthcheck:
       test: curl --fail http://localhost:8080/ || exit 1
       retries: 3

--- a/compose/reports.yml
+++ b/compose/reports.yml
@@ -30,6 +30,8 @@ services:
         -Dcom.sun.management.jmxremote.ssl=false
         -Dcom.sun.management.jmxremote.local.only=false
       QUARKUS_HTTP_PORT: 10001
+      CRYOSTAT_STORAGE_IGNORE_TLS: "true"
+      CRYOSTAT_STORAGE_VERIFY_HOSTNAME: "true"
     healthcheck:
       test: curl --fail http://localhost:10001/ || exit 1
       retries: 3

--- a/compose/s3-seaweed.yml
+++ b/compose/s3-seaweed.yml
@@ -4,7 +4,7 @@ services:
       s3:
         condition: service_healthy
     environment:
-      QUARKUS_S3_ENDPOINT_OVERRIDE: http://s3:8333
+      QUARKUS_S3_ENDPOINT_OVERRIDE: https://s3:8333
       STORAGE_EXT_URL: /storage/
       STORAGE_PRESIGNED_TRANSFERS_ENABLED: "true"
       STORAGE_PRESIGNED_DOWNLOADS_ENABLED: "true"
@@ -12,19 +12,31 @@ services:
       QUARKUS_S3_AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: access_key
       AWS_SECRET_ACCESS_KEY: secret_key
+      # Configure S3 clients to use system truststore for TLS (matches operator)
+      # The entrypoint will build the truststore and append SSL FLAGS to JAVA_OPTS_APPEND
+      QUARKUS_S3_SYNC_CLIENT_TLS_KEY_MANAGERS_PROVIDER_TYPE: none
+      QUARKUS_S3_SYNC_CLIENT_TLS_TRUST_MANAGERS_PROVIDER_TYPE: system-property
+      QUARKUS_S3_ASYNC_CLIENT_TLS_KEY_MANAGERS_PROVIDER_TYPE: none
+      QUARKUS_S3_ASYNC_CLIENT_TLS_TRUST_MANAGERS_PROVIDER_TYPE: system-property
   s3:
     image: ${STORAGE_IMAGE:-quay.io/cryostat/cryostat-storage:${CRYOSTAT_VERSION:-latest}}
     hostname: s3
+    command:
+      - -s3.port=0
+      - -s3.port.https=8333
+      - -s3.cert.file=/certs/certificate.pem
+      - -s3.key.file=/certs/private.key
     environment:
       CRYOSTAT_BUCKETS: ${PRECREATE_BUCKETS}
       CRYOSTAT_ACCESS_KEY: access_key
       CRYOSTAT_SECRET_KEY: secret_key
       DATA_DIR: /data
       IP_BIND: 0.0.0.0
-      WEED_V: "4" # glog logging level
+      WEED_V: "1" # glog logging level
       REST_ENCRYPTION_ENABLE: "1"
     volumes:
       - seaweed_data:/data
+      - s3_certs:/certs:ro
     ports:
       - "8888:8888"
     expose:
@@ -46,3 +58,5 @@ services:
 volumes:
   seaweed_data:
     driver: local
+  s3_certs:
+    external: true

--- a/compose/s3_certs/generate.sh
+++ b/compose/s3_certs/generate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/sh
+
+set -xe
+
+CERTS_DIR="$(dirname "$(readlink -f "$0")")"
+TRUSTSTORE_DIR="$(dirname "${CERTS_DIR}")"/../truststore
+
+# Generate self-signed certificate for SeaweedFS S3 server
+openssl req -new -addext "subjectAltName = DNS:s3,DNS:localhost,IP:127.0.0.1" -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out "${CERTS_DIR}/certificate.pem" -keyout "${CERTS_DIR}/private.key" -subj "/C=CA/ST=ON/L=Toronto/O=RedHat/OU=JavaMonitoring/CN=s3"
+
+# Copy S3 certificate to truststore directory so Cryostat trusts it
+cp "${CERTS_DIR}/certificate.pem" "${TRUSTSTORE_DIR}/s3_storage.cer"

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -238,19 +238,7 @@ function bucketname() {
 
 if [ ! "${DRY_RUN}" = "true" ]; then
     set -xe
-    CRYOSTAT_JAVA_OPTS=$( cat <<-END
--XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m
--XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
--Dcom.sun.management.jmxremote.autodiscovery=true
--Dcom.sun.management.jmxremote
--Dcom.sun.management.jmxremote.port=9091
--Dcom.sun.management.jmxremote.rmi.port=9091
--Djava.rmi.server.hostname=127.0.0.1
--Dcom.sun.management.jmxremote.authenticate=false
--Dcom.sun.management.jmxremote.ssl=false
--Dcom.sun.management.jmxremote.local.only=false
-END
-)
+    CRYOSTAT_JAVA_OPTS="-XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     export CRYOSTAT_JAVA_OPTS
 else
     CRYOSTAT_STORAGE_BUCKETS_ARCHIVES_NAME="$(bucketname 'archives')"
@@ -366,6 +354,19 @@ createPrometheusCfgVolume() {
     fi
 }
 
+createS3CertsVolume() {
+    "${container_engine}" volume create s3_certs
+    "${container_engine}" container create --name s3_certs_helper -v s3_certs:/certs registry.access.redhat.com/ubi9/ubi-micro
+    if [ -f "${DIR}/compose/s3_certs/certificate.pem" ] && [ -f "${DIR}/compose/s3_certs/private.key" ]; then
+        chmod 644 "${DIR}/compose/s3_certs/private.key"
+        "${container_engine}" cp "${DIR}/compose/s3_certs/certificate.pem" s3_certs_helper:/certs/certificate.pem
+        "${container_engine}" cp "${DIR}/compose/s3_certs/private.key" s3_certs_helper:/certs/private.key
+    fi
+    if [ "${DRY_RUN}" = "true" ]; then
+        "${container_engine}" volume export s3_certs > s3_certs.tar
+    fi
+}
+
 createVolumes() {
     if [ "${USE_PROXY}" = "true" ]; then
         createProxyCfgVolume
@@ -376,6 +377,10 @@ createVolumes() {
     fi
     if [ "${s3}" = "localstack" ]; then
         createLocalstackCfgVolume
+    fi
+    if [ "${USE_TLS}" = "true" ] && [ "${s3}" = "seaweed" ]; then
+        sh "${DIR}/compose/s3_certs/generate.sh"
+        createS3CertsVolume
     fi
     createJmxTlsCertVolume
     createEventTemplateVolume
@@ -396,6 +401,10 @@ cleanupVolumes() {
     if [ "${s3}" = "localstack" ]; then
         ${container_engine} rm localstack_cfg_helper || true
         ${container_engine} volume rm localstack_cfg || true
+    fi
+    if [ "${s3}" = "seaweed" ]; then
+        ${container_engine} rm s3_certs_helper || true
+        ${container_engine} volume rm s3_certs || true
     fi
     ${container_engine} rm jmxtls_cfg_helper || true
     ${container_engine} volume rm jmxtls_cfg || true
@@ -441,6 +450,11 @@ cleanup() {
     if [ "${USE_TLS}" = "true" ]; then
         rm "${DIR}/compose/auth_certs/certificate.pem" || true
         rm "${DIR}/compose/auth_certs/private.key" || true
+    fi
+    if [ "${USE_TLS}" = "true" ] && [ "${s3}" = "seaweed" ]; then
+        rm "${DIR}/compose/s3_certs/certificate.pem" || true
+        rm "${DIR}/compose/s3_certs/private.key" || true
+        rm "${DIR}/truststore/s3_storage.cer" || true
     fi
     cleanupVolumes
     truncate -s 0 "${HOSTSFILE}"

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -367,6 +367,22 @@ createS3CertsVolume() {
     fi
 }
 
+createDbCertsVolume() {
+    "${container_engine}" volume create db_certs
+    "${container_engine}" container create --name db_certs_helper -v db_certs:/certs registry.access.redhat.com/ubi9/ubi-micro
+    if [ -f "${DIR}/compose/db_certs/certificate.pem" ] && [ -f "${DIR}/compose/db_certs/private.key" ]; then
+        "${container_engine}" cp "${DIR}/compose/db_certs/certificate.pem" db_certs_helper:/certs/certificate.pem
+        "${container_engine}" cp "${DIR}/compose/db_certs/private.key" db_certs_helper:/certs/private.key
+        # Set ownership to postgres user (UID 26) and permissions for PostgreSQL's requirements
+        "${container_engine}" run --rm -v db_certs:/certs registry.access.redhat.com/ubi9/ubi-micro chown -R 26:26 /certs
+        "${container_engine}" run --rm -v db_certs:/certs registry.access.redhat.com/ubi9/ubi-micro chmod 600 /certs/private.key
+        "${container_engine}" run --rm -v db_certs:/certs registry.access.redhat.com/ubi9/ubi-micro chmod 644 /certs/certificate.pem
+    fi
+    if [ "${DRY_RUN}" = "true" ]; then
+        "${container_engine}" volume export db_certs > db_certs.tar
+    fi
+}
+
 createVolumes() {
     if [ "${USE_PROXY}" = "true" ]; then
         createProxyCfgVolume
@@ -381,6 +397,10 @@ createVolumes() {
     if [ "${USE_TLS}" = "true" ] && [ "${s3}" = "seaweed" ]; then
         sh "${DIR}/compose/s3_certs/generate.sh"
         createS3CertsVolume
+    fi
+    if [ "${USE_TLS}" = "true" ]; then
+        sh "${DIR}/compose/db_certs/generate.sh"
+        createDbCertsVolume
     fi
     createJmxTlsCertVolume
     createEventTemplateVolume
@@ -406,6 +426,8 @@ cleanupVolumes() {
         ${container_engine} rm s3_certs_helper || true
         ${container_engine} volume rm s3_certs || true
     fi
+    ${container_engine} rm db_certs_helper || true
+    ${container_engine} volume rm db_certs || true
     ${container_engine} rm jmxtls_cfg_helper || true
     ${container_engine} volume rm jmxtls_cfg || true
     ${container_engine} rm templates_helper || true
@@ -455,6 +477,11 @@ cleanup() {
         rm "${DIR}/compose/s3_certs/certificate.pem" || true
         rm "${DIR}/compose/s3_certs/private.key" || true
         rm "${DIR}/truststore/s3_storage.cer" || true
+    fi
+    if [ "${USE_TLS}" = "true" ]; then
+        rm "${DIR}/compose/db_certs/certificate.pem" || true
+        rm "${DIR}/compose/db_certs/private.key" || true
+        rm "${DIR}/truststore/database.cer" || true
     fi
     cleanupVolumes
     truncate -s 0 "${HOSTSFILE}"

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -394,14 +394,12 @@ createVolumes() {
     if [ "${s3}" = "localstack" ]; then
         createLocalstackCfgVolume
     fi
-    if [ "${USE_TLS}" = "true" ] && [ "${s3}" = "seaweed" ]; then
+    if [ "${s3}" = "seaweed" ]; then
         sh "${DIR}/compose/s3_certs/generate.sh"
         createS3CertsVolume
     fi
-    if [ "${USE_TLS}" = "true" ]; then
-        sh "${DIR}/compose/db_certs/generate.sh"
-        createDbCertsVolume
-    fi
+    sh "${DIR}/compose/db_certs/generate.sh"
+    createDbCertsVolume
     createJmxTlsCertVolume
     createEventTemplateVolume
     createProbeTemplateVolume
@@ -473,16 +471,14 @@ cleanup() {
         rm "${DIR}/compose/auth_certs/certificate.pem" || true
         rm "${DIR}/compose/auth_certs/private.key" || true
     fi
-    if [ "${USE_TLS}" = "true" ] && [ "${s3}" = "seaweed" ]; then
+    if [ "${s3}" = "seaweed" ]; then
         rm "${DIR}/compose/s3_certs/certificate.pem" || true
         rm "${DIR}/compose/s3_certs/private.key" || true
         rm "${DIR}/truststore/s3_storage.cer" || true
     fi
-    if [ "${USE_TLS}" = "true" ]; then
-        rm "${DIR}/compose/db_certs/certificate.pem" || true
-        rm "${DIR}/compose/db_certs/private.key" || true
-        rm "${DIR}/truststore/database.cer" || true
-    fi
+    rm "${DIR}/compose/db_certs/certificate.pem" || true
+    rm "${DIR}/compose/db_certs/private.key" || true
+    rm "${DIR}/truststore/database.cer" || true
     cleanupVolumes
     truncate -s 0 "${HOSTSFILE}"
     for i in "${PIDS[@]}"; do


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1594
See #1596
Related to #1593

## Description of the change:
Sets up self-signed TLS certs for db and storage (seaweed/cryostat-storage only) to use in local smoketest.

## Motivation for the change:
This makes the common local development setup more similar to real Cryostat deployments and should help to catch issues like the recent AWS CRT TLS configuration problem.

Unit and integration tests still don't have TLS set up so there is still a gap here where problems of this sort may not be detected until someone goes through a manual testing case (smoketest, or full Operator deployment).

As-is on `main` this will currently fail smoketesting with the same #1593 error as observed in a full Operator deployment on Kubernetes (where there is normally a full TLS setup as well). If combined with #1594 then it should work normally.