### PR TITLE
test(websocket): improve WebSocket connection reliability

### DIFF
--- a/src/test/java/io/cryostat/AbstractTestBase.java
+++ b/src/test/java/io/cryostat/AbstractTestBase.java
@@ -86,10 +86,7 @@ public abstract class AbstractTestBase {
         if (webSocketClient == null) {
             webSocketClient = new WebSocketTestClient(wsUri);
         }
-        if (!webSocketClient.isConnected()) {
-            webSocketClient.connect();
-            webSocketClient.awaitFullyConnected(Duration.ofSeconds(5));
-        }
+        webSocketClient.connect();
         webSocketClient.clearMessages();
 
         cleanupSelfActiveAndArchivedRecordings();

--- a/src/test/java/io/cryostat/AbstractTestBase.java
+++ b/src/test/java/io/cryostat/AbstractTestBase.java
@@ -88,7 +88,6 @@ public abstract class AbstractTestBase {
         }
         if (!webSocketClient.isConnected()) {
             webSocketClient.connect();
-            webSocketClient.awaitFullyConnected(Duration.ofSeconds(5));
         }
         webSocketClient.clearMessages();
 

--- a/src/test/java/io/cryostat/AbstractTestBase.java
+++ b/src/test/java/io/cryostat/AbstractTestBase.java
@@ -86,7 +86,10 @@ public abstract class AbstractTestBase {
         if (webSocketClient == null) {
             webSocketClient = new WebSocketTestClient(wsUri);
         }
-        webSocketClient.connect();
+        if (!webSocketClient.isConnected()) {
+            webSocketClient.connect();
+            webSocketClient.awaitFullyConnected(Duration.ofSeconds(5));
+        }
         webSocketClient.clearMessages();
 
         cleanupSelfActiveAndArchivedRecordings();

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -80,8 +80,13 @@ public class WebSocketTestClient {
             session = ContainerProvider.getWebSocketContainer().connectToServer(client, wsUri);
             awaitFullyConnected(Duration.ofSeconds(5));
             logger.infov("WebSocket connected to {0}", wsUri);
-        } finally {
+        } catch (IOException
+                | DeploymentException
+                | TimeoutException
+                | InterruptedException
+                | IllegalStateException e) {
             disconnect();
+            throw e;
         }
     }
 

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -16,10 +16,13 @@
 package io.cryostat.util;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
@@ -34,6 +37,7 @@ import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.DeploymentException;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.Session;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.jboss.logging.Logger;
 
 public class WebSocketTestClient {
@@ -53,13 +57,23 @@ public class WebSocketTestClient {
         this(() -> wsUri);
     }
 
-    public void connect() throws IOException, DeploymentException {
+    @Retry(
+            delay = 5000,
+            maxRetries = 6,
+            retryOn = {
+                InterruptedIOException.class,
+                ExecutionException.class,
+                ConnectException.class
+            })
+    public void connect()
+            throws IOException, DeploymentException, TimeoutException, InterruptedException {
         if (session != null && session.isOpen()) {
             logger.warn("WebSocket already connected");
             return;
         }
         URI wsUri = wsUriSupplier.get();
         session = ContainerProvider.getWebSocketContainer().connectToServer(client, wsUri);
+        awaitFullyConnected(Duration.ofSeconds(3));
         logger.infov("WebSocket connected to {0}", wsUri);
     }
 

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -63,7 +63,8 @@ public class WebSocketTestClient {
             retryOn = {
                 InterruptedIOException.class,
                 ExecutionException.class,
-                ConnectException.class
+                ConnectException.class,
+                TimeoutException.class
             })
     public void connect()
             throws IOException, DeploymentException, TimeoutException, InterruptedException {

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -75,10 +75,14 @@ public class WebSocketTestClient {
             logger.warn("WebSocket already connected");
             return;
         }
-        URI wsUri = wsUriSupplier.get();
-        session = ContainerProvider.getWebSocketContainer().connectToServer(client, wsUri);
-        awaitFullyConnected(Duration.ofSeconds(5));
-        logger.infov("WebSocket connected to {0}", wsUri);
+        try {
+            URI wsUri = wsUriSupplier.get();
+            session = ContainerProvider.getWebSocketContainer().connectToServer(client, wsUri);
+            awaitFullyConnected(Duration.ofSeconds(5));
+            logger.infov("WebSocket connected to {0}", wsUri);
+        } finally {
+            disconnect();
+        }
     }
 
     public void clearMessages() {

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -58,8 +58,8 @@ public class WebSocketTestClient {
     }
 
     @Retry(
-            delay = 5000,
-            maxRetries = 6,
+            delay = 6000,
+            maxRetries = 5,
             retryOn = {
                 InterruptedIOException.class,
                 ExecutionException.class,
@@ -77,7 +77,7 @@ public class WebSocketTestClient {
         }
         URI wsUri = wsUriSupplier.get();
         session = ContainerProvider.getWebSocketContainer().connectToServer(client, wsUri);
-        awaitFullyConnected(Duration.ofSeconds(3));
+        awaitFullyConnected(Duration.ofSeconds(5));
         logger.infov("WebSocket connected to {0}", wsUri);
     }
 

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -66,6 +66,8 @@ public class WebSocketTestClient {
                 ConnectException.class,
                 TimeoutException.class,
                 IllegalStateException.class,
+                IOException.class,
+                DeploymentException.class,
             })
     public void connect()
             throws IOException, DeploymentException, TimeoutException, InterruptedException {

--- a/src/test/java/io/cryostat/util/WebSocketTestClient.java
+++ b/src/test/java/io/cryostat/util/WebSocketTestClient.java
@@ -64,7 +64,8 @@ public class WebSocketTestClient {
                 InterruptedIOException.class,
                 ExecutionException.class,
                 ConnectException.class,
-                TimeoutException.class
+                TimeoutException.class,
+                IllegalStateException.class,
             })
     public void connect()
             throws IOException, DeploymentException, TimeoutException, InterruptedException {

--- a/src/test/java/itest/bases/WebSocketTestBase.java
+++ b/src/test/java/itest/bases/WebSocketTestBase.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 import io.cryostat.util.WebSocketTestClient;
 
@@ -50,7 +51,8 @@ public abstract class WebSocketTestBase {
     protected static WebSocketTestClient webSocketClient;
 
     @BeforeAll
-    static void setupTestBase() throws IOException, DeploymentException {
+    static void setupTestBase()
+            throws IOException, DeploymentException, TimeoutException, InterruptedException {
         // Integration tests don't have Quarkus injection, so construct URI from environment
         int port = Integer.parseInt(System.getenv().getOrDefault("QUARKUS_HTTP_PORT", "8081"));
         RestAssured.baseURI = "http://localhost";
@@ -63,6 +65,7 @@ public abstract class WebSocketTestBase {
                                         String.format(
                                                 "ws://localhost:%d/api/notifications", port)));
         webSocketClient.connect();
+        webSocketClient.clearMessages();
     }
 
     @BeforeEach

--- a/src/test/java/itest/bases/WebSocketTestBase.java
+++ b/src/test/java/itest/bases/WebSocketTestBase.java
@@ -17,7 +17,6 @@ package itest.bases;
 
 import java.io.IOException;
 import java.net.URI;
-import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
@@ -67,7 +66,6 @@ public abstract class WebSocketTestBase {
                                                 "ws://localhost:%d/api/notifications", port)));
         if (!webSocketClient.isConnected()) {
             webSocketClient.connect();
-            webSocketClient.awaitFullyConnected(Duration.ofSeconds(5));
         }
         webSocketClient.clearMessages();
     }

--- a/src/test/java/itest/bases/WebSocketTestBase.java
+++ b/src/test/java/itest/bases/WebSocketTestBase.java
@@ -64,7 +64,10 @@ public abstract class WebSocketTestBase {
                                 URI.create(
                                         String.format(
                                                 "ws://localhost:%d/api/notifications", port)));
-        webSocketClient.connect();
+        if (!webSocketClient.isConnected()) {
+            webSocketClient.connect();
+            webSocketClient.awaitFullyConnected(Duration.ofSeconds(5));
+        }
         webSocketClient.clearMessages();
     }
 

--- a/src/test/java/itest/bases/WebSocketTestBase.java
+++ b/src/test/java/itest/bases/WebSocketTestBase.java
@@ -17,6 +17,7 @@ package itest.bases;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1319

Fairly often there are intermittent test failures or flakey results which appear to stem from an `InterruptedIOException` on the `webSocketClient.connect()` call in `WebSocketTestBase`. This happens in CI but is not observed locally, and is very significantly more common on integration test runs than unit test runs. I suspect the cause is simple: the Cryostat process is not yet up and running and able to receive WebSocket client connection attempts. Things execute more slowly in the CI environment, and in integration tests a full Cryostat container image build is starting up vs a local JVM process like in unit tests. The test harness' WebSocket connection attempt should tolerate and retry after a few failures to ensure Cryostat has been given sufficient time to start and accept connections.