### PR TITLE
fix(recording): already-stopped external recordings should be archived immediately

### DIFF
--- a/compose/jfr-datasource.yml
+++ b/compose/jfr-datasource.yml
@@ -19,6 +19,7 @@ services:
       io.cryostat.jmxPort: "11223"
     environment:
       JAVA_OPTS_APPEND: >-
+        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
         -Dcom.sun.management.jmxremote.autodiscovery=true
         -Dcom.sun.management.jmxremote
         -Dcom.sun.management.jmxremote.port=11223

--- a/compose/sample_apps/gameserver.yml
+++ b/compose/sample_apps/gameserver.yml
@@ -27,6 +27,9 @@ services:
       CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B: 153600 # "$(echo 1024*150 | bc)"
       MINECRAFT_ONLINE_MODE: "false"
       JAVA_OPTS: >-
+        -XX:StartFlightRecording=filename=/tmp/,name=toofast,settings=profile,disk=true,duration=10s
+        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
+        -XX:StartFlightRecording=filename=/tmp/,name=external,settings=profile,disk=true
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/opt/cryostat/agent.jar
     volumes:

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -9,8 +9,6 @@ services:
       - "9977"
     environment:
       JAVA_OPTS_APPEND: >-
-        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=2m
-        -XX:StartFlightRecording=filename=/tmp/,name=toofast,settings=profile,disk=true,duration=10s
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -9,7 +9,7 @@ services:
       - "9977"
     environment:
       JAVA_OPTS_APPEND: >-
-        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
+        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=2m
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -10,7 +10,7 @@ services:
     environment:
       JAVA_OPTS_APPEND: >-
         -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=2m
-        -XX:StartFlightRecording=filename=/tmp/,name=toofast,settings=profile,disk=true,duration=30s
+        -XX:StartFlightRecording=filename=/tmp/,name=toofast,settings=profile,disk=true,duration=10s
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -10,6 +10,7 @@ services:
     environment:
       JAVA_OPTS_APPEND: >-
         -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=2m
+        -XX:StartFlightRecording=filename=/tmp/,name=toofast,settings=profile,disk=true,duration=30s
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -9,6 +9,7 @@ services:
       - "9977"
     environment:
       JAVA_OPTS_APPEND: >-
+        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -204,8 +204,7 @@ public class ActiveRecording extends PanacheEntity {
                                         activeRecording.target.connectUrl.toString(),
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
-            }
-            if (RecordingState.STOPPED.equals(activeRecording.state)
+            } else if (RecordingState.STOPPED.equals(activeRecording.state)
                     && activeRecording.archiveOnStop
                     && archiveExternal) {
                 doArchive(activeRecording);
@@ -223,8 +222,7 @@ public class ActiveRecording extends PanacheEntity {
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
                 if (activeRecording.archiveOnStop
-                        && (!activeRecording.external
-                                || (activeRecording.external && archiveExternal))) {
+                        && (!activeRecording.external || archiveExternal)) {
                     doArchive(activeRecording);
                 }
             }

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -193,19 +193,23 @@ public class ActiveRecording extends PanacheEntity {
 
         @PostPersist
         public void postPersist(ActiveRecording activeRecording) {
-            if (activeRecording.external) {
-                // if the recording was started externally, ex. by -XX:StartFlightRecording flag,
-                // then we don't want to emit spurious notifications as if we have initiated this
-                // recording
-                return;
+            // if the recording was started externally, ex. by -XX:StartFlightRecording flag,
+            // then we don't want to emit spurious notifications as if we have initiated this
+            // recording
+            if (!activeRecording.external) {
+                createdEvent.fire(
+                        new ActiveRecordingEvents.ActiveRecordingCreated(
+                                activeRecording.id.longValue(),
+                                new ActiveRecordingEvents.ActiveRecordingSnapshot(
+                                        activeRecording.target.connectUrl.toString(),
+                                        recordingHelper.toExternalForm(activeRecording),
+                                        activeRecording.target.jvmId)));
             }
-            createdEvent.fire(
-                    new ActiveRecordingEvents.ActiveRecordingCreated(
-                            activeRecording.id.longValue(),
-                            new ActiveRecordingEvents.ActiveRecordingSnapshot(
-                                    activeRecording.target.connectUrl.toString(),
-                                    recordingHelper.toExternalForm(activeRecording),
-                                    activeRecording.target.jvmId)));
+            if (RecordingState.STOPPED.equals(activeRecording.state)
+                    && activeRecording.archiveOnStop
+                    && archiveExternal) {
+                doArchive(activeRecording);
+            }
         }
 
         @PostUpdate
@@ -221,27 +225,29 @@ public class ActiveRecording extends PanacheEntity {
                 if (activeRecording.archiveOnStop
                         && (!activeRecording.external
                                 || (activeRecording.external && archiveExternal))) {
-                    executor.submit(
-                            () ->
-                                    QuarkusTransaction.joiningExisting()
-                                            .run(
-                                                    () -> {
-                                                        try {
-                                                            ActiveRecording recording =
-                                                                    ActiveRecording.find(
-                                                                                    "id",
-                                                                                    activeRecording
-                                                                                            .id)
-                                                                            .singleResult();
-                                                            recordingHelper.archiveRecording(
-                                                                    recording);
-                                                        } catch (Exception e) {
-                                                            logger.error(e);
-                                                            throw new RuntimeException(e);
-                                                        }
-                                                    }));
+                    doArchive(activeRecording);
                 }
             }
+        }
+
+        private void doArchive(ActiveRecording activeRecording) {
+            executor.submit(
+                    () ->
+                            QuarkusTransaction.joiningExisting()
+                                    .run(
+                                            () -> {
+                                                try {
+                                                    ActiveRecording recording =
+                                                            ActiveRecording.find(
+                                                                            "id",
+                                                                            activeRecording.id)
+                                                                    .singleResult();
+                                                    recordingHelper.archiveRecording(recording);
+                                                } catch (Exception e) {
+                                                    logger.error(e);
+                                                    throw new RuntimeException(e);
+                                                }
+                                            }));
         }
 
         @PostRemove

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -15,13 +15,16 @@
  */
 package io.cryostat.recordings;
 
+import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.flightrecorder.configuration.IRecordingDescriptor;
 
+import io.cryostat.ConfigProperties;
 import io.cryostat.recordings.ActiveRecordings.Metadata;
 import io.cryostat.recordings.events.ActiveRecordingEvents;
 import io.cryostat.targets.Target;
@@ -46,6 +49,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jdk.jfr.RecordingState;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.envers.Audited;
 import org.hibernate.type.SqlTypes;
@@ -184,7 +188,11 @@ public class ActiveRecording extends PanacheEntity {
         @Inject Event<ActiveRecordingEvents.ActiveRecordingCreated> createdEvent;
         @Inject Event<ActiveRecordingEvents.ActiveRecordingStopped> stoppedEvent;
         @Inject Event<ActiveRecordingEvents.ActiveRecordingDeleted> deletedEvent;
-        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+
+        @ConfigProperty(name = ConfigProperties.EXTERNAL_RECORDINGS_DELAY)
+        Duration externalRecordingDelay;
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
         @PostPersist
         public void postPersist(ActiveRecording activeRecording) {
@@ -222,23 +230,32 @@ public class ActiveRecording extends PanacheEntity {
         }
 
         private void doArchive(ActiveRecording activeRecording) {
-            executor.submit(
-                    () ->
-                            QuarkusTransaction.joiningExisting()
-                                    .run(
-                                            () -> {
-                                                try {
-                                                    ActiveRecording recording =
-                                                            ActiveRecording.find(
-                                                                            "id",
-                                                                            activeRecording.id)
-                                                                    .singleResult();
-                                                    recordingHelper.archiveRecording(recording);
-                                                } catch (Exception e) {
-                                                    logger.error(e);
-                                                    throw new RuntimeException(e);
-                                                }
-                                            }));
+            scheduler.schedule(
+                    () -> {
+                        Thread.ofVirtual()
+                                .start(
+                                        () -> {
+                                            QuarkusTransaction.requiringNew()
+                                                    .run(
+                                                            () -> {
+                                                                try {
+                                                                    ActiveRecording recording =
+                                                                            ActiveRecording.find(
+                                                                                            "id",
+                                                                                            activeRecording
+                                                                                                    .id)
+                                                                                    .singleResult();
+                                                                    recordingHelper
+                                                                            .archiveRecording(
+                                                                                    recording);
+                                                                } catch (Exception e) {
+                                                                    logger.error(e);
+                                                                }
+                                                            });
+                                        });
+                    },
+                    externalRecordingDelay.toMillis(),
+                    TimeUnit.MILLISECONDS);
         }
 
         @PostRemove

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -199,7 +199,9 @@ public class ActiveRecording extends PanacheEntity {
                                         activeRecording.target.connectUrl.toString(),
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
-            } else if (RecordingState.STOPPED.equals(activeRecording.state)) {
+            }
+
+            if (activeRecording.external && RecordingState.STOPPED.equals(activeRecording.state)) {
                 doArchive(activeRecording);
             }
         }

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -199,9 +199,8 @@ public class ActiveRecording extends PanacheEntity {
                                         activeRecording.target.connectUrl.toString(),
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
-            }
-
-            if (activeRecording.external && RecordingState.STOPPED.equals(activeRecording.state)) {
+            } else if (activeRecording.archiveOnStop
+                    && RecordingState.STOPPED.equals(activeRecording.state)) {
                 doArchive(activeRecording);
             }
         }

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -250,6 +250,7 @@ public class ActiveRecording extends PanacheEntity {
                                                                                     recording);
                                                                 } catch (Exception e) {
                                                                     logger.error(e);
+                                                                    throw new RuntimeException(e);
                                                                 }
                                                             });
                                         });

--- a/src/main/java/io/cryostat/recordings/ActiveRecording.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecording.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.flightrecorder.configuration.IRecordingDescriptor;
 
-import io.cryostat.ConfigProperties;
 import io.cryostat.recordings.ActiveRecordings.Metadata;
 import io.cryostat.recordings.events.ActiveRecordingEvents;
 import io.cryostat.targets.Target;
@@ -47,7 +46,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jdk.jfr.RecordingState;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.envers.Audited;
 import org.hibernate.type.SqlTypes;
@@ -188,9 +186,6 @@ public class ActiveRecording extends PanacheEntity {
         @Inject Event<ActiveRecordingEvents.ActiveRecordingDeleted> deletedEvent;
         ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
-        @ConfigProperty(name = ConfigProperties.EXTERNAL_RECORDINGS_ARCHIVE)
-        boolean archiveExternal;
-
         @PostPersist
         public void postPersist(ActiveRecording activeRecording) {
             // if the recording was started externally, ex. by -XX:StartFlightRecording flag,
@@ -204,9 +199,7 @@ public class ActiveRecording extends PanacheEntity {
                                         activeRecording.target.connectUrl.toString(),
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
-            } else if (RecordingState.STOPPED.equals(activeRecording.state)
-                    && activeRecording.archiveOnStop
-                    && archiveExternal) {
+            } else if (RecordingState.STOPPED.equals(activeRecording.state)) {
                 doArchive(activeRecording);
             }
         }
@@ -221,8 +214,7 @@ public class ActiveRecording extends PanacheEntity {
                                         activeRecording.target.connectUrl.toString(),
                                         recordingHelper.toExternalForm(activeRecording),
                                         activeRecording.target.jvmId)));
-                if (activeRecording.archiveOnStop
-                        && (!activeRecording.external || archiveExternal)) {
+                if (activeRecording.archiveOnStop) {
                     doArchive(activeRecording);
                 }
             }

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -396,9 +396,7 @@ public class RecordingHelper {
                     // TODO is there any other metadata to attach here?
                     var recording = ActiveRecording.from(target, descriptor, new Metadata(labels));
                     recording.external = true;
-                    if (externalRecordingArchive && recording.external) {
-                        recording.archiveOnStop = true;
-                    }
+                    recording.archiveOnStop = externalRecordingArchive;
                     // FIXME this is a hack. Older Cryostat versions enforced that recordings' names
                     // were unique within the target JVM, but this could only be enforced when
                     // Cryostat was originating the recording creation. Recordings already have

--- a/src/main/java/io/cryostat/targets/TargetUpdateJob.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateJob.java
@@ -25,7 +25,6 @@ import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.inject.Inject;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceException;
-import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.ObjectDeletedException;
@@ -51,15 +50,12 @@ public class TargetUpdateJob implements Job {
     ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
     @Override
-    @Transactional
     public void execute(JobExecutionContext context) throws JobExecutionException {
-        Target target;
         long targetId = (long) context.getMergedJobDataMap().get("targetId");
         try {
-            target = Target.getTargetById(targetId);
-            if (StringUtils.isBlank(target.jvmId)) {
-                updateTargetJvmId(target);
-            }
+            Target target =
+                    QuarkusTransaction.joiningExisting().call(() -> Target.getTargetById(targetId));
+            updateTargetJvmId(target);
             updateTargetRecordings(target);
         } catch (Exception e) {
             boolean targetLost =
@@ -84,6 +80,9 @@ public class TargetUpdateJob implements Job {
     }
 
     private void updateTargetJvmId(Target target) {
+        if (StringUtils.isNotBlank(target.jvmId)) {
+            return;
+        }
         final String jvmId =
                 connectionManager
                         .executeConnectedTask(

--- a/src/main/java/io/cryostat/targets/TargetUpdateJob.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateJob.java
@@ -26,7 +26,6 @@ import jakarta.inject.Inject;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
-import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.ObjectDeletedException;
@@ -35,7 +34,6 @@ import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.quartz.SchedulerException;
 
 /**
  * Attempt to connect to a remote target JVM to retrieve {@link java.lang.management.RuntimeMXBean}
@@ -120,17 +118,7 @@ public class TargetUpdateJob implements Job {
                             t.persist();
 
                             t.activeRecordings.stream()
-                                    .filter(r -> !r.continuous)
-                                    .filter(r -> !RecordingState.CLOSED.equals(r.state))
-                                    .filter(r -> !RecordingState.STOPPED.equals(r.state))
-                                    .forEach(
-                                            r -> {
-                                                try {
-                                                    updateService.fireActiveRecordingUpdate(r);
-                                                } catch (SchedulerException e) {
-                                                    logger.error(e);
-                                                }
-                                            });
+                                    .forEach(updateService::fireActiveRecordingUpdate);
                         });
     }
 }

--- a/src/main/java/io/cryostat/targets/TargetUpdateJob.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateJob.java
@@ -111,14 +111,14 @@ public class TargetUpdateJob implements Job {
 
     private void updateTargetRecordings(Target target) {
         QuarkusTransaction.joiningExisting()
-                .run(
+                .call(
                         () -> {
                             Target t = Target.getTargetById(target.id);
                             t.activeRecordings = recordingHelper.syncActiveRecordings(t);
                             t.persist();
-
-                            t.activeRecordings.stream()
-                                    .forEach(updateService::fireActiveRecordingUpdate);
-                        });
+                            return t.activeRecordings;
+                        })
+                .stream()
+                .forEach(updateService::fireActiveRecordingUpdate);
     }
 }

--- a/src/main/java/io/cryostat/targets/TargetUpdateService.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateService.java
@@ -33,6 +33,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.TransactionPhase;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jdk.jfr.RecordingState;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.quartz.JobBuilder;
@@ -149,24 +150,39 @@ public class TargetUpdateService {
         scheduler.scheduleJob(job, trigger);
     }
 
-    void fireActiveRecordingUpdate(ActiveRecording recording) throws SchedulerException {
+    void fireActiveRecordingUpdate(ActiveRecording recording) {
+        if (RecordingState.CLOSED.equals(recording.state) || recording.continuous) {
+            return;
+        }
         JobKey key =
                 JobKey.jobKey(
                         String.format("%s.%d", recording.target.jvmId, recording.remoteId),
                         "recording-update");
-        if (scheduler.checkExists(key)) {
-            return;
+        try {
+            if (scheduler.checkExists(key)) {
+                return;
+            }
+        } catch (SchedulerException se) {
+            logger.error(se);
         }
         JobDetail jobDetail =
                 JobBuilder.newJob(ActiveRecordingUpdateJob.class)
                         .withIdentity(key)
                         .usingJobData("recordingId", recording.id)
                         .build();
-        var when =
-                Instant.ofEpochMilli(recording.startTime)
-                        .plusMillis(recording.duration)
-                        .plus(externalRecordingDelay);
-        Trigger trigger = TriggerBuilder.newTrigger().startAt(Date.from(when)).build();
-        scheduler.scheduleJob(jobDetail, trigger);
+        Instant endTime = Instant.ofEpochMilli(recording.startTime).plusMillis(recording.duration);
+        Instant when = endTime.plus(externalRecordingDelay);
+
+        TriggerBuilder<Trigger> triggerBuilder = TriggerBuilder.newTrigger();
+        if (when.isBefore(Instant.now())) {
+            triggerBuilder = triggerBuilder.startNow();
+        } else {
+            triggerBuilder = triggerBuilder.startAt(Date.from(when));
+        }
+        try {
+            scheduler.scheduleJob(jobDetail, triggerBuilder.build());
+        } catch (SchedulerException se) {
+            logger.error(se);
+        }
     }
 }

--- a/src/main/java/io/cryostat/targets/TargetUpdateService.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateService.java
@@ -164,20 +164,24 @@ public class TargetUpdateService {
             }
         } catch (SchedulerException se) {
             logger.error(se);
+            return;
         }
         JobDetail jobDetail =
                 JobBuilder.newJob(ActiveRecordingUpdateJob.class)
                         .withIdentity(key)
                         .usingJobData("recordingId", recording.id)
                         .build();
-        Instant endTime = Instant.ofEpochMilli(recording.startTime).plusMillis(recording.duration);
-        Instant when = endTime.plus(externalRecordingDelay);
+
+        Instant when =
+                Instant.ofEpochMilli(recording.startTime)
+                        .plusMillis(recording.duration)
+                        .plus(externalRecordingDelay);
 
         TriggerBuilder<Trigger> triggerBuilder = TriggerBuilder.newTrigger();
-        if (when.isBefore(Instant.now())) {
+        if (RecordingState.STOPPED.equals(recording.state)) {
             triggerBuilder = triggerBuilder.startNow();
         } else {
-            triggerBuilder = triggerBuilder.startAt(Date.from(when));
+            triggerBuilder = triggerBuilder.startAt(when);
         }
         try {
             scheduler.scheduleJob(jobDetail, triggerBuilder.build());

--- a/src/test/java/io/cryostat/resources/AgentExternalRecordingAlreadyStoppedApplicationResource.java
+++ b/src/test/java/io/cryostat/resources/AgentExternalRecordingAlreadyStoppedApplicationResource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test resource that starts an agent container with a very short pre-started JFR recording. The
+ * recording completes before Cryostat discovers the target, so it is already in STOPPED state when
+ * first synced to the database. This is used to test that Cryostat immediately archives such
+ * recordings.
+ */
+public class AgentExternalRecordingAlreadyStoppedApplicationResource
+        extends AgentApplicationResource {
+
+    public static final String RECORDING_NAME = "already-stopped-recording";
+    public static final int RECORDING_DURATION_SECONDS = 5;
+
+    @Override
+    protected Map<String, String> getEnvMap() {
+        Map<String, String> envMap = new HashMap<>(super.getEnvMap());
+
+        String baseJavaOpts = envMap.get("JAVA_OPTS_APPEND");
+        String recordingOpts =
+                String.format(
+                        "-XX:StartFlightRecording=filename=/tmp/,name=%s,settings=profile,duration=%ds",
+                        RECORDING_NAME, RECORDING_DURATION_SECONDS);
+
+        envMap.put(
+                "JAVA_OPTS_APPEND",
+                (baseJavaOpts + " " + recordingOpts).replace("\n", " ").strip());
+
+        return envMap;
+    }
+}

--- a/src/test/java/io/cryostat/resources/AgentExternalRecordingAlreadyStoppedApplicationResource.java
+++ b/src/test/java/io/cryostat/resources/AgentExternalRecordingAlreadyStoppedApplicationResource.java
@@ -28,7 +28,7 @@ public class AgentExternalRecordingAlreadyStoppedApplicationResource
         extends AgentApplicationResource {
 
     public static final String RECORDING_NAME = "already-stopped-recording";
-    public static final int RECORDING_DURATION_SECONDS = 5;
+    public static final int RECORDING_DURATION_SECONDS = 1;
 
     @Override
     protected Map<String, String> getEnvMap() {

--- a/src/test/java/itest/agent/AgentExternalRecordingAlreadyStoppedIT.java
+++ b/src/test/java/itest/agent/AgentExternalRecordingAlreadyStoppedIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package itest.agent;
+
+import static io.restassured.RestAssured.given;
+
+import java.time.Duration;
+
+import io.cryostat.resources.AgentExternalRecordingAlreadyStoppedApplicationResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import itest.resources.S3StorageITResource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for the case where an external recording is already in STOPPED state when Cryostat first
+ * discovers the target. Verifies that the recording is immediately archived.
+ */
+@QuarkusIntegrationTest
+@QuarkusTestResource(
+        value = AgentExternalRecordingAlreadyStoppedApplicationResource.class,
+        restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = S3StorageITResource.class, restrictToAnnotatedClass = true)
+public class AgentExternalRecordingAlreadyStoppedIT extends AgentTestBase {
+
+    @Test
+    void testAlreadyStoppedExternalRecordingIsArchivedImmediately() throws Exception {
+        Thread.sleep(
+                Duration.ofSeconds(
+                                AgentExternalRecordingAlreadyStoppedApplicationResource
+                                                .RECORDING_DURATION_SECONDS
+                                        + 5)
+                        .toMillis());
+
+        var response =
+                given().log()
+                        .all()
+                        .pathParams("targetId", target.id())
+                        .when()
+                        .get("/api/v4/targets/{targetId}/recordings")
+                        .then()
+                        .log()
+                        .all()
+                        .statusCode(200)
+                        .extract()
+                        .response();
+
+        JsonArray recordings = new JsonArray(response.body().asString());
+
+        MatcherAssert.assertThat(
+                "Should have exactly 1 recording (the already-stopped external one)",
+                recordings.size(),
+                Matchers.equalTo(1));
+
+        JsonObject recording = recordings.getJsonObject(0);
+
+        MatcherAssert.assertThat(
+                "Recording name should match",
+                recording.getString("name"),
+                Matchers.equalTo(
+                        AgentExternalRecordingAlreadyStoppedApplicationResource.RECORDING_NAME));
+
+        MatcherAssert.assertThat(
+                "Recording should already be stopped when discovered",
+                recording.getString("state"),
+                Matchers.equalTo("STOPPED"));
+
+        JsonObject archiveNotification =
+                webSocketClient.expectNotification(
+                        "ArchivedRecordingCreated", Duration.ofSeconds(30));
+
+        JsonObject archiveMessage = archiveNotification.getJsonObject("message");
+        JsonObject archivedRecording = archiveMessage.getJsonObject("recording");
+
+        MatcherAssert.assertThat(
+                "Archived recording name should contain the already-stopped recording name",
+                archivedRecording.getString("name"),
+                Matchers.containsString(
+                        AgentExternalRecordingAlreadyStoppedApplicationResource.RECORDING_NAME));
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1670

## Description of the change:
Cryostat detects "external" recordings on targets - ones that were started by some other mechanism than Cryostat initiating them. `-XX:StartFlightRecording` would be a common source. When these are detected and if they have a fixed duration, Cryostat sets up a timed job to run when the recording ends so that Cryostat can update the database entity representing that recording, as well as to copy the recording content to archives.

Critically, the current implementation filters out detected recordings that have a fixed duration *that has already elapsed* and is already `STOPPED`. In that case, the database entity representing the recording is correctly in the `STOPPED` state, but the job for archiving the recording wouldn't be scheduled. If the user doesn't manually archive that recording or take some other action to preserve the data, then the recorded data would be lost.

## How to manually test:
1. Check out and build PR
2. `./smoketest.bash -O -t gameserver` to run a sample application that has three `-XX:StartFlightRecording` examples: one with 10s duration, one 30s, and one continuous. This application's Agent registration will take some time, longer than 10 seconds, so by the time the application is discovered by Cryostat at least one recording will have already completed and will be initially synched in the `STOPPED` state. Prior to this patch this recording would never be automatically archived, but now it should be ~2 seconds after the target is discovered.