### PR TITLE
fix(discovery): preserve target identity across Agent re-registration

### DIFF
--- a/src/main/java/io/cryostat/credentials/Credential.java
+++ b/src/main/java/io/cryostat/credentials/Credential.java
@@ -92,7 +92,7 @@ public class Credential extends PanacheEntity {
                             'default_key')
                         )
                     """)
-    @Column(updatable = false, columnDefinition = "bytea")
+    @Column(columnDefinition = "bytea")
     @NotBlank
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String username;
@@ -114,7 +114,7 @@ public class Credential extends PanacheEntity {
                             'default_key')
                         )
                     """)
-    @Column(updatable = false, columnDefinition = "bytea")
+    @Column(columnDefinition = "bytea")
     @NotBlank
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String password;

--- a/src/main/java/io/cryostat/credentials/CredentialsFinder.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsFinder.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import io.cryostat.expressions.MatchExpressionEvaluator;
 import io.cryostat.targets.Target;
-import io.cryostat.targets.Target.EventKind;
 import io.cryostat.targets.Target.TargetDiscovery;
 
 import io.quarkus.narayana.jta.QuarkusTransaction;
@@ -42,7 +41,12 @@ public class CredentialsFinder {
     @Inject MatchExpressionEvaluator expressionEvaluator;
     @Inject Logger logger;
 
-    private final BidiMap<Target, Credential> cache = new DualHashBidiMap<>();
+    private final BidiMap<Target, Long> cache = new DualHashBidiMap<>();
+
+    @ConsumeEvent(Credential.CREDENTIALS_UPDATED)
+    void onCredentialsUpdated(Credential credential) {
+        cache.removeValue(credential);
+    }
 
     @ConsumeEvent(Credential.CREDENTIALS_DELETED)
     void onCredentialsDeleted(Credential credential) {
@@ -51,33 +55,41 @@ public class CredentialsFinder {
 
     @ConsumeEvent(Target.TARGET_JVM_DISCOVERY)
     void onMessage(TargetDiscovery event) {
-        if (EventKind.LOST.equals(event.kind())) {
-            cache.remove(event.serviceRef());
+        switch (event.kind()) {
+            case MODIFIED:
+            // fall-through
+            case LOST:
+                cache.remove(event.serviceRef());
+                break;
+            default:
+                // no-op
         }
     }
 
     public Optional<Credential> getCredentialsForTarget(Target target) {
         return Optional.ofNullable(
-                cache.computeIfAbsent(
-                        target,
-                        t ->
-                                QuarkusTransaction.joiningExisting()
-                                        .call(
-                                                () ->
-                                                        Credential.<Credential>listAll()
-                                                                .parallelStream())
-                                        .filter(
-                                                c -> {
-                                                    try {
-                                                        return expressionEvaluator.applies(
-                                                                c.matchExpression, t);
-                                                    } catch (ScriptException e) {
-                                                        logger.warn(e);
-                                                        return false;
-                                                    }
-                                                })
-                                        .findFirst()
-                                        .orElse(null)));
+                        cache.computeIfAbsent(
+                                target,
+                                t ->
+                                        QuarkusTransaction.joiningExisting()
+                                                .call(
+                                                        () ->
+                                                                Credential.<Credential>listAll()
+                                                                        .parallelStream())
+                                                .filter(
+                                                        c -> {
+                                                            try {
+                                                                return expressionEvaluator.applies(
+                                                                        c.matchExpression, t);
+                                                            } catch (ScriptException e) {
+                                                                logger.warn(e);
+                                                                return false;
+                                                            }
+                                                        })
+                                                .map(c -> c.id)
+                                                .findFirst()
+                                                .orElse(null)))
+                .flatMap(i -> Optional.ofNullable(Credential.findById(i)));
     }
 
     public Optional<Credential> getCredentialsForConnectUrl(URI connectUrl) {

--- a/src/main/java/io/cryostat/credentials/CredentialsFinder.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsFinder.java
@@ -73,10 +73,7 @@ public class CredentialsFinder {
                                 target,
                                 t ->
                                         QuarkusTransaction.joiningExisting()
-                                                .call(
-                                                        () ->
-                                                                Credential.<Credential>listAll()
-                                                                        .parallelStream())
+                                                .call(() -> Credential.<Credential>streamAll())
                                                 .filter(
                                                         c -> {
                                                             try {

--- a/src/main/java/io/cryostat/credentials/CredentialsFinder.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsFinder.java
@@ -63,6 +63,7 @@ public class CredentialsFinder {
                 break;
             default:
                 // no-op
+                break;
         }
     }
 

--- a/src/main/java/io/cryostat/credentials/CredentialsFinder.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsFinder.java
@@ -18,6 +18,7 @@ package io.cryostat.credentials;
 import java.net.URI;
 import java.util.Optional;
 
+import io.cryostat.expressions.MatchExpression;
 import io.cryostat.expressions.MatchExpressionEvaluator;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.Target.TargetDiscovery;
@@ -74,16 +75,7 @@ public class CredentialsFinder {
                                 t ->
                                         QuarkusTransaction.joiningExisting()
                                                 .call(() -> Credential.<Credential>streamAll())
-                                                .filter(
-                                                        c -> {
-                                                            try {
-                                                                return expressionEvaluator.applies(
-                                                                        c.matchExpression, t);
-                                                            } catch (ScriptException e) {
-                                                                logger.warn(e);
-                                                                return false;
-                                                            }
-                                                        })
+                                                .filter(c -> applies(t, c.matchExpression))
                                                 .map(c -> c.id)
                                                 .findFirst()
                                                 .orElse(null)))
@@ -95,5 +87,14 @@ public class CredentialsFinder {
                 .call(() -> Target.find("connectUrl", connectUrl))
                 .<Target>singleResultOptional()
                 .flatMap(this::getCredentialsForTarget);
+    }
+
+    private boolean applies(Target t, MatchExpression m) {
+        try {
+            return expressionEvaluator.applies(m, t);
+        } catch (ScriptException e) {
+            logger.warn(e);
+            return false;
+        }
     }
 }

--- a/src/main/java/io/cryostat/credentials/CredentialsFinder.java
+++ b/src/main/java/io/cryostat/credentials/CredentialsFinder.java
@@ -45,12 +45,12 @@ public class CredentialsFinder {
 
     @ConsumeEvent(Credential.CREDENTIALS_UPDATED)
     void onCredentialsUpdated(Credential credential) {
-        cache.removeValue(credential);
+        cache.removeValue(credential.id);
     }
 
     @ConsumeEvent(Credential.CREDENTIALS_DELETED)
     void onCredentialsDeleted(Credential credential) {
-        cache.removeValue(credential);
+        cache.removeValue(credential.id);
     }
 
     @ConsumeEvent(Target.TARGET_JVM_DISCOVERY)

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -348,16 +348,10 @@ public class Discovery {
                         Optional.ofNullable(body.fillStrategy()),
                         Optional.ofNullable(body.context()));
 
-        // Registration includes opening a network connection to the registering Agent and waiting
-        // for its ping response. Ping the Agent first, before opening any database transaction, so
-        // that we do not hold a transaction (and its row locks) open across that network
-        // round-trip.
-        // See cryostatio/cryostat#1604.
+        // Ping the Agent before opening any transaction, so we do not hold one open across the
+        // network round-trip. See cryostatio/cryostat#1604.
         boolean reachable = pingAgentCallback(callback.unauthCallback(), credential);
 
-        // Persist the plugin and its credential in a short, targeted transaction. The ping above
-        // already tested reachability, so findOrCreatePlugin records it and the prePersist hook
-        // skips its own (in-transaction) ping.
         DiscoveryPlugin plugin =
                 QuarkusTransaction.joiningExisting()
                         .call(
@@ -393,8 +387,6 @@ public class Discovery {
             throw new InternalServerErrorException(e);
         }
 
-        // Publish the target tree in its own transaction, re-loading the plugin so that it is
-        // managed within this transaction's persistence context.
         UUID pluginId = plugin.id;
         QuarkusTransaction.joiningExisting()
                 .run(
@@ -486,11 +478,8 @@ public class Discovery {
             n.target.discoveryNode = n;
         }
 
-        // Reconcile the published nodes against this plugin's existing nodes by connectUrl so that
-        // targets which are still present keep their identity across re-publication - ex. an Agent
-        // registration refresh or a response to a Cryostat ping - rather than being deleted and
-        // immediately recreated, which would fire spurious LOST then FOUND discovery events.
-        // See cryostatio/cryostat#1604.
+        // Reconcile published nodes against existing ones by connectUrl so surviving targets keep
+        // their identity rather than being deleted and recreated (spurious LOST/FOUND). See #1604.
         boolean kubernetes =
                 body.fillStrategy
                         .map(algo -> algo == DiscoveryFillStrategy.KUBERNETES)
@@ -537,9 +526,6 @@ public class Discovery {
                         .orElseThrow(
                                 () -> new IllegalStateException("KubernetesApi realm not found"));
 
-        // Index the target nodes this plugin previously published (tagged with its plugin ID) by
-        // connectUrl, so unchanged targets can be updated in place rather than deleted and
-        // recreated.
         Map<URI, DiscoveryNode> existingByUrl = new HashMap<>();
         for (DiscoveryNode node : DiscoveryNode.getByPluginId(plugin.id)) {
             if (node.target != null && node.target.connectUrl != null) {
@@ -576,8 +562,7 @@ public class Discovery {
                 k8sDiscovery.getKubernetesMetadata(namespace, name, nodeType);
         DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
 
-        // Persist any newly-created lineage nodes (namespace -> ... -> innermost) top-down, so the
-        // target nodes attached below always reference a persisted parent.
+        // Persist new lineage nodes top-down so target nodes below reference a persisted parent.
         List<DiscoveryNode> lineageChain = new ArrayList<>();
         for (DiscoveryNode c = innermost; c != null && c != nsNode; c = c.parent) {
             lineageChain.add(c);
@@ -594,8 +579,6 @@ public class Discovery {
             }
             n.labels.put(DISCOVERY_PLUGIN_ID_LABEL_KEY, plugin.id.toString());
 
-            // Remove matched survivors from the index as we go; whatever remains afterwards is no
-            // longer published and gets deleted below.
             DiscoveryNode existing = existingByUrl.remove(n.target.connectUrl);
             if (existing == null) {
                 n.parent = innermost;
@@ -604,9 +587,6 @@ public class Discovery {
                 continue;
             }
 
-            // Update the surviving node/target in place rather than recreating it, so its Target
-            // keeps the same identity (jvmId, active recordings, etc.) and no LOST/FOUND discovery
-            // events are fired. connectUrl is the match key and is immutable.
             DiscoveryNode oldParent = existing.parent;
             existing.name = n.name;
             existing.nodeType = n.nodeType;
@@ -631,8 +611,6 @@ public class Discovery {
             }
         }
 
-        // Remove target nodes this plugin previously published that are no longer present, pruning
-        // any now-empty ancestor lineage left behind.
         for (DiscoveryNode gone : existingByUrl.values()) {
             DiscoveryNode parent = gone.parent;
             if (parent != null) {
@@ -807,9 +785,6 @@ public class Discovery {
             incomingUrls.add(n.target.connectUrl);
         }
 
-        // Delete only the previously-published targets that are no longer present, preserving the
-        // database identity - and therefore the discovery state, active recordings, etc. - of those
-        // that remain.
         for (DiscoveryNode child : new ArrayList<>(realm.children)) {
             URI url = child.target != null ? child.target.connectUrl : null;
             if (url == null || !incomingUrls.contains(url)) {
@@ -817,8 +792,8 @@ public class Discovery {
                 deleteSubtree(child);
             }
         }
-        // Flush removals before inserting replacements so Hibernate does not order the insert of a
-        // re-published connectUrl ahead of the delete of the node that previously held it.
+        // Flush removals before inserts so Hibernate does not insert a re-published connectUrl
+        // before deleting the node that held it (connectUrl is unique).
         entityManager.flush();
 
         for (DiscoveryNode n : incoming) {
@@ -829,9 +804,6 @@ public class Discovery {
                 n.persist();
                 continue;
             }
-            // Update the surviving node in place rather than recreating it, so its Target keeps the
-            // same identity and no LOST/FOUND discovery events are fired. connectUrl is the match
-            // key and is immutable, so it is intentionally left untouched.
             existing.name = n.name;
             existing.nodeType = n.nodeType;
             if (n.labels != null) {
@@ -905,8 +877,6 @@ public class Discovery {
 
     private DiscoveryPlugin findOrCreatePlugin(
             URI callbackUri, URI unauthCallback, String realmName, Credential credential) {
-        // No pre-registration ping has occurred, so let the prePersist lifecycle hook test the
-        // callback's reachability the way it always has.
         return findOrCreatePlugin(callbackUri, unauthCallback, realmName, credential, null);
     }
 
@@ -967,9 +937,6 @@ public class Discovery {
             }
         }
 
-        // New registration. If the caller already pinged the Agent and found it unreachable, reject
-        // the registration here rather than persisting an unreachable plugin; this preserves the
-        // reachability check the prePersist hook would otherwise perform.
         if (Boolean.FALSE.equals(prePinged)) {
             throw new BadRequestException(
                     String.format("Agent callback is not reachable: %s", unauthCallback));
@@ -986,10 +953,7 @@ public class Discovery {
             credential.discoveryPlugin = plugin;
         }
         if (Boolean.TRUE.equals(prePinged)) {
-            // The caller already confirmed reachability above, so record the successful ping and
-            // let
-            // the prePersist hook skip its own ping (which would otherwise run in this
-            // transaction).
+            // Record the ping we already did so prePersist skips its own (in-transaction) ping.
             plugin.lastSuccessfulPing = Instant.now();
         }
 
@@ -1004,10 +968,6 @@ public class Discovery {
     }
 
     private boolean pingAgentCallback(URI unauthCallback, Credential credential) {
-        // Build a transient (unpersisted) plugin purely to exercise the callback client. No
-        // database
-        // state is touched here - this only opens the network connection to the Agent and waits for
-        // its response, deliberately outside of any transaction.
         DiscoveryPlugin probe = new DiscoveryPlugin();
         probe.callback = unauthCallback;
         probe.credential = credential;

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -350,7 +350,10 @@ public class Discovery {
 
         // Ping the Agent before opening any transaction, so we do not hold one open across the
         // network round-trip. See cryostatio/cryostat#1604.
-        boolean reachable = pingAgentCallback(callback.unauthCallback(), credential);
+        PrePingResult prePingResult =
+                pingAgentCallback(callback.unauthCallback(), credential)
+                        ? PrePingResult.REACHABLE
+                        : PrePingResult.UNREACHABLE;
 
         DiscoveryPlugin plugin =
                 QuarkusTransaction.joiningExisting()
@@ -362,7 +365,7 @@ public class Discovery {
                                                     callback.unauthCallback(),
                                                     body.realm(),
                                                     credential,
-                                                    reachable);
+                                                    prePingResult);
                                     replaceCredential(p, credential);
                                     return p;
                                 });
@@ -877,7 +880,8 @@ public class Discovery {
 
     private DiscoveryPlugin findOrCreatePlugin(
             URI callbackUri, URI unauthCallback, String realmName, Credential credential) {
-        return findOrCreatePlugin(callbackUri, unauthCallback, realmName, credential, null);
+        return findOrCreatePlugin(
+                callbackUri, unauthCallback, realmName, credential, PrePingResult.NOT_ATTEMPTED);
     }
 
     private DiscoveryPlugin findOrCreatePlugin(
@@ -885,7 +889,7 @@ public class Discovery {
             URI unauthCallback,
             String realmName,
             Credential credential,
-            Boolean prePinged) {
+            PrePingResult prePingResult) {
         Optional<DiscoveryPlugin> existing =
                 DiscoveryPlugin.findByCallbackAndRealmName(unauthCallback, realmName);
 
@@ -937,7 +941,7 @@ public class Discovery {
             }
         }
 
-        if (Boolean.FALSE.equals(prePinged)) {
+        if (prePingResult == PrePingResult.UNREACHABLE) {
             throw new BadRequestException(
                     String.format("Agent callback is not reachable: %s", unauthCallback));
         }
@@ -952,7 +956,7 @@ public class Discovery {
             plugin.credential = credential;
             credential.discoveryPlugin = plugin;
         }
-        if (Boolean.TRUE.equals(prePinged)) {
+        if (prePingResult == PrePingResult.REACHABLE) {
             // Record the ping we already did so prePersist skips its own (in-transaction) ping.
             plugin.lastSuccessfulPing = Instant.now();
         }
@@ -968,11 +972,8 @@ public class Discovery {
     }
 
     private boolean pingAgentCallback(URI unauthCallback, Credential credential) {
-        DiscoveryPlugin probe = new DiscoveryPlugin();
-        probe.callback = unauthCallback;
-        probe.credential = credential;
         try {
-            callbackFactory.create(probe).ping();
+            callbackFactory.create(unauthCallback, credential).ping();
             logger.debugv("Agent callback reachable: {0}", unauthCallback);
             return true;
         } catch (Exception e) {
@@ -985,10 +986,14 @@ public class Discovery {
         if (credential == null) {
             return;
         }
-        if (plugin.credential == credential) {
+        if (credentialsEquivalent(plugin.credential, credential)) {
             return;
         }
-        if (credentialsEquivalent(plugin.credential, credential)) {
+        if (hasSameMatchExpression(plugin.credential, credential)) {
+            plugin.credential.username = credential.username;
+            plugin.credential.password = credential.password;
+            plugin.credential.persist();
+            plugin.persist();
             return;
         }
         if (plugin.credential != null) {
@@ -1012,6 +1017,13 @@ public class Discovery {
         return Objects.equals(existing.username, incoming.username)
                 && Objects.equals(existing.password, incoming.password)
                 && Objects.equals(matchExpressionScript(existing), matchExpressionScript(incoming));
+    }
+
+    private boolean hasSameMatchExpression(Credential existing, Credential incoming) {
+        if (existing == null || incoming == null) {
+            return false;
+        }
+        return Objects.equals(matchExpressionScript(existing), matchExpressionScript(incoming));
     }
 
     private String matchExpressionScript(Credential credential) {
@@ -1224,6 +1236,12 @@ public class Discovery {
 
     private static record NodeContext(
             DiscoveryNode node, DiscoveryNode parent, boolean fromBuiltin) {}
+
+    private enum PrePingResult {
+        NOT_ATTEMPTED,
+        REACHABLE,
+        UNREACHABLE
+    }
 
     /**
      * Check that discovery plugins are still alive/reachable and prompt them to regenerate expiring

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -988,6 +988,9 @@ public class Discovery {
         if (plugin.credential == credential) {
             return;
         }
+        if (credentialsEquivalent(plugin.credential, credential)) {
+            return;
+        }
         if (plugin.credential != null) {
             plugin.credential.discoveryPlugin = null;
         }
@@ -997,6 +1000,22 @@ public class Discovery {
             credential.persist();
         }
         plugin.persist();
+    }
+
+    private boolean credentialsEquivalent(Credential existing, Credential incoming) {
+        if (existing == incoming) {
+            return true;
+        }
+        if (existing == null || incoming == null) {
+            return false;
+        }
+        return Objects.equals(existing.username, incoming.username)
+                && Objects.equals(existing.password, incoming.password)
+                && Objects.equals(matchExpressionScript(existing), matchExpressionScript(incoming));
+    }
+
+    private String matchExpressionScript(Credential credential) {
+        return credential.matchExpression == null ? null : credential.matchExpression.script;
     }
 
     private Credential credentialFrom(AgentCredentialRequest body) {

--- a/src/main/java/io/cryostat/discovery/Discovery.java
+++ b/src/main/java/io/cryostat/discovery/Discovery.java
@@ -313,7 +313,6 @@ public class Discovery {
         return new PluginRegistration(plugin.id.toString(), token, getEnvMap());
     }
 
-    @Transactional
     @Bulkhead
     @Timeout
     @Retry(retryOn = {OptimisticLockException.class})
@@ -349,13 +348,30 @@ public class Discovery {
                         Optional.ofNullable(body.fillStrategy()),
                         Optional.ofNullable(body.context()));
 
+        // Registration includes opening a network connection to the registering Agent and waiting
+        // for its ping response. Ping the Agent first, before opening any database transaction, so
+        // that we do not hold a transaction (and its row locks) open across that network
+        // round-trip.
+        // See cryostatio/cryostat#1604.
+        boolean reachable = pingAgentCallback(callback.unauthCallback(), credential);
+
+        // Persist the plugin and its credential in a short, targeted transaction. The ping above
+        // already tested reachability, so findOrCreatePlugin records it and the prePersist hook
+        // skips its own (in-transaction) ping.
         DiscoveryPlugin plugin =
-                findOrCreatePlugin(
-                        callback.callbackUri(),
-                        callback.unauthCallback(),
-                        body.realm(),
-                        credential);
-        replaceCredential(plugin, credential);
+                QuarkusTransaction.joiningExisting()
+                        .call(
+                                () -> {
+                                    DiscoveryPlugin p =
+                                            findOrCreatePlugin(
+                                                    callback.callbackUri(),
+                                                    callback.unauthCallback(),
+                                                    body.realm(),
+                                                    credential,
+                                                    reachable);
+                                    replaceCredential(p, credential);
+                                    return p;
+                                });
 
         List<URI> locations;
         try {
@@ -377,7 +393,16 @@ public class Discovery {
             throw new InternalServerErrorException(e);
         }
 
-        publishPluginTree(plugin, publication);
+        // Publish the target tree in its own transaction, re-loading the plugin so that it is
+        // managed within this transaction's persistence context.
+        UUID pluginId = plugin.id;
+        QuarkusTransaction.joiningExisting()
+                .run(
+                        () ->
+                                publishPluginTree(
+                                        DiscoveryPlugin.<DiscoveryPlugin>find("id", pluginId)
+                                                .singleResult(),
+                                        publication));
 
         return new PluginRegistration(plugin.id.toString(), token, getEnvMap());
     }
@@ -453,169 +478,194 @@ public class Discovery {
     }
 
     private void publishPluginTree(DiscoveryPlugin plugin, DiscoveryPublication body) {
-        DiscoveryNode realm =
-                entityManager.find(
-                        DiscoveryNode.class, plugin.realm.id, LockModeType.PESSIMISTIC_WRITE);
-
         for (var n : body.nodes) {
             validatePublishedNode(n);
         }
 
-        // Remove anything this plugin previously published so that re-publication, ex. on Agent
-        // re-registration, replaces the previous nodes rather than colliding with its own earlier
-        // Target records. The removals are flushed before the replacement nodes are inserted,
-        // since Hibernate otherwise orders insertions before deletions within the transaction.
-        cleanupHelper.cleanupPluginNodes(plugin);
-        List<DiscoveryNode> previousChildren = new ArrayList<>(realm.children);
-        realm.children.clear();
-        for (DiscoveryNode child : previousChildren) {
-            deleteSubtree(child);
-        }
-        entityManager.flush();
-
-        List<DiscoveryNode> replacementChildren = new ArrayList<>();
-
         for (var n : body.nodes) {
             n.target.discoveryNode = n;
         }
-        body.fillStrategy.ifPresentOrElse(
-                algo -> {
-                    Map<String, String> pubCtx = body.context.orElse(Map.of());
-                    switch (algo) {
-                        case KUBERNETES:
-                            String namespace = pubCtx.get("namespace");
-                            String nodeType = pubCtx.get("nodetype");
-                            String name = pubCtx.get("name");
-                            if (StringUtils.isBlank(namespace)
-                                    || StringUtils.isBlank(nodeType)
-                                    || StringUtils.isBlank(name)) {
-                                String key;
-                                if (StringUtils.isBlank(namespace)) {
-                                    key = "namespace";
-                                } else if (StringUtils.isBlank(nodeType)) {
-                                    key = "nodeType";
-                                } else {
-                                    key = "name";
-                                }
-                                throw new BadRequestException(
-                                        new IllegalArgumentException(
-                                                String.format("%s cannot be blank", key)));
-                            }
 
-                            DiscoveryNode k8sRealm =
-                                    DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM)
-                                            .orElseThrow(
-                                                    () ->
-                                                            new IllegalStateException(
-                                                                    "KubernetesApi realm not"
-                                                                            + " found"));
-
-                            DiscoveryNode nsNode =
-                                    DiscoveryNode.<DiscoveryNode>find(
-                                                    "#DiscoveryNode.byTypeWithName",
-                                                    Parameters.with(
-                                                                    "nodeType",
-                                                                    KubeDiscoveryNodeType.NAMESPACE
-                                                                            .getKind())
-                                                            .and("name", namespace))
-                                            .firstResultOptional()
-                                            .orElseGet(
-                                                    () -> {
-                                                        DiscoveryNode newNs = new DiscoveryNode();
-                                                        newNs.name = namespace;
-                                                        newNs.nodeType =
-                                                                KubeDiscoveryNodeType.NAMESPACE
-                                                                        .getKind();
-                                                        newNs.labels = new HashMap<>();
-                                                        newNs.children = new ArrayList<>();
-                                                        newNs.target = null;
-                                                        newNs.parent = k8sRealm;
-                                                        newNs.persist();
-                                                        return newNs;
-                                                    });
-
-                            if (nsNode.parent == null || !nsNode.parent.equals(k8sRealm)) {
-                                nsNode.parent = k8sRealm;
-                            }
-
-                            DiscoveryNode lineage =
-                                    k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
-
-                            KubeEndpointSlicesDiscovery.KubernetesMetadata k8sMetadata =
-                                    k8sDiscovery.getKubernetesMetadata(namespace, name, nodeType);
-
-                            DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
-
-                            innermost.children.addAll(body.nodes);
-                            body.nodes.forEach(
-                                    n -> {
-                                        n.parent = innermost;
-                                        n.labels.put(
-                                                DISCOVERY_PLUGIN_ID_LABEL_KEY,
-                                                plugin.id.toString());
-
-                                        if (n.target != null) {
-                                            if (!k8sMetadata.labels().isEmpty()) {
-                                                if (n.target.labels == null) {
-                                                    n.target.labels = new HashMap<>();
-                                                }
-                                                k8sMetadata
-                                                        .labels()
-                                                        .forEach(
-                                                                (k, v) ->
-                                                                        n.target.labels.putIfAbsent(
-                                                                                k, v));
-                                            }
-
-                                            if (!k8sMetadata.annotations().isEmpty()) {
-                                                if (n.target.annotations == null) {
-                                                    n.target.annotations = new Annotations();
-                                                }
-                                                Map<String, String> platformAnnotations =
-                                                        new HashMap<>(
-                                                                n.target.annotations.platform());
-                                                k8sMetadata
-                                                        .annotations()
-                                                        .forEach(
-                                                                (k, v) ->
-                                                                        platformAnnotations
-                                                                                .putIfAbsent(k, v));
-                                                n.target.annotations =
-                                                        new Annotations(
-                                                                platformAnnotations,
-                                                                n.target.annotations.cryostat());
-                                            }
-                                        }
-
-                                        n.persist();
-                                    });
-
-                            DiscoveryNode current = innermost;
-                            while (current != null && current != nsNode) {
-                                current.persist();
-                                current = current.parent;
-                            }
-                            nsNode.persist();
-                            break;
-                        default:
-                            replacementChildren.addAll(body.nodes);
-                            for (var n : body.nodes) {
-                                n.parent = realm;
-                                n.persist();
-                            }
-                            break;
-                    }
-                },
-                () -> {
-                    replacementChildren.addAll(body.nodes);
-                    for (var n : body.nodes) {
-                        n.parent = realm;
-                        n.persist();
-                    }
-                });
-
-        replaceChildren(realm, replacementChildren);
+        // Reconcile the published nodes against this plugin's existing nodes by connectUrl so that
+        // targets which are still present keep their identity across re-publication - ex. an Agent
+        // registration refresh or a response to a Cryostat ping - rather than being deleted and
+        // immediately recreated, which would fire spurious LOST then FOUND discovery events.
+        // See cryostatio/cryostat#1604.
+        boolean kubernetes =
+                body.fillStrategy
+                        .map(algo -> algo == DiscoveryFillStrategy.KUBERNETES)
+                        .orElse(false);
+        if (kubernetes) {
+            reconcileKubernetesPublication(plugin, body);
+        } else {
+            DiscoveryNode realm =
+                    entityManager.find(
+                            DiscoveryNode.class, plugin.realm.id, LockModeType.PESSIMISTIC_WRITE);
+            reconcileFlatChildren(realm, body.nodes);
+        }
         plugin.persist();
+    }
+
+    @SuppressFBWarnings(
+            value = "UC_USELESS_OBJECT",
+            justification =
+                    "existingByUrl is read via remove() to match survivors and iterated via"
+                        + " values() to delete stale nodes; SpotBugs cannot see the side effects of"
+                        + " the Panache delete()/persist() consumers.")
+    private void reconcileKubernetesPublication(DiscoveryPlugin plugin, DiscoveryPublication body) {
+        Map<String, String> pubCtx = body.context.orElse(Map.of());
+        String namespace = pubCtx.get("namespace");
+        String nodeType = pubCtx.get("nodetype");
+        String name = pubCtx.get("name");
+        if (StringUtils.isBlank(namespace)
+                || StringUtils.isBlank(nodeType)
+                || StringUtils.isBlank(name)) {
+            String key;
+            if (StringUtils.isBlank(namespace)) {
+                key = "namespace";
+            } else if (StringUtils.isBlank(nodeType)) {
+                key = "nodeType";
+            } else {
+                key = "name";
+            }
+            throw new BadRequestException(
+                    new IllegalArgumentException(String.format("%s cannot be blank", key)));
+        }
+
+        DiscoveryNode k8sRealm =
+                DiscoveryNode.getRealm(KubeEndpointSlicesDiscovery.REALM)
+                        .orElseThrow(
+                                () -> new IllegalStateException("KubernetesApi realm not found"));
+
+        // Index the target nodes this plugin previously published (tagged with its plugin ID) by
+        // connectUrl, so unchanged targets can be updated in place rather than deleted and
+        // recreated.
+        Map<URI, DiscoveryNode> existingByUrl = new HashMap<>();
+        for (DiscoveryNode node : DiscoveryNode.getByPluginId(plugin.id)) {
+            if (node.target != null && node.target.connectUrl != null) {
+                existingByUrl.put(node.target.connectUrl, node);
+            }
+        }
+
+        DiscoveryNode nsNode =
+                DiscoveryNode.<DiscoveryNode>find(
+                                "#DiscoveryNode.byTypeWithName",
+                                Parameters.with(
+                                                "nodeType",
+                                                KubeDiscoveryNodeType.NAMESPACE.getKind())
+                                        .and("name", namespace))
+                        .firstResultOptional()
+                        .orElseGet(
+                                () -> {
+                                    DiscoveryNode newNs = new DiscoveryNode();
+                                    newNs.name = namespace;
+                                    newNs.nodeType = KubeDiscoveryNodeType.NAMESPACE.getKind();
+                                    newNs.labels = new HashMap<>();
+                                    newNs.children = new ArrayList<>();
+                                    newNs.target = null;
+                                    newNs.parent = k8sRealm;
+                                    newNs.persist();
+                                    return newNs;
+                                });
+        if (nsNode.parent == null || !nsNode.parent.equals(k8sRealm)) {
+            nsNode.parent = k8sRealm;
+        }
+
+        DiscoveryNode lineage = k8sDiscovery.getOwnershipLineage(namespace, name, nodeType);
+        KubeEndpointSlicesDiscovery.KubernetesMetadata k8sMetadata =
+                k8sDiscovery.getKubernetesMetadata(namespace, name, nodeType);
+        DiscoveryNode innermost = mergeLineageIntoTree(nsNode, lineage);
+
+        // Persist any newly-created lineage nodes (namespace -> ... -> innermost) top-down, so the
+        // target nodes attached below always reference a persisted parent.
+        List<DiscoveryNode> lineageChain = new ArrayList<>();
+        for (DiscoveryNode c = innermost; c != null && c != nsNode; c = c.parent) {
+            lineageChain.add(c);
+        }
+        nsNode.persist();
+        for (int i = lineageChain.size() - 1; i >= 0; i--) {
+            lineageChain.get(i).persist();
+        }
+
+        for (var n : body.nodes) {
+            enrichWithKubernetesMetadata(n, k8sMetadata);
+            if (n.labels == null) {
+                n.labels = new HashMap<>();
+            }
+            n.labels.put(DISCOVERY_PLUGIN_ID_LABEL_KEY, plugin.id.toString());
+
+            // Remove matched survivors from the index as we go; whatever remains afterwards is no
+            // longer published and gets deleted below.
+            DiscoveryNode existing = existingByUrl.remove(n.target.connectUrl);
+            if (existing == null) {
+                n.parent = innermost;
+                innermost.children.add(n);
+                n.persist();
+                continue;
+            }
+
+            // Update the surviving node/target in place rather than recreating it, so its Target
+            // keeps the same identity (jvmId, active recordings, etc.) and no LOST/FOUND discovery
+            // events are fired. connectUrl is the match key and is immutable.
+            DiscoveryNode oldParent = existing.parent;
+            existing.name = n.name;
+            existing.nodeType = n.nodeType;
+            existing.labels = n.labels;
+            existing.target.alias = n.target.alias;
+            if (n.target.labels != null) {
+                existing.target.labels = n.target.labels;
+            }
+            if (n.target.annotations != null) {
+                existing.target.annotations = n.target.annotations;
+            }
+            if (oldParent == null || !oldParent.equals(innermost)) {
+                if (oldParent != null) {
+                    oldParent.children.remove(existing);
+                }
+                existing.parent = innermost;
+                innermost.children.add(existing);
+            }
+            existing.persist();
+            if (oldParent != null && !oldParent.equals(innermost)) {
+                cleanupHelper.pruneEmptyAncestors(oldParent);
+            }
+        }
+
+        // Remove target nodes this plugin previously published that are no longer present, pruning
+        // any now-empty ancestor lineage left behind.
+        for (DiscoveryNode gone : existingByUrl.values()) {
+            DiscoveryNode parent = gone.parent;
+            if (parent != null) {
+                parent.children.remove(gone);
+            }
+            gone.parent = null;
+            gone.delete();
+            cleanupHelper.pruneEmptyAncestors(parent);
+        }
+        entityManager.flush();
+    }
+
+    private void enrichWithKubernetesMetadata(
+            DiscoveryNode n, KubeEndpointSlicesDiscovery.KubernetesMetadata k8sMetadata) {
+        if (n.target == null) {
+            return;
+        }
+        if (!k8sMetadata.labels().isEmpty()) {
+            if (n.target.labels == null) {
+                n.target.labels = new HashMap<>();
+            }
+            k8sMetadata.labels().forEach((k, v) -> n.target.labels.putIfAbsent(k, v));
+        }
+        if (!k8sMetadata.annotations().isEmpty()) {
+            if (n.target.annotations == null) {
+                n.target.annotations = new Annotations();
+            }
+            Map<String, String> platformAnnotations =
+                    new HashMap<>(n.target.annotations.platform());
+            k8sMetadata.annotations().forEach((k, v) -> platformAnnotations.putIfAbsent(k, v));
+            n.target.annotations =
+                    new Annotations(platformAnnotations, n.target.annotations.cryostat());
+        }
     }
 
     @Transactional
@@ -744,18 +794,59 @@ public class Discovery {
         node.delete();
     }
 
-    private void replaceChildren(DiscoveryNode parent, List<DiscoveryNode> replacementChildren) {
-        List<DiscoveryNode> existingChildren = new ArrayList<>(parent.children);
-        parent.children.clear();
-        existingChildren.forEach(child -> child.parent = null);
-        replacementChildren.forEach(child -> child.parent = parent);
-        parent.children.addAll(replacementChildren);
-        try {
-            parent.persist();
-            entityManager.flush();
-        } catch (OptimisticLockException e) {
-            throw new BadRequestException("Discovery tree update conflict", e);
+    private void reconcileFlatChildren(DiscoveryNode realm, List<DiscoveryNode> incoming) {
+        Map<URI, DiscoveryNode> existingByUrl = new HashMap<>();
+        for (DiscoveryNode child : new ArrayList<>(realm.children)) {
+            if (child.target != null && child.target.connectUrl != null) {
+                existingByUrl.put(child.target.connectUrl, child);
+            }
         }
+
+        Set<URI> incomingUrls = new HashSet<>();
+        for (DiscoveryNode n : incoming) {
+            incomingUrls.add(n.target.connectUrl);
+        }
+
+        // Delete only the previously-published targets that are no longer present, preserving the
+        // database identity - and therefore the discovery state, active recordings, etc. - of those
+        // that remain.
+        for (DiscoveryNode child : new ArrayList<>(realm.children)) {
+            URI url = child.target != null ? child.target.connectUrl : null;
+            if (url == null || !incomingUrls.contains(url)) {
+                realm.children.remove(child);
+                deleteSubtree(child);
+            }
+        }
+        // Flush removals before inserting replacements so Hibernate does not order the insert of a
+        // re-published connectUrl ahead of the delete of the node that previously held it.
+        entityManager.flush();
+
+        for (DiscoveryNode n : incoming) {
+            DiscoveryNode existing = existingByUrl.get(n.target.connectUrl);
+            if (existing == null) {
+                n.parent = realm;
+                realm.children.add(n);
+                n.persist();
+                continue;
+            }
+            // Update the surviving node in place rather than recreating it, so its Target keeps the
+            // same identity and no LOST/FOUND discovery events are fired. connectUrl is the match
+            // key and is immutable, so it is intentionally left untouched.
+            existing.name = n.name;
+            existing.nodeType = n.nodeType;
+            if (n.labels != null) {
+                existing.labels = n.labels;
+            }
+            existing.target.alias = n.target.alias;
+            if (n.target.labels != null) {
+                existing.target.labels = n.target.labels;
+            }
+            if (n.target.annotations != null) {
+                existing.target.annotations = n.target.annotations;
+            }
+            existing.persist();
+        }
+        realm.persist();
     }
 
     private CallbackValidation validateCallback(
@@ -814,6 +905,17 @@ public class Discovery {
 
     private DiscoveryPlugin findOrCreatePlugin(
             URI callbackUri, URI unauthCallback, String realmName, Credential credential) {
+        // No pre-registration ping has occurred, so let the prePersist lifecycle hook test the
+        // callback's reachability the way it always has.
+        return findOrCreatePlugin(callbackUri, unauthCallback, realmName, credential, null);
+    }
+
+    private DiscoveryPlugin findOrCreatePlugin(
+            URI callbackUri,
+            URI unauthCallback,
+            String realmName,
+            Credential credential,
+            Boolean prePinged) {
         Optional<DiscoveryPlugin> existing =
                 DiscoveryPlugin.findByCallbackAndRealmName(unauthCallback, realmName);
 
@@ -865,6 +967,14 @@ public class Discovery {
             }
         }
 
+        // New registration. If the caller already pinged the Agent and found it unreachable, reject
+        // the registration here rather than persisting an unreachable plugin; this preserves the
+        // reachability check the prePersist hook would otherwise perform.
+        if (Boolean.FALSE.equals(prePinged)) {
+            throw new BadRequestException(
+                    String.format("Agent callback is not reachable: %s", unauthCallback));
+        }
+
         DiscoveryPlugin plugin = new DiscoveryPlugin();
         plugin.callback = callbackUri;
         plugin.realm =
@@ -875,6 +985,13 @@ public class Discovery {
             plugin.credential = credential;
             credential.discoveryPlugin = plugin;
         }
+        if (Boolean.TRUE.equals(prePinged)) {
+            // The caller already confirmed reachability above, so record the successful ping and
+            // let
+            // the prePersist hook skip its own ping (which would otherwise run in this
+            // transaction).
+            plugin.lastSuccessfulPing = Instant.now();
+        }
 
         var universe = DiscoveryNode.getUniverse();
         plugin.realm.parent = universe;
@@ -884,6 +1001,24 @@ public class Discovery {
 
         logger.debugv("Created new plugin: {0}", plugin.id);
         return plugin;
+    }
+
+    private boolean pingAgentCallback(URI unauthCallback, Credential credential) {
+        // Build a transient (unpersisted) plugin purely to exercise the callback client. No
+        // database
+        // state is touched here - this only opens the network connection to the Agent and waits for
+        // its response, deliberately outside of any transaction.
+        DiscoveryPlugin probe = new DiscoveryPlugin();
+        probe.callback = unauthCallback;
+        probe.credential = credential;
+        try {
+            callbackFactory.create(probe).ping();
+            logger.debugv("Agent callback reachable: {0}", unauthCallback);
+            return true;
+        } catch (Exception e) {
+            logger.debugv(e, "Agent callback ping failed during registration: {0}", unauthCallback);
+            return false;
+        }
     }
 
     private void replaceCredential(DiscoveryPlugin plugin, Credential credential) {

--- a/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
+++ b/src/main/java/io/cryostat/discovery/DiscoveryPlugin.java
@@ -330,11 +330,15 @@ public class DiscoveryPlugin extends PanacheEntityBase {
         public void refresh();
 
         public static PluginCallback create(DiscoveryPlugin plugin) throws URISyntaxException {
+            return create(plugin.callback, plugin.credential);
+        }
+
+        public static PluginCallback create(URI callback, Credential credential) {
             PluginCallback client =
                     QuarkusRestClientBuilder.newBuilder()
-                            .baseUri(plugin.callback)
+                            .baseUri(callback)
                             .clientHeadersFactory(
-                                    new DiscoveryPluginAuthorizationHeaderFactory(plugin))
+                                    new DiscoveryPluginAuthorizationHeaderFactory(credential))
                             .build(PluginCallback.class);
             return client;
         }
@@ -345,10 +349,14 @@ public class DiscoveryPlugin extends PanacheEntityBase {
             private final Supplier<UsernamePasswordCredentials> credentialSupplier;
 
             public DiscoveryPluginAuthorizationHeaderFactory(DiscoveryPlugin plugin) {
+                this(plugin.credential);
+            }
+
+            public DiscoveryPluginAuthorizationHeaderFactory(Credential credential) {
                 this(
                         () ->
                                 new UsernamePasswordCredentials(
-                                        plugin.credential.username, plugin.credential.password));
+                                        credential.username, credential.password));
             }
 
             public DiscoveryPluginAuthorizationHeaderFactory(

--- a/src/main/java/io/cryostat/discovery/PluginCallbackFactory.java
+++ b/src/main/java/io/cryostat/discovery/PluginCallbackFactory.java
@@ -15,8 +15,10 @@
  */
 package io.cryostat.discovery;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 
+import io.cryostat.credentials.Credential;
 import io.cryostat.discovery.DiscoveryPlugin.PluginCallback;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,5 +32,9 @@ public class PluginCallbackFactory {
 
     public PluginCallback create(DiscoveryPlugin plugin) throws URISyntaxException {
         return PluginCallback.create(plugin);
+    }
+
+    public PluginCallback create(URI callback, Credential credential) {
+        return PluginCallback.create(callback, credential);
     }
 }

--- a/src/main/java/io/cryostat/targets/TargetConnectionManager.java
+++ b/src/main/java/io/cryostat/targets/TargetConnectionManager.java
@@ -292,6 +292,11 @@ public class TargetConnectionManager {
         }
     }
 
+    public void clearConnections() {
+        connections.synchronous().invalidateAll();
+        connections.synchronous().cleanUp();
+    }
+
     private void closeConnection(URI connectUrl, JFRConnection connection, RemovalCause cause) {
         if (connectUrl == null) {
             logger.warn("Connection eviction triggered with null connectUrl");

--- a/src/test/java/io/cryostat/AbstractTransactionalTestBase.java
+++ b/src/test/java/io/cryostat/AbstractTransactionalTestBase.java
@@ -15,6 +15,8 @@
  */
 package io.cryostat;
 
+import io.cryostat.targets.TargetConnectionManager;
+
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import org.flywaydb.core.Flyway;
@@ -25,10 +27,12 @@ public abstract class AbstractTransactionalTestBase extends AbstractTestBase {
 
     @Inject Flyway flyway;
     @Inject EntityManager entityManager;
+    @Inject TargetConnectionManager connectionManager;
 
     @BeforeEach
     void migrateFlyway() throws SchedulerException {
         shutdownScheduler();
+        connectionManager.clearConnections();
         flyway.clean();
         flyway.migrate();
         flyway.validate();

--- a/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.discovery;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.cryostat.AbstractTransactionalTestBase;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase {
+
+    @InjectMock KubeEndpointSlicesDiscovery k8sDiscovery;
+
+    @BeforeEach
+    void setupK8sMocks() {
+        // The KUBERNETES fill strategy asks the discovery service to resolve the agent pod's
+        // ownership lineage and metadata from the Kubernetes API; there is no API to talk to in a
+        // unit test, so return a fixed single-Pod lineage and empty metadata.
+        Mockito.when(k8sDiscovery.getOwnershipLineage(anyString(), anyString(), anyString()))
+                .thenAnswer(
+                        inv -> {
+                            DiscoveryNode pod = new DiscoveryNode();
+                            pod.name = inv.getArgument(1);
+                            pod.nodeType = "Pod";
+                            pod.labels = new HashMap<>();
+                            pod.children = new ArrayList<>();
+                            pod.target = null;
+                            return pod;
+                        });
+        Mockito.when(k8sDiscovery.getKubernetesMetadata(anyString(), anyString(), anyString()))
+                .thenReturn(new KubeEndpointSlicesDiscovery.KubernetesMetadata(Map.of(), Map.of()));
+    }
+
+    @Test
+    void testKubernetesAgentReregistrationPreservesTargetIdentity() {
+        // Reproduces cryostatio/cryostat#1604 for operator-injected Agents, which publish with the
+        // KUBERNETES fill strategy. A registration refresh with an unchanged target set must keep
+        // the published Target in place rather than deleting and recreating it (which momentarily
+        // LOSES and re-FINDS the target, dropping active connections/recordings).
+        var realmName = "agent_k8s_identity_realm";
+        var callback = "http://localhost:8081/health/liveness";
+        var connectUrl = URI.create("http://localhost:8081");
+        var target = new Target(connectUrl, "k8s-agent");
+        var node = new Node("k8s-agent", NodeType.BaseNodeType.AGENT.getKind(), target);
+        var requestBody =
+                Map.of(
+                        "realm",
+                        realmName,
+                        "callback",
+                        callback,
+                        "credential",
+                        Map.of(
+                                "matchExpression", "true",
+                                "username", "user",
+                                "password", "pass"),
+                        "nodes",
+                        List.of(node),
+                        "fillStrategy",
+                        "KUBERNETES",
+                        "context",
+                        Map.of("namespace", "test-ns", "nodetype", "Pod", "name", "test-pod"));
+
+        var firstRegistration =
+                given().log()
+                        .all()
+                        .when()
+                        .body(requestBody)
+                        .contentType(ContentType.JSON)
+                        .post("/api/v4.3/discovery/agents")
+                        .then()
+                        .log()
+                        .all()
+                        .and()
+                        .assertThat()
+                        .statusCode(200)
+                        .contentType(ContentType.JSON)
+                        .extract()
+                        .jsonPath();
+        var pluginId = firstRegistration.getString("id");
+        MatcherAssert.assertThat(pluginId, Matchers.is(Matchers.not(Matchers.emptyOrNullString())));
+
+        Long firstTargetId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
+                                                .id);
+
+        // Re-register the same Agent with an identical node set, ex. a registration refresh or a
+        // response to a Cryostat ping.
+        given().log()
+                .all()
+                .when()
+                .body(requestBody)
+                .contentType(ContentType.JSON)
+                .post("/api/v4.3/discovery/agents")
+                .then()
+                .log()
+                .all()
+                .and()
+                .assertThat()
+                .statusCode(200);
+
+        Long secondTargetId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
+                                                .id);
+
+        // The unchanged target must keep its identity across the refresh - if the id changed, the
+        // Target was deleted and recreated, which fires LOST then FOUND discovery events.
+        MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
+    }
+
+    record Node(String name, String nodeType, Target target, List<?> children) {
+        Node(String name, String nodeType, Target target) {
+            this(name, nodeType, target, null);
+        }
+    }
+
+    record Target(URI connectUrl, String alias) {}
+}

--- a/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import io.cryostat.AbstractTransactionalTestBase;
 
@@ -112,6 +113,14 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
                                 () ->
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
+        Long firstCredentialId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        DiscoveryPlugin.<DiscoveryPlugin>findById(
+                                                        UUID.fromString(pluginId))
+                                                .credential
+                                                .id);
 
         // Re-register the same Agent with an identical node set (ex. a registration refresh).
         given().log()
@@ -133,8 +142,17 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
                                 () ->
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
+        Long secondCredentialId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        DiscoveryPlugin.<DiscoveryPlugin>findById(
+                                                        UUID.fromString(pluginId))
+                                                .credential
+                                                .id);
 
         MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
+        MatcherAssert.assertThat(secondCredentialId, Matchers.equalTo(firstCredentialId));
     }
 
     record Node(String name, String nodeType, Target target, List<?> children) {

--- a/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
@@ -122,7 +122,7 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
                                                 .credential
                                                 .id);
 
-        // Re-register the same Agent with an identical node set (ex. a registration refresh).
+        // Re-register the same Agent with an identical node set (ex. a registration refresh)
         given().log()
                 .all()
                 .when()

--- a/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryAgentKubernetesTest.java
@@ -43,9 +43,8 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
 
     @BeforeEach
     void setupK8sMocks() {
-        // The KUBERNETES fill strategy asks the discovery service to resolve the agent pod's
-        // ownership lineage and metadata from the Kubernetes API; there is no API to talk to in a
-        // unit test, so return a fixed single-Pod lineage and empty metadata.
+        // No Kubernetes API in a unit test, so return a fixed single-Pod lineage and empty
+        // metadata.
         Mockito.when(k8sDiscovery.getOwnershipLineage(anyString(), anyString(), anyString()))
                 .thenAnswer(
                         inv -> {
@@ -63,10 +62,8 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
 
     @Test
     void testKubernetesAgentReregistrationPreservesTargetIdentity() {
-        // Reproduces cryostatio/cryostat#1604 for operator-injected Agents, which publish with the
-        // KUBERNETES fill strategy. A registration refresh with an unchanged target set must keep
-        // the published Target in place rather than deleting and recreating it (which momentarily
-        // LOSES and re-FINDS the target, dropping active connections/recordings).
+        // cryostatio/cryostat#1604, KUBERNETES strategy (operator-injected Agents): re-registration
+        // with an unchanged node set must preserve the Target, not recreate it.
         var realmName = "agent_k8s_identity_realm";
         var callback = "http://localhost:8081/health/liveness";
         var connectUrl = URI.create("http://localhost:8081");
@@ -116,8 +113,7 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
 
-        // Re-register the same Agent with an identical node set, ex. a registration refresh or a
-        // response to a Cryostat ping.
+        // Re-register the same Agent with an identical node set (ex. a registration refresh).
         given().log()
                 .all()
                 .when()
@@ -138,8 +134,6 @@ public class DiscoveryAgentKubernetesTest extends AbstractTransactionalTestBase 
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
 
-        // The unchanged target must keep its identity across the refresh - if the id changed, the
-        // Target was deleted and recreated, which fires LOST then FOUND discovery events.
         MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
     }
 

--- a/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
@@ -694,7 +694,7 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
     }
 
     @Test
-    void testAgentReregistrationReplacesCredentialAndRepublishes() {
+    void testAgentReregistrationUpdatesCredentialAndRepublishes() {
         var realmName = "agent_reregistration_test_realm";
         var callback = "http://localhost:8081/health/liveness";
         var target = new Target(URI.create("http://localhost:8081"), "agent-node");
@@ -762,9 +762,9 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                         "context",
                         Map.of());
 
-        // Re-register as the same Agent with changed credentials, ex. after the Agent's token has
-        // expired and its local credential configuration has changed. The same plugin record should
-        // be reused, the stored credential should be replaced, and the published nodes should be
+        // Re-register as the same Agent with changed credentials, ex. after the Agent has rotated
+        // its local credential configuration. The same plugin and credential records should be
+        // reused, the stored credential secret should be updated, and the published nodes should be
         // replaced rather than duplicated.
         var secondRegistration =
                 given().log()
@@ -792,9 +792,11 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                             UUID.fromString(pluginId));
                             MatcherAssert.assertThat(plugin.credential, Matchers.notNullValue());
                             MatcherAssert.assertThat(
-                                    plugin.credential.id, Matchers.not(firstCredentialId));
+                                    plugin.credential.id, Matchers.equalTo(firstCredentialId));
                             MatcherAssert.assertThat(
-                                    Credential.findById(firstCredentialId), Matchers.nullValue());
+                                    plugin.credential.username, Matchers.equalTo("user"));
+                            MatcherAssert.assertThat(
+                                    plugin.credential.password, Matchers.equalTo("updated-pass"));
                         });
 
         given().log()

--- a/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
@@ -807,11 +807,8 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
 
     @Test
     void testAgentReregistrationPreservesTargetIdentity() {
-        // Reproduces cryostatio/cryostat#1604: when an Agent refreshes its registration (or
-        // responds to a Cryostat ping) by re-POSTing to the combined registration endpoint with an
-        // unchanged set of target nodes, the published Target should be preserved in place. If the
-        // server instead deletes and recreates the Target row, the target is momentarily LOST and
-        // then re-FOUND/rediscovered, dropping any active connections and recordings.
+        // cryostatio/cryostat#1604: re-registration with an unchanged node set must preserve the
+        // Target, not delete and recreate it (which fires LOST then FOUND).
         var realmName = "agent_identity_test_realm";
         var callback = "http://localhost:8081/health/liveness";
         var connectUrl = URI.create("http://localhost:8081");
@@ -860,8 +857,7 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
 
-        // Re-register as the same Agent with an identical set of nodes, ex. a registration refresh
-        // or a response to a Cryostat ping.
+        // Re-register the same Agent with an identical node set (ex. a registration refresh).
         var secondRegistration =
                 given().log()
                         .all()
@@ -887,8 +883,6 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
 
-        // The unchanged target must keep its identity across the refresh - if the id changed, the
-        // Target was deleted and recreated, which fires LOST then FOUND discovery events.
         MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
 
         given().log()

--- a/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
@@ -744,14 +744,33 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                                 .credential
                                                 .id);
 
-        // Re-register as the same Agent, ex. after the Agent's token has expired. The same
-        // plugin record should be reused, the stored credential should be replaced, and the
-        // published nodes should be replaced rather than duplicated.
+        var updatedRequestBody =
+                Map.of(
+                        "realm",
+                        realmName,
+                        "callback",
+                        callback,
+                        "credential",
+                        Map.of(
+                                "matchExpression", "true",
+                                "username", "user",
+                                "password", "updated-pass"),
+                        "nodes",
+                        List.of(node),
+                        "fillStrategy",
+                        "NONE",
+                        "context",
+                        Map.of());
+
+        // Re-register as the same Agent with changed credentials, ex. after the Agent's token has
+        // expired and its local credential configuration has changed. The same plugin record should
+        // be reused, the stored credential should be replaced, and the published nodes should be
+        // replaced rather than duplicated.
         var secondRegistration =
                 given().log()
                         .all()
                         .when()
-                        .body(requestBody)
+                        .body(updatedRequestBody)
                         .contentType(ContentType.JSON)
                         .post("/api/v4.3/discovery/agents")
                         .then()
@@ -856,6 +875,14 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                 () ->
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
+        Long firstCredentialId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        DiscoveryPlugin.<DiscoveryPlugin>findById(
+                                                        UUID.fromString(pluginId))
+                                                .credential
+                                                .id);
 
         // Re-register the same Agent with an identical node set (ex. a registration refresh).
         var secondRegistration =
@@ -882,8 +909,17 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                                 () ->
                                         io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
                                                 .id);
+        Long secondCredentialId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        DiscoveryPlugin.<DiscoveryPlugin>findById(
+                                                        UUID.fromString(pluginId))
+                                                .credential
+                                                .id);
 
         MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
+        MatcherAssert.assertThat(secondCredentialId, Matchers.equalTo(firstCredentialId));
 
         given().log()
                 .all()

--- a/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
+++ b/src/test/java/io/cryostat/discovery/DiscoveryPluginTest.java
@@ -805,6 +805,105 @@ public class DiscoveryPluginTest extends AbstractTransactionalTestBase {
                 .statusCode(204);
     }
 
+    @Test
+    void testAgentReregistrationPreservesTargetIdentity() {
+        // Reproduces cryostatio/cryostat#1604: when an Agent refreshes its registration (or
+        // responds to a Cryostat ping) by re-POSTing to the combined registration endpoint with an
+        // unchanged set of target nodes, the published Target should be preserved in place. If the
+        // server instead deletes and recreates the Target row, the target is momentarily LOST and
+        // then re-FOUND/rediscovered, dropping any active connections and recordings.
+        var realmName = "agent_identity_test_realm";
+        var callback = "http://localhost:8081/health/liveness";
+        var connectUrl = URI.create("http://localhost:8081");
+        var target = new Target(connectUrl, "agent-node");
+        var node = new Node("agent-node", NodeType.BaseNodeType.AGENT.getKind(), target);
+        var requestBody =
+                Map.of(
+                        "realm",
+                        realmName,
+                        "callback",
+                        callback,
+                        "credential",
+                        Map.of(
+                                "matchExpression", "true",
+                                "username", "user",
+                                "password", "pass"),
+                        "nodes",
+                        List.of(node),
+                        "fillStrategy",
+                        "NONE",
+                        "context",
+                        Map.of());
+
+        var firstRegistration =
+                given().log()
+                        .all()
+                        .when()
+                        .body(requestBody)
+                        .contentType(ContentType.JSON)
+                        .post("/api/v4.3/discovery/agents")
+                        .then()
+                        .log()
+                        .all()
+                        .and()
+                        .assertThat()
+                        .statusCode(200)
+                        .contentType(ContentType.JSON)
+                        .extract()
+                        .jsonPath();
+        var pluginId = firstRegistration.getString("id");
+
+        Long firstTargetId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
+                                                .id);
+
+        // Re-register as the same Agent with an identical set of nodes, ex. a registration refresh
+        // or a response to a Cryostat ping.
+        var secondRegistration =
+                given().log()
+                        .all()
+                        .when()
+                        .body(requestBody)
+                        .contentType(ContentType.JSON)
+                        .post("/api/v4.3/discovery/agents")
+                        .then()
+                        .log()
+                        .all()
+                        .and()
+                        .assertThat()
+                        .statusCode(200)
+                        .contentType(ContentType.JSON)
+                        .extract()
+                        .jsonPath();
+        MatcherAssert.assertThat(secondRegistration.getString("id"), Matchers.equalTo(pluginId));
+
+        Long secondTargetId =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        io.cryostat.targets.Target.getTargetByConnectUrl(connectUrl)
+                                                .id);
+
+        // The unchanged target must keep its identity across the refresh - if the id changed, the
+        // Target was deleted and recreated, which fires LOST then FOUND discovery events.
+        MatcherAssert.assertThat(secondTargetId, Matchers.equalTo(firstTargetId));
+
+        given().log()
+                .all()
+                .when()
+                .header(DISCOVERY_HEADER, secondRegistration.getString("token"))
+                .delete(String.format("/api/v4/discovery/%s", pluginId))
+                .then()
+                .log()
+                .all()
+                .and()
+                .assertThat()
+                .statusCode(204);
+    }
+
     record Node(String name, String nodeType, Target target, List<?> children) {
         Node(String name, String nodeType, Target target) {
             this(name, nodeType, target, null);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________
Fixes: #1604

## Description of the change:
- Make discovery publication idempotent: `publishPluginTree` now reconciles the incoming nodes against the plugin's existing nodes by `connectUrl` instead of deleting and recreating them, so an Agent that re-registers keeps the same `Target` (`id`/`jvmId`). Covers both the `NONE`/flat and `KUBERNETES` fill strategies, and the shared `POST /api/v4.2/discovery/{id}` publish path.
- `POST /api/v4.3/discovery/agents` is no longer one `@Transactional` method: it pings the Agent first (outside any transaction), then writes the plugin/credential and the publication in two small `QuarkusTransaction` blocks. The `prePersist` ping is skipped since reachability is already confirmed.
- Added unit tests asserting the target `id` is unchanged across re-registration (flat + `KUBERNETES`).

## Motivation for the change:
Since #1586 an Agent re-publishes its nodes on every registration refresh, and the old delete-and-recreate logic reset each target's identity, so the target was briefly LOST then FOUND - dropping active connections and recordings. Reconciling by `connectUrl` keeps unchanged targets stable. Separately, registration makes a network call to the Agent, so per review feedback Cryostat now pings the Agent first and uses short scoped transactions rather than holding one open across the round-trip.

## How to manually test:
1. Run the smoketest with the post-#1586 Agent (lost/rediscovered on `main`, stable here):
```
CRYOSTAT_IMAGE=<your built image> \
QUARKUS_TEST_IMAGE=quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest \
./smoketest.bash -t quarkus-cryostat-agent
```
2. Integration reproducer - fails on `main`, passes with this change:
```
QUARKUS_TEST_IMAGE=quay.io/redhat-java-monitoring/quarkus-cryostat-agent:2026-06-15 ./mvnw -Dskip.surefire.tests clean verify
```
3. Unit tests for identity preservation:
```
./mvnw test -Dtest='DiscoveryPluginTest,DiscoveryAgentKubernetesTest'
```