### PR TITLE
fix(recordings): dual-discovered targets do not result in double external recording archival

### DIFF
--- a/compose/sample_apps/quarkus-cryostat-agent.yml
+++ b/compose/sample_apps/quarkus-cryostat-agent.yml
@@ -9,6 +9,7 @@ services:
       - "9977"
     environment:
       JAVA_OPTS_APPEND: >-
+        -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=2m
         -Djava.util.logging.manager=org.jboss.logmanager.LogManager
         -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=warn
         -javaagent:/deployments/app/cryostat-agent.jar

--- a/smoketest.bash
+++ b/smoketest.bash
@@ -238,7 +238,7 @@ function bucketname() {
 
 if [ ! "${DRY_RUN}" = "true" ]; then
     set -xe
-    CRYOSTAT_JAVA_OPTS="-XX:StartFlightRecording=filename=/tmp/,name=onstart,settings=default,disk=true,maxage=5m -XX:StartFlightRecording=filename=/tmp/,name=startup,settings=profile,disk=true,duration=30s -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
+    CRYOSTAT_JAVA_OPTS="-XX:StartFlightRecording=filename=/tmp/onstart.jfr,name=onstart,settings=default,disk=true,maxage=5m -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false"
     export CRYOSTAT_JAVA_OPTS
 else
     CRYOSTAT_STORAGE_BUCKETS_ARCHIVES_NAME="$(bucketname 'archives')"

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -90,6 +90,7 @@ import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
@@ -617,7 +618,8 @@ public class RecordingHelper {
                     JobBuilder.newJob(StopRecordingJob.class)
                             .withIdentity(key)
                             .usingJobData(JobInterruptMonitorPlugin.AUTO_INTERRUPTIBLE, "true")
-                            .usingJobData("recordingId", recording.id)
+                            .usingJobData("jvmId", lockedTarget.jvmId)
+                            .usingJobData("remoteId", recording.remoteId)
                             .build();
             try {
                 if (!scheduler.checkExists(key)) {
@@ -1622,9 +1624,19 @@ public class RecordingHelper {
         @Transactional
         public void execute(JobExecutionContext ctx) throws JobExecutionException {
             try {
-                ActiveRecording recording =
-                        ActiveRecording.find("id", ctx.getMergedJobDataMap().get("recordingId"))
-                                .singleResult();
+                String jvmId = ctx.getMergedJobDataMap().getString("jvmId");
+                long remoteId = ctx.getMergedJobDataMap().getLong("remoteId");
+                Target target =
+                        Target.findPreferredByJvmId(jvmId)
+                                .orElseThrow(
+                                        () ->
+                                                new NoResultException(
+                                                        "No target found for jvmId: " + jvmId));
+                ActiveRecording recording = target.getRecordingById(remoteId);
+                if (recording == null) {
+                    throw new NoResultException(
+                            "No recording found for jvmId: " + jvmId + " remoteId: " + remoteId);
+                }
                 recordingHelper.stopRecording(recording).await().atMost(connectionFailedTimeout);
             } catch (Exception e) {
                 var jee = new JobExecutionException(e);

--- a/src/main/java/io/cryostat/targets/ActiveRecordingUpdateJob.java
+++ b/src/main/java/io/cryostat/targets/ActiveRecordingUpdateJob.java
@@ -15,7 +15,6 @@
  */
 package io.cryostat.targets;
 
-import io.cryostat.recordings.ActiveRecording;
 import io.cryostat.recordings.RecordingHelper;
 
 import jakarta.inject.Inject;
@@ -40,17 +39,20 @@ import org.quartz.JobExecutionException;
 public class ActiveRecordingUpdateJob implements Job {
 
     @Inject Logger logger;
-    @Inject TargetConnectionManager connectionManager;
     @Inject RecordingHelper recordingHelper;
 
     @Override
     @Transactional
     public void execute(JobExecutionContext context) throws JobExecutionException {
-        long recordingId = (long) context.getMergedJobDataMap().get("recordingId");
-        ActiveRecording recording = ActiveRecording.findById(recordingId);
+        String jvmId = context.getMergedJobDataMap().getString("jvmId");
         Target target;
         try {
-            target = Target.getTargetById(recording.target.id);
+            target =
+                    Target.findPreferredByJvmId(jvmId)
+                            .orElseThrow(
+                                    () ->
+                                            new NoResultException(
+                                                    "No target found for jvmId: " + jvmId));
         } catch (NoResultException | ObjectDeletedException e) {
             // target disappeared in the meantime. No big deal.
             logger.debug(e);

--- a/src/main/java/io/cryostat/targets/Target.java
+++ b/src/main/java/io/cryostat/targets/Target.java
@@ -162,6 +162,19 @@ public class Target extends PanacheEntity {
         return find("jvmId", jvmId).firstResultOptional();
     }
 
+    /**
+     * Returns the preferred target for a given JVM ID when multiple targets share the same JVM ID
+     * (e.g. dual discovery via Agent HTTP + JMX). The Agent HTTP target is preferred over JMX.
+     * Falls back to any matching target if no agent target is present.
+     */
+    public static Optional<Target> findPreferredByJvmId(String jvmId) {
+        List<Target> targets = find("jvmId", jvmId).list();
+        return targets.stream()
+                .filter(Target::isAgent)
+                .findFirst()
+                .or(() -> targets.stream().findFirst());
+    }
+
     public static List<Target> findByRealm(String realm) {
         List<Target> targets = findAll().list();
 

--- a/src/main/java/io/cryostat/targets/TargetUpdateService.java
+++ b/src/main/java/io/cryostat/targets/TargetUpdateService.java
@@ -160,7 +160,8 @@ public class TargetUpdateService {
         JobDetail jobDetail =
                 JobBuilder.newJob(ActiveRecordingUpdateJob.class)
                         .withIdentity(key)
-                        .usingJobData("recordingId", recording.id)
+                        .usingJobData("jvmId", recording.target.jvmId)
+                        .usingJobData("remoteId", recording.remoteId)
                         .build();
         var when =
                 Instant.ofEpochMilli(recording.startTime)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1673
Based on #1672
Depends on #1672

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
