### PR TITLE
fix(agent-push): filter harvester-pushed files using pushType label

### DIFF
--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -155,7 +155,7 @@ public class ArchivedRecordings {
                     @RestForm("maxFiles")
                     int maxFiles)
             throws Exception {
-        jvmId = jvmId.strip();
+        final String id = jvmId.strip();
         int max = Integer.MAX_VALUE;
         if (maxFiles > 0) {
             max = maxFiles;
@@ -164,31 +164,44 @@ public class ArchivedRecordings {
         if (rawLabels != null) {
             rawLabels.getMap().forEach((k, v) -> labels.put(k, v.toString()));
         }
-        labels.put("jvmId", jvmId);
+        labels.put("jvmId", id);
         Metadata metadata = new Metadata(labels);
         logger.tracev(
                 "recording:{0}, labels:{1}, maxFiles:{2}", recording.fileName(), labels, maxFiles);
-        doUpload(recording, metadata, jvmId);
-        var objs = new ArrayList<S3Object>(recordingHelper.listArchivedRecordingObjects(jvmId));
-        var toRemove =
-                objs.stream()
-                        .sorted((a, b) -> b.lastModified().compareTo(a.lastModified()))
-                        .skip(max)
-                        .map(S3Object::key)
-                        .map(s -> s.split("/"))
-                        .map(a -> Pair.of(a[0], a[1]))
-                        .toList();
-        if (toRemove.isEmpty()) {
-            return;
+        if (max < Integer.MAX_VALUE) {
+            var objs = new ArrayList<S3Object>(recordingHelper.listArchivedRecordingObjects(id));
+            var toRemove =
+                    objs.stream()
+                            .filter(
+                                    obj -> {
+                                        String filename = obj.key().strip().split("/")[1];
+                                        return recordingHelper
+                                                .getArchivedRecordingMetadata(id, filename)
+                                                .map(
+                                                        m ->
+                                                                "SCHEDULED"
+                                                                        .equals(
+                                                                                m.labels()
+                                                                                        .get(
+                                                                                                "pushType")))
+                                                .orElse(false);
+                                    })
+                            .sorted((a, b) -> b.lastModified().compareTo(a.lastModified()))
+                            .skip(max - 1)
+                            .map(S3Object::key)
+                            .map(s -> s.split("/"))
+                            .map(a -> Pair.of(a[0], a[1]))
+                            .toList();
+            toRemove.forEach(
+                    p -> {
+                        try {
+                            recordingHelper.deleteArchivedRecording(p.getKey(), p.getValue());
+                        } catch (IOException ioe) {
+                            logger.error(ioe);
+                        }
+                    });
         }
-        toRemove.forEach(
-                p -> {
-                    try {
-                        recordingHelper.deleteArchivedRecording(p.getKey(), p.getValue());
-                    } catch (IOException ioe) {
-                        logger.error(ioe);
-                    }
-                });
+        doUpload(recording, metadata, id);
     }
 
     @GET

--- a/src/test/java/io/cryostat/recordings/AgentPushMaxFilesTest.java
+++ b/src/test/java/io/cryostat/recordings/AgentPushMaxFilesTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.recordings.ActiveRecordings.Metadata;
+import io.cryostat.resources.S3StorageResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = S3StorageResource.class, restrictToAnnotatedClass = true)
+public class AgentPushMaxFilesTest extends AbstractTransactionalTestBase {
+
+    static final String TEST_JVM_ID = "test-agent-jvmid";
+
+    @Inject RecordingHelper recordingHelper;
+
+    @BeforeEach
+    void setup() {
+        cleanupAgentRecordings();
+    }
+
+    @AfterEach
+    void cleanup() {
+        cleanupAgentRecordings();
+    }
+
+    private void cleanupAgentRecordings() {
+        recordingHelper
+                .listArchivedRecordingObjects(TEST_JVM_ID)
+                .forEach(
+                        obj -> {
+                            String filename = obj.key().strip().split("/")[1];
+                            try {
+                                recordingHelper.deleteArchivedRecording(TEST_JVM_ID, filename);
+                            } catch (Exception e) {
+                                // ignore cleanup errors
+                            }
+                        });
+    }
+
+    @Test
+    void testAgentPushWithMaxFilesOnlyPrunesScheduledPushes() throws Exception {
+        // Seed one non-pushed recording (no pushType label) for the same target
+        Path nonPushedFile = Files.createTempFile("non-pushed", ".jfr");
+        Files.write(nonPushedFile, new byte[] {1, 2, 3, 4});
+        recordingHelper.uploadArchivedRecording(
+                TEST_JVM_ID,
+                new TestFileUpload("non-pushed.jfr", nonPushedFile),
+                new Metadata(Map.of("jvmId", TEST_JVM_ID)));
+
+        // Seed one scheduled-push recording (with pushType=SCHEDULED label)
+        Path pushedFile1 = Files.createTempFile("pushed-1", ".jfr");
+        Files.write(pushedFile1, new byte[] {5, 6, 7, 8});
+        recordingHelper.uploadArchivedRecording(
+                TEST_JVM_ID,
+                new TestFileUpload("pushed-1.jfr", pushedFile1),
+                new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
+
+        // Verify both are present
+        var before = recordingHelper.listArchivedRecordings(TEST_JVM_ID);
+        assertThat(
+                before.stream().map(ArchivedRecordings.ArchivedRecording::name).toList(),
+                hasItem("non-pushed.jfr"));
+        assertThat(
+                before.stream().map(ArchivedRecordings.ArchivedRecording::name).toList(),
+                hasItem("pushed-1.jfr"));
+
+        // Push a second scheduled recording with maxFiles=1; only pushed-1 should be pruned
+        Path pushedFile2 = Files.createTempFile("pushed-2", ".jfr");
+        Files.write(pushedFile2, new byte[] {9, 10, 11, 12});
+
+        given().log()
+                .all()
+                .when()
+                .contentType(ContentType.MULTIPART)
+                .pathParam("jvmId", TEST_JVM_ID)
+                .multiPart("recording", pushedFile2.toFile(), "application/octet-stream")
+                .multiPart("labels", "{\"pushType\":\"SCHEDULED\"}", "application/json")
+                .multiPart("maxFiles", "1")
+                .post("/api/beta/recordings/{jvmId}")
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(204);
+
+        List<String> names =
+                recordingHelper.listArchivedRecordings(TEST_JVM_ID).stream()
+                        .map(ArchivedRecordings.ArchivedRecording::name)
+                        .toList();
+
+        // Non-pushed recording must be untouched
+        assertThat(names, hasItem("non-pushed.jfr"));
+        // Older pushed recording must have been pruned
+        assertThat(names, not(hasItem("pushed-1.jfr")));
+        // The newly uploaded pushed recording must be present
+        assertThat(names, hasItem("pushed-2.jfr"));
+        // Total: non-pushed + newest pushed = 2
+        assertThat(names.size(), equalTo(2));
+    }
+
+    @Test
+    void testAgentPushWithoutMaxFilesDoesNotPrune() throws Exception {
+        // Seed two scheduled-push recordings
+        Path pushedFile1 = Files.createTempFile("pushed-a", ".jfr");
+        Files.write(pushedFile1, new byte[] {1, 2, 3, 4});
+        recordingHelper.uploadArchivedRecording(
+                TEST_JVM_ID,
+                new TestFileUpload("pushed-a.jfr", pushedFile1),
+                new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
+
+        Path pushedFile2 = Files.createTempFile("pushed-b", ".jfr");
+        Files.write(pushedFile2, new byte[] {5, 6, 7, 8});
+        recordingHelper.uploadArchivedRecording(
+                TEST_JVM_ID,
+                new TestFileUpload("pushed-b.jfr", pushedFile2),
+                new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
+
+        // Push a third recording without maxFiles; nothing should be pruned
+        Path pushedFile3 = Files.createTempFile("pushed-c", ".jfr");
+        Files.write(pushedFile3, new byte[] {9, 10, 11, 12});
+
+        given().log()
+                .all()
+                .when()
+                .contentType(ContentType.MULTIPART)
+                .pathParam("jvmId", TEST_JVM_ID)
+                .multiPart("recording", pushedFile3.toFile(), "application/octet-stream")
+                .multiPart("labels", "{\"pushType\":\"SCHEDULED\"}", "application/json")
+                .post("/api/beta/recordings/{jvmId}")
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(204);
+
+        List<String> names =
+                recordingHelper.listArchivedRecordings(TEST_JVM_ID).stream()
+                        .map(ArchivedRecordings.ArchivedRecording::name)
+                        .toList();
+
+        assertThat(names, hasItem("pushed-a.jfr"));
+        assertThat(names, hasItem("pushed-b.jfr"));
+        assertThat(names, hasItem("pushed-c.jfr"));
+        assertThat(names.size(), equalTo(3));
+    }
+}

--- a/src/test/java/io/cryostat/recordings/AgentPushMaxFilesTest.java
+++ b/src/test/java/io/cryostat/recordings/AgentPushMaxFilesTest.java
@@ -46,8 +46,11 @@ public class AgentPushMaxFilesTest extends AbstractTransactionalTestBase {
 
     @Inject RecordingHelper recordingHelper;
 
+    Path tmpDir;
+
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
+        tmpDir = Files.createTempDirectory("agent-push-test");
         cleanupAgentRecordings();
     }
 
@@ -70,22 +73,24 @@ public class AgentPushMaxFilesTest extends AbstractTransactionalTestBase {
                         });
     }
 
+    private Path createRecordingFile(String name) throws Exception {
+        Path file = tmpDir.resolve(name);
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        return file;
+    }
+
     @Test
     void testAgentPushWithMaxFilesOnlyPrunesScheduledPushes() throws Exception {
         // Seed one non-pushed recording (no pushType label) for the same target
-        Path nonPushedFile = Files.createTempFile("non-pushed", ".jfr");
-        Files.write(nonPushedFile, new byte[] {1, 2, 3, 4});
         recordingHelper.uploadArchivedRecording(
                 TEST_JVM_ID,
-                new TestFileUpload("non-pushed.jfr", nonPushedFile),
+                new TestFileUpload("non-pushed.jfr", createRecordingFile("non-pushed.jfr")),
                 new Metadata(Map.of("jvmId", TEST_JVM_ID)));
 
         // Seed one scheduled-push recording (with pushType=SCHEDULED label)
-        Path pushedFile1 = Files.createTempFile("pushed-1", ".jfr");
-        Files.write(pushedFile1, new byte[] {5, 6, 7, 8});
         recordingHelper.uploadArchivedRecording(
                 TEST_JVM_ID,
-                new TestFileUpload("pushed-1.jfr", pushedFile1),
+                new TestFileUpload("pushed-1.jfr", createRecordingFile("pushed-1.jfr")),
                 new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
 
         // Verify both are present
@@ -98,15 +103,15 @@ public class AgentPushMaxFilesTest extends AbstractTransactionalTestBase {
                 hasItem("pushed-1.jfr"));
 
         // Push a second scheduled recording with maxFiles=1; only pushed-1 should be pruned
-        Path pushedFile2 = Files.createTempFile("pushed-2", ".jfr");
-        Files.write(pushedFile2, new byte[] {9, 10, 11, 12});
-
         given().log()
                 .all()
                 .when()
                 .contentType(ContentType.MULTIPART)
                 .pathParam("jvmId", TEST_JVM_ID)
-                .multiPart("recording", pushedFile2.toFile(), "application/octet-stream")
+                .multiPart(
+                        "recording",
+                        createRecordingFile("pushed-2.jfr").toFile(),
+                        "application/octet-stream")
                 .multiPart("labels", "{\"pushType\":\"SCHEDULED\"}", "application/json")
                 .multiPart("maxFiles", "1")
                 .post("/api/beta/recordings/{jvmId}")
@@ -134,30 +139,26 @@ public class AgentPushMaxFilesTest extends AbstractTransactionalTestBase {
     @Test
     void testAgentPushWithoutMaxFilesDoesNotPrune() throws Exception {
         // Seed two scheduled-push recordings
-        Path pushedFile1 = Files.createTempFile("pushed-a", ".jfr");
-        Files.write(pushedFile1, new byte[] {1, 2, 3, 4});
         recordingHelper.uploadArchivedRecording(
                 TEST_JVM_ID,
-                new TestFileUpload("pushed-a.jfr", pushedFile1),
+                new TestFileUpload("pushed-a.jfr", createRecordingFile("pushed-a.jfr")),
                 new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
 
-        Path pushedFile2 = Files.createTempFile("pushed-b", ".jfr");
-        Files.write(pushedFile2, new byte[] {5, 6, 7, 8});
         recordingHelper.uploadArchivedRecording(
                 TEST_JVM_ID,
-                new TestFileUpload("pushed-b.jfr", pushedFile2),
+                new TestFileUpload("pushed-b.jfr", createRecordingFile("pushed-b.jfr")),
                 new Metadata(Map.of("jvmId", TEST_JVM_ID, "pushType", "SCHEDULED")));
 
         // Push a third recording without maxFiles; nothing should be pruned
-        Path pushedFile3 = Files.createTempFile("pushed-c", ".jfr");
-        Files.write(pushedFile3, new byte[] {9, 10, 11, 12});
-
         given().log()
                 .all()
                 .when()
                 .contentType(ContentType.MULTIPART)
                 .pathParam("jvmId", TEST_JVM_ID)
-                .multiPart("recording", pushedFile3.toFile(), "application/octet-stream")
+                .multiPart(
+                        "recording",
+                        createRecordingFile("pushed-c.jfr").toFile(),
+                        "application/octet-stream")
                 .multiPart("labels", "{\"pushType\":\"SCHEDULED\"}", "application/json")
                 .post("/api/beta/recordings/{jvmId}")
                 .then()

--- a/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingHelperTest.java
@@ -29,9 +29,6 @@ import io.cryostat.resources.S3StorageResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -82,55 +79,6 @@ class RecordingHelperTest extends AbstractTransactionalTestBase {
         } finally {
             Files.deleteIfExists(firstRecording);
             Files.deleteIfExists(secondRecording);
-        }
-    }
-
-    static class TestFileUpload implements FileUpload {
-        private final String fileName;
-        private final Path path;
-
-        TestFileUpload(String fileName, Path path) {
-            this.fileName = fileName;
-            this.path = path;
-        }
-
-        @Override
-        public String name() {
-            return "recording";
-        }
-
-        @Override
-        public Path filePath() {
-            return path;
-        }
-
-        @Override
-        public String fileName() {
-            return fileName;
-        }
-
-        @Override
-        public long size() {
-            try {
-                return Files.size(path);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public String contentType() {
-            return "application/octet-stream";
-        }
-
-        @Override
-        public String charSet() {
-            return "";
-        }
-
-        @Override
-        public MultivaluedMap<String, String> getHeaders() {
-            return new MultivaluedHashMap<>();
         }
     }
 }

--- a/src/test/java/io/cryostat/recordings/TestFileUpload.java
+++ b/src/test/java/io/cryostat/recordings/TestFileUpload.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+class TestFileUpload implements FileUpload {
+    private final String fileName;
+    private final Path path;
+
+    TestFileUpload(String fileName, Path path) {
+        this.fileName = fileName;
+        this.path = path;
+    }
+
+    @Override
+    public String name() {
+        return "recording";
+    }
+
+    @Override
+    public Path filePath() {
+        return path;
+    }
+
+    @Override
+    public String fileName() {
+        return fileName;
+    }
+
+    @Override
+    public long size() {
+        try {
+            return Files.size(path);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String contentType() {
+        return "application/octet-stream";
+    }
+
+    @Override
+    public String charSet() {
+        return "";
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getHeaders() {
+        return new MultivaluedHashMap<>();
+    }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1671

## Description of the change:
1. `agentPush` endpoint uses the `pushType` label sent by the Agent to determine which files in storage belonging to the Agent instance are periodically-pushed harvester files and only prunes these, leaving other archives intact (manually archived, external recordings - see #1672 #1674)
2. Refactors the order of operations so that the pruning operation is done first and then the new file is uploaded. This matches the `ScheduledArchiveJob` used by Automated Rules. This prevents storage from temporarily exceeding the intended storage usage, and also means that we're not relying on an uploaded file to be immediately visible in the storage query with its full updated metadata - we're only pruning on older files which should have had time to settle.

## How to manually test:
1. Check out and build PR
2. Run `./smoketest.bash -O -t quarkus-cryostat-agent` - this sample application is already configured with a harvester to push a recording every 30 seconds and retain 3 pushes
3. Manually archive the harvester recording, and/or start a new recording and archive it
4. Wait and watch notifications and archives content. The manually archived recordings should not be deleted, and the harvester periodic pushed recordings should be rotated once there are 3.
5. The order of operations when pushed recordings are rotated should be that the oldest pushed recording is deleted, then the new file is uploaded to storage. Previously this was reversed - there would temporarily be 4 files in storage.