### PR TITLE
ci(renovate): minor version updates in dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,9 @@
   "major": {
     "dependencyDashboardApproval": true
   },
+  "minor": {
+    "dependencyDashboardApproval": true
+  },
   "git-submodules": {
       "enabled": true
   },


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1568

The current configuration is too noisy and produces too many update PRs for dependency minor versions which we aren't able to upgrade to. Noting these in the dependency dashboard issue is sufficient for awareness. Patch versions should still get PRs.
