### PR TITLE
fix(events): tolerate null JFR option metadata

### DIFF
--- a/src/main/java/io/cryostat/events/SerializableOptionDescriptor.java
+++ b/src/main/java/io/cryostat/events/SerializableOptionDescriptor.java
@@ -21,15 +21,15 @@ import org.openjdk.jmc.common.unit.IOptionDescriptor;
 
 public record SerializableOptionDescriptor(String name, String description, String defaultValue) {
     public SerializableOptionDescriptor {
-        Objects.requireNonNull(name);
-        Objects.requireNonNull(description);
-        Objects.requireNonNull(defaultValue);
+        name = Objects.toString(name, "");
+        description = Objects.toString(description, "");
+        defaultValue = Objects.toString(defaultValue, "");
     }
 
     public static SerializableOptionDescriptor fromOptionDescriptor(IOptionDescriptor<?> desc) {
         var name = desc.getName();
         var description = desc.getDescription();
-        var defaultValue = desc.getDefault().toString();
+        var defaultValue = Objects.toString(desc.getDefault(), "");
         return new SerializableOptionDescriptor(name, description, defaultValue);
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1617

## Description of the change:
This change makes event option serialization tolerate null values returned by JFR metadata, normalizing missing option fields to empty strings.

## Motivation for the change:
Java 25 can return null descriptions for some JFR event options, which caused the target events endpoint to return 500 errors and made related match-expression tests fail in CI.