### PR TITLE
feat(graphql): add DiscoveryNodeFilter field for target alias

### DIFF
--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -77,6 +77,8 @@ public class RootNode {
         public @Nullable List<String> jvmIds;
         public @Nullable String name;
         public @Nullable List<String> names;
+        public @Nullable String alias;
+        public @Nullable List<String> aliases;
         public @Nullable List<String> nodeTypes;
         public @Nullable List<String> labels;
         public @Nullable List<String> annotations;
@@ -95,6 +97,14 @@ public class RootNode {
                     n -> targetIds == null || (n.target != null && targetIds.contains(n.target.id));
             Predicate<DiscoveryNode> matchesName = n -> name == null || name.equals(n.name);
             Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);
+            Predicate<DiscoveryNode> matchesAlias =
+                    n ->
+                            alias == null
+                                    || (n.target != null && alias.equals(n.target.alias));
+            Predicate<DiscoveryNode> matchesAliases =
+                    n ->
+                            aliases == null
+                                    || (n.target != null && aliases.contains(n.target.alias));
             Predicate<DiscoveryNode> matchesNodeTypes =
                     n -> nodeTypes == null || nodeTypes.contains(n.nodeType);
             Predicate<DiscoveryNode> matchesLabels =
@@ -128,6 +138,8 @@ public class RootNode {
                             matchesTargetIds,
                             matchesName,
                             matchesNames,
+                            matchesAlias,
+                            matchesAliases,
                             matchesNodeTypes,
                             matchesLabels,
                             matchesAnnotations)

--- a/src/main/java/io/cryostat/graphql/RootNode.java
+++ b/src/main/java/io/cryostat/graphql/RootNode.java
@@ -98,13 +98,9 @@ public class RootNode {
             Predicate<DiscoveryNode> matchesName = n -> name == null || name.equals(n.name);
             Predicate<DiscoveryNode> matchesNames = n -> names == null || names.contains(n.name);
             Predicate<DiscoveryNode> matchesAlias =
-                    n ->
-                            alias == null
-                                    || (n.target != null && alias.equals(n.target.alias));
+                    n -> alias == null || (n.target != null && alias.equals(n.target.alias));
             Predicate<DiscoveryNode> matchesAliases =
-                    n ->
-                            aliases == null
-                                    || (n.target != null && aliases.contains(n.target.alias));
+                    n -> aliases == null || (n.target != null && aliases.contains(n.target.alias));
             Predicate<DiscoveryNode> matchesNodeTypes =
                     n -> nodeTypes == null || nodeTypes.contains(n.nodeType);
             Predicate<DiscoveryNode> matchesLabels =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-mcp/issues/39

## Description of the change:
Clients such as the upcoming Cryostat MCP need to be able to look up targets (from the live dataset or from audit logs) using the target's associated Pod name.

From the live dataset this can be done by using the GraphQL `environmentNodes` query since this supports filtering like `nodeType: "Pod", name: <podName>`, but there is no audit log support in the GraphQL API for `DiscoveryNode` instances yet. Clients should also be able to do this kind of lookup for targets which have been lost, for example when trying to troubleshoot a Pod that has crashed. DiscoveryNodes are already audited so the basis is there, but adding support to look them up in the GraphQL API is a larger change.

So from the existing GraphQL targetNodes query, clients can already use the `useAuditLog` parameter to enable historical Target lookup. Unfortunately, in a typical Kubernetes/cryostat-operator/agent-autoconfig deployment scenario, the `podName` lookup key does not exactly match any existing field of the Target records. The `alias` is close, but the `podName` also contains `-agent-<uuid>` as a suffix. It's not ideal to return the full list of results to the client and make the client do the filtering, so simply adding a field to the node filter to allow filtering by target alias works, since that will match the `podName`.

It's also possible for clients to query based on target annotations since in this scenario with Agent autoconfig instances the `HOST` annotation should be set to the container's hostname, which would also be the Pod name, but the alias is a more robust check and should be possible.