### PR TITLE
feat(archive): include recording labels for startTime, duration, activeRecordingId

### DIFF
--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -165,6 +165,12 @@ public class ArchivedRecordings {
             rawLabels.getMap().forEach((k, v) -> labels.put(k, v.toString()));
         }
         labels.put("jvmId", id);
+        resolveActiveRecordingId(id, labels)
+                .ifPresent(
+                        i ->
+                                labels.put(
+                                        RecordingHelper.ACTIVE_RECORDING_ID_LABEL,
+                                        String.valueOf(i)));
         Metadata metadata = new Metadata(labels);
         logger.tracev(
                 "recording:{0}, labels:{1}, maxFiles:{2}", recording.fileName(), labels, maxFiles);
@@ -202,6 +208,42 @@ public class ArchivedRecordings {
                     });
         }
         doUpload(recording, metadata, id);
+    }
+
+    private Optional<Long> resolveActiveRecordingId(String jvmId, Map<String, String> labels) {
+        String sourceRecordingId = labels.get(RecordingHelper.SOURCE_RECORDING_ID_LABEL);
+        if (StringUtils.isBlank(sourceRecordingId)) {
+            logger.warnv(
+                    "No {0} provided for archived recording upload on target {1}",
+                    RecordingHelper.SOURCE_RECORDING_ID_LABEL, jvmId);
+            return Optional.empty();
+        }
+        long remoteId;
+        try {
+            remoteId = Long.parseLong(sourceRecordingId);
+        } catch (NumberFormatException e) {
+            logger.warnv(
+                    e,
+                    "Invalid {0}={1} provided for archived recording upload on target {2}",
+                    RecordingHelper.SOURCE_RECORDING_ID_LABEL,
+                    sourceRecordingId,
+                    jvmId);
+            return Optional.empty();
+        }
+        Optional<Target> target = Target.getTargetByJvmId(jvmId);
+        if (target.isEmpty()) {
+            logger.warnv("No target found for archived recording upload on target {0}", jvmId);
+            return Optional.empty();
+        }
+        Optional<ActiveRecording> recording =
+                recordingHelper.getActiveRecording(target.get(), remoteId);
+        if (recording.isEmpty()) {
+            logger.warnv(
+                    "No active recording found for {0}={1} on target {2}",
+                    RecordingHelper.SOURCE_RECORDING_ID_LABEL, sourceRecordingId, jvmId);
+            return Optional.empty();
+        }
+        return Optional.of(recording.get().id);
     }
 
     @GET

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -39,6 +39,7 @@ import io.cryostat.targets.Target;
 import io.cryostat.util.HttpMimeType;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.smallrye.common.annotation.Blocking;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -230,13 +231,15 @@ public class ArchivedRecordings {
                     jvmId);
             return Optional.empty();
         }
-        Optional<Target> target = Target.getTargetByJvmId(jvmId);
+        Optional<Target> target =
+                QuarkusTransaction.joiningExisting().call(() -> Target.getTargetByJvmId(jvmId));
         if (target.isEmpty()) {
             logger.warnv("No target found for archived recording upload on target {0}", jvmId);
             return Optional.empty();
         }
         Optional<ActiveRecording> recording =
-                recordingHelper.getActiveRecording(target.get(), remoteId);
+                QuarkusTransaction.joiningExisting()
+                        .call(() -> recordingHelper.getActiveRecording(target.get(), remoteId));
         if (recording.isEmpty()) {
             logger.warnv(
                     "No active recording found for {0}={1} on target {2}",

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -1038,9 +1038,7 @@ public class RecordingHelper {
                 .run(
                         () ->
                                 ArchivedRecordingInfo.of(
-                                                recording.target.jvmId,
-                                                filename,
-                                                recording.id.longValue())
+                                                recording.target.jvmId, filename, recording.id)
                                         .persist());
         ArchivedRecording archivedRecording =
                 getArchivedRecordingInfo(recording.target.jvmId, filename).orElseThrow();

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -165,6 +165,10 @@ public class RecordingHelper {
     private static final Pattern TEMPLATE_PATTERN =
             Pattern.compile("^template=([\\w]+)(?:,type=([\\w]+))?$");
     public static final String DATASOURCE_FILENAME = "cryostat-analysis.jfr";
+    public static final String ACTIVE_RECORDING_ID_LABEL = "activeRecordingId";
+    public static final String SOURCE_RECORDING_ID_LABEL = "sourceRecordingId";
+    public static final String START_TIME_LABEL = "startTime";
+    public static final String DURATION_LABEL = "duration";
 
     @Inject S3Client storage;
     @Inject S3TransferManager transferManager;
@@ -1030,6 +1034,14 @@ public class RecordingHelper {
                     .completionFuture()
                     .join();
         }
+        QuarkusTransaction.joiningExisting()
+                .run(
+                        () ->
+                                ArchivedRecordingInfo.of(
+                                                recording.target.jvmId,
+                                                filename,
+                                                recording.id.longValue())
+                                        .persist());
         ArchivedRecording archivedRecording =
                 getArchivedRecordingInfo(recording.target.jvmId, filename).orElseThrow();
 
@@ -1278,6 +1290,13 @@ public class RecordingHelper {
         Map<String, String> labels = new HashMap<>(recording.metadata.labels());
         labels.put("connectUrl", recording.target.connectUrl.toString());
         labels.put("jvmId", recording.target.jvmId);
+        labels.put(START_TIME_LABEL, String.valueOf(recording.startTime));
+        long duration = recording.duration;
+        if (duration <= 0) {
+            duration = clock.now().toEpochMilli() - recording.startTime;
+        }
+        labels.put(DURATION_LABEL, String.valueOf(duration));
+        labels.put(ACTIVE_RECORDING_ID_LABEL, String.valueOf(recording.id));
         Metadata metadata = new Metadata(labels);
         return metadata;
     }
@@ -1370,6 +1389,11 @@ public class RecordingHelper {
         }
         Map<String, String> labels = new HashMap<>(metadata.labels());
         labels.put("jvmId", jvmId);
+        Long activeRecordingId =
+                Optional.ofNullable(labels.get(ACTIVE_RECORDING_ID_LABEL))
+                        .map(Long::valueOf)
+                        .orElse(null);
+        Metadata resolvedMetadata = new Metadata(labels);
         String key = archivedRecordingKey(jvmId, filename);
         Builder requestBuilder =
                 PutObjectRequest.builder()
@@ -1379,14 +1403,13 @@ public class RecordingHelper {
                         .contentDisposition(String.format("attachment; filename=\"%s\"", filename));
         switch (storageMode()) {
             case TAGGING:
-                requestBuilder =
-                        requestBuilder.tagging(createMetadataTagging(new Metadata(labels)));
+                requestBuilder = requestBuilder.tagging(createMetadataTagging(resolvedMetadata));
                 break;
             case METADATA:
                 requestBuilder = requestBuilder.metadata(labels);
                 break;
             case BUCKET:
-                metadataService.get().create(jvmId, filename, metadata);
+                metadataService.get().create(jvmId, filename, resolvedMetadata);
                 break;
             default:
                 throw new IllegalStateException();
@@ -1402,7 +1425,10 @@ public class RecordingHelper {
 
         String finalFilename = filename;
         QuarkusTransaction.joiningExisting()
-                .run(() -> ArchivedRecordingInfo.of(jvmId, finalFilename, null).persist());
+                .run(
+                        () ->
+                                ArchivedRecordingInfo.of(jvmId, finalFilename, activeRecordingId)
+                                        .persist());
 
         var target = Target.getTargetByJvmId(jvmId);
         ArchivedRecording archivedRecording =
@@ -1411,7 +1437,7 @@ public class RecordingHelper {
                         filename,
                         downloadUrl(jvmId, filename),
                         reportUrl(jvmId, filename),
-                        metadata,
+                        resolvedMetadata,
                         recording.size(),
                         clock.now().getEpochSecond());
         var event =

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -1294,6 +1294,9 @@ public class RecordingHelper {
         long duration = recording.duration;
         if (duration <= 0) {
             duration = clock.now().toEpochMilli() - recording.startTime;
+            if (recording.maxAge > 0) {
+                duration = Math.min(duration, recording.maxAge);
+            }
         }
         labels.put(DURATION_LABEL, String.valueOf(duration));
         labels.put(ACTIVE_RECORDING_ID_LABEL, String.valueOf(recording.id));

--- a/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
@@ -144,6 +144,29 @@ class RecordingHelperTest extends AbstractTransactionalTestBase {
     }
 
     @Test
+    void shouldUseMaxAgeAsDurationApproximationForContinuousRecording() throws Exception {
+        long recordingId = 44L;
+        long startTime = Instant.now().minusSeconds(3600).toEpochMilli();
+        long maxAge = 5 * 60 * 1000L;
+        ActiveRecording recording = new ActiveRecording();
+        recording.id = recordingId;
+        recording.startTime = startTime;
+        recording.duration = 0L;
+        recording.maxAge = maxAge;
+        recording.metadata = new ActiveRecordings.Metadata(Map.of("label", "value"));
+        Target target = new Target();
+        target.jvmId = selfJvmId;
+        target.connectUrl = URI.create(SELF_JMX_URL);
+        recording.target = target;
+
+        ActiveRecordings.Metadata metadata =
+                recordingHelper.createActiveRecordingMetadata(recording);
+
+        assertThat(
+                metadata.labels().get(RecordingHelper.DURATION_LABEL), is(String.valueOf(maxAge)));
+    }
+
+    @Test
     void shouldPersistActiveRecordingIdWhenUploadingArchivedRecording() throws Exception {
         defineSelfCustomTarget();
         long remoteId =

--- a/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
@@ -18,14 +18,18 @@ package io.cryostat.recordings;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 import io.cryostat.AbstractTransactionalTestBase;
 import io.cryostat.resources.S3StorageResource;
+import io.cryostat.targets.Target;
 
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -79,6 +83,114 @@ class RecordingHelperTest extends AbstractTransactionalTestBase {
         } finally {
             Files.deleteIfExists(firstRecording);
             Files.deleteIfExists(secondRecording);
+        }
+    }
+
+    @Test
+    void shouldIncludeConfiguredDurationInActiveRecordingMetadata() throws Exception {
+        long recordingId = 42L;
+        long startTime = 123456789L;
+        long duration = 98765L;
+        ActiveRecording recording = new ActiveRecording();
+        recording.id = recordingId;
+        recording.startTime = startTime;
+        recording.duration = duration;
+        recording.metadata = new ActiveRecordings.Metadata(Map.of("label", "value"));
+        Target target = new Target();
+        target.jvmId = selfJvmId;
+        target.connectUrl = URI.create(SELF_JMX_URL);
+        recording.target = target;
+
+        ActiveRecordings.Metadata metadata =
+                recordingHelper.createActiveRecordingMetadata(recording);
+
+        assertThat(metadata.labels().get("label"), is("value"));
+        assertThat(metadata.labels().get("connectUrl"), is(SELF_JMX_URL));
+        assertThat(metadata.labels().get("jvmId"), is(selfJvmId));
+        assertThat(
+                metadata.labels().get(RecordingHelper.START_TIME_LABEL),
+                is(String.valueOf(startTime)));
+        assertThat(
+                metadata.labels().get(RecordingHelper.DURATION_LABEL),
+                is(String.valueOf(duration)));
+        assertThat(
+                metadata.labels().get(RecordingHelper.ACTIVE_RECORDING_ID_LABEL),
+                is(String.valueOf(recordingId)));
+    }
+
+    @Test
+    void shouldUseElapsedDurationInActiveRecordingMetadataForContinuousRecording()
+            throws Exception {
+        long recordingId = 43L;
+        long startTime = Instant.now().minusSeconds(5).toEpochMilli();
+        ActiveRecording recording = new ActiveRecording();
+        recording.id = recordingId;
+        recording.startTime = startTime;
+        recording.duration = 0L;
+        recording.metadata = new ActiveRecordings.Metadata(Map.of("label", "value"));
+        Target target = new Target();
+        target.jvmId = selfJvmId;
+        target.connectUrl = URI.create(SELF_JMX_URL);
+        recording.target = target;
+
+        long before = Instant.now().toEpochMilli();
+        ActiveRecordings.Metadata metadata =
+                recordingHelper.createActiveRecordingMetadata(recording);
+        long after = Instant.now().toEpochMilli();
+        long actualDuration = Long.parseLong(metadata.labels().get(RecordingHelper.DURATION_LABEL));
+
+        assertThat(actualDuration, greaterThanOrEqualTo(before - startTime));
+        assertThat(actualDuration, lessThanOrEqualTo(after - startTime));
+    }
+
+    @Test
+    void shouldPersistActiveRecordingIdWhenUploadingArchivedRecording() throws Exception {
+        defineSelfCustomTarget();
+        long remoteId =
+                startSelfRecording("recording-helper-active-id", Map.of("events", "template=ALL"))
+                        .getLong("remoteId");
+        ActiveRecording activeRecording =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () ->
+                                        ActiveRecording.find("remoteId", remoteId)
+                                                .firstResultOptional()
+                                                .map(ActiveRecording.class::cast)
+                                                .orElseThrow());
+
+        Path recordingFile = Files.createTempFile("recording-helper-active-id", ".jfr");
+        Files.write(recordingFile, new byte[] {9, 8, 7, 6});
+
+        try {
+            ActiveRecordings.Metadata metadata =
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    "purpose",
+                                    "persist-active-id",
+                                    RecordingHelper.ACTIVE_RECORDING_ID_LABEL,
+                                    String.valueOf(activeRecording.id)));
+
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("persist-active-id.jfr", recordingFile),
+                    metadata);
+
+            ArchivedRecordingInfo info =
+                    QuarkusTransaction.requiringNew()
+                            .call(
+                                    () ->
+                                            ArchivedRecordingInfo.find(
+                                                            "jvmId = ?1 and filename = ?2",
+                                                            selfJvmId,
+                                                            "persist-active-id.jfr")
+                                                    .firstResultOptional()
+                                                    .map(ArchivedRecordingInfo.class::cast)
+                                                    .orElseThrow());
+
+            assertThat(info.activeRecordingId, is(activeRecording.id));
+        } finally {
+            cleanupSelfRecording();
+            Files.deleteIfExists(recordingFile);
         }
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes #1665

## Description of the change:
When Cryostat archives a recording, add additional labels:
1. `activeRecordingId`, the database ID of the ActiveRecording record in the database. Along with the existing `jvmId` label this enables complete audit log lookup of what the source recording was
2. `duration`, for a fixed-length recording this is simply the recording duration that was set. For an ongoing continuous recording this is the difference in time between when the recording was started and the moment it's being archived, or the recording's `maxAge` if it's less than that timespan.
3. `startTime`, simply the timestamp when the recording was started

## Motivation for the change:
See #1665 , #1605 , and cryostatio/cryostat-mcp#26 . If archived recordings are appropriately labelled so that a client (like the Cryostat MCP) can approximate the timestamp range covered by a recording file, then a series of files can be collected and concatenated to form a synthetic recording covering a wider span.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
