### PR TITLE
fix(async-profiler): quartz update job handles case where Target has been lost

### DIFF
--- a/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/io/cryostat/asyncprofiler/AsyncProfiler.java
@@ -42,6 +42,8 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DELETE;
@@ -51,6 +53,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.hibernate.ObjectDeletedException;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -297,15 +300,27 @@ public class AsyncProfiler {
 
         @Override
         public void execute(JobExecutionContext context) throws JobExecutionException {
-            Target target =
-                    QuarkusTransaction.joiningExisting()
-                            .call(
-                                    () ->
-                                            Target.find(
-                                                            "id",
-                                                            context.getMergedJobDataMap()
-                                                                    .getLong("targetId"))
-                                                    .singleResult());
+            Target target;
+            try {
+                target =
+                        QuarkusTransaction.requiringNew()
+                                .call(
+                                        () ->
+                                                Target.getTargetById(
+                                                        context.getMergedJobDataMap()
+                                                                .getLong("targetId")));
+            } catch (NoResultException | ObjectDeletedException e) {
+                // target disappeared in the meantime. No big deal.
+                logger.debug(e);
+                JobExecutionException ex = new JobExecutionException(e);
+                ex.setRefireImmediately(false);
+                ex.setUnscheduleFiringTrigger(true);
+                throw ex;
+            } catch (PersistenceException e) {
+                JobExecutionException ex = new JobExecutionException(e);
+                ex.setRefireImmediately(false);
+                throw ex;
+            }
             String id = context.getMergedJobDataMap().getString("id");
             long duration = context.getMergedJobDataMap().getLong("duration");
             tcm.executeConnectedTaskUni(


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1227

## Description of the change:
Quartz scheduled job for async-profiler recording session handling on fixed duration elapse should cleanly handle the case where the source target has been lost in the meantime. Other examples:

https://github.com/cryostatio/cryostat/blob/3e02e85f84aed2a778233f36a8e4f2693d535ce0/src/main/java/io/cryostat/targets/TargetUpdateJob.java#L58
https://github.com/cryostatio/cryostat/blob/3e02e85f84aed2a778233f36a8e4f2693d535ce0/src/main/java/io/cryostat/targets/ActiveRecordingUpdateJob.java#L53
