### PR TITLE
fix(discovery): prevent Kubernetes endpoint handling during shutdown

### DIFF
--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -350,13 +350,18 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         this.shuttingDown = shuttingDown;
     }
 
+<<<<<<< Updated upstream
     boolean enterDiscoveryEventHandler() {
+=======
+    boolean withDiscoveryEventHandler(Runnable handler) {
+>>>>>>> Stashed changes
         if (shuttingDown) {
             return false;
         }
 
         var readLock = shutdownLock.readLock();
         readLock.lock();
+<<<<<<< Updated upstream
         if (shuttingDown) {
             readLock.unlock();
             return false;
@@ -366,6 +371,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
     void exitDiscoveryEventHandler() {
         shutdownLock.readLock().unlock();
+=======
+        try {
+            if (shuttingDown) {
+                return false;
+            }
+            handler.run();
+            return true;
+        } finally {
+            readLock.unlock();
+        }
+>>>>>>> Stashed changes
     }
 
     @Override
@@ -423,6 +439,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConsumeEvent(value = NAMESPACE_QUERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRES_NEW)
     public void handleQueryEvent(NamespaceQueryEvent evt) {
+<<<<<<< Updated upstream
         if (!enterDiscoveryEventHandler()) {
             logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
             return;
@@ -431,6 +448,17 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             for (var namespace : evt.namespaces) {
                 try {
                     Set<Target> persistedTargets = queryPersistedTargets(namespace);
+=======
+        if (!withDiscoveryEventHandler(() -> syncNamespaceTargets(evt))) {
+            logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
+        }
+    }
+
+    private void syncNamespaceTargets(NamespaceQueryEvent evt) {
+        for (var namespace : evt.namespaces) {
+            try {
+                Set<Target> persistedTargets = queryPersistedTargets(namespace);
+>>>>>>> Stashed changes
 
                     Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
                             buildInMemoryTreeForNamespaceDTO(namespace);
@@ -509,6 +537,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConsumeEvent(value = ENDPOINT_SLICE_DISCOVERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRED)
     public void handleEndpointEvent(EndpointDiscoveryEvent evt) {
+<<<<<<< Updated upstream
         if (!enterDiscoveryEventHandler()) {
             logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
             return;
@@ -531,6 +560,29 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                         created.persist();
                                         return created;
                                     });
+=======
+        if (!withDiscoveryEventHandler(() -> applyEndpointDiscoveryEvent(evt))) {
+            logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
+        }
+    }
+
+    private void applyEndpointDiscoveryEvent(EndpointDiscoveryEvent evt) {
+        String namespace = evt.namespace;
+        DiscoveryNode realm = DiscoveryNode.getRealm(REALM).orElseThrow();
+        realm = entityManager.find(DiscoveryNode.class, realm.id, LockModeType.PESSIMISTIC_WRITE);
+        DiscoveryNode lockedRealm = realm;
+        DiscoveryNode nsNode =
+                DiscoveryNode.getChild(lockedRealm, n -> n.name.equals(namespace))
+                        .orElseGet(
+                                () -> {
+                                    DiscoveryNode created =
+                                            DiscoveryNode.environment(
+                                                    namespace, KubeDiscoveryNodeType.NAMESPACE);
+                                    created.parent = lockedRealm;
+                                    created.persist();
+                                    return created;
+                                });
+>>>>>>> Stashed changes
 
             if (evt.eventKind == EventKind.FOUND) {
                 if (evt.targetDto != null && evt.hierarchyRoot != null) {

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -308,11 +308,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             }
             logger.debugv("Shutting down {0} client", REALM);
 
-            try {
-                scheduler.deleteJob(RESYNC_JOB_KEY);
-            } catch (SchedulerException se) {
-                logger.warn(se);
-            }
+            deleteResyncJobIfSchedulerRunning();
             safeGetInformers()
                     .forEach(
                             (ns, informer) -> {
@@ -323,6 +319,16 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                             });
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    void deleteResyncJobIfSchedulerRunning() {
+        try {
+            if (!scheduler.isShutdown()) {
+                scheduler.deleteJob(RESYNC_JOB_KEY);
+            }
+        } catch (SchedulerException se) {
+            logger.warn(se);
         }
     }
 

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -350,28 +350,13 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         this.shuttingDown = shuttingDown;
     }
 
-<<<<<<< Updated upstream
-    boolean enterDiscoveryEventHandler() {
-=======
     boolean withDiscoveryEventHandler(Runnable handler) {
->>>>>>> Stashed changes
         if (shuttingDown) {
             return false;
         }
 
         var readLock = shutdownLock.readLock();
         readLock.lock();
-<<<<<<< Updated upstream
-        if (shuttingDown) {
-            readLock.unlock();
-            return false;
-        }
-        return true;
-    }
-
-    void exitDiscoveryEventHandler() {
-        shutdownLock.readLock().unlock();
-=======
         try {
             if (shuttingDown) {
                 return false;
@@ -381,7 +366,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         } finally {
             readLock.unlock();
         }
->>>>>>> Stashed changes
     }
 
     @Override
@@ -439,16 +423,6 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConsumeEvent(value = NAMESPACE_QUERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRES_NEW)
     public void handleQueryEvent(NamespaceQueryEvent evt) {
-<<<<<<< Updated upstream
-        if (!enterDiscoveryEventHandler()) {
-            logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
-            return;
-        }
-        try {
-            for (var namespace : evt.namespaces) {
-                try {
-                    Set<Target> persistedTargets = queryPersistedTargets(namespace);
-=======
         if (!withDiscoveryEventHandler(() -> syncNamespaceTargets(evt))) {
             logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
         }
@@ -458,109 +432,75 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         for (var namespace : evt.namespaces) {
             try {
                 Set<Target> persistedTargets = queryPersistedTargets(namespace);
->>>>>>> Stashed changes
 
-                    Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
-                            buildInMemoryTreeForNamespaceDTO(namespace);
+                Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
+                        buildInMemoryTreeForNamespaceDTO(namespace);
 
-                    Set<TargetDTO> observedTargetDtos = observedTargetsWithHierarchy.keySet();
+                Set<TargetDTO> observedTargetDtos = observedTargetsWithHierarchy.keySet();
 
-                    Set<String> observedConnectUrls =
-                            observedTargetDtos.stream()
-                                    .map(TargetDTO::connectUrl)
-                                    .collect(Collectors.toSet());
+                Set<String> observedConnectUrls =
+                        observedTargetDtos.stream()
+                                .map(TargetDTO::connectUrl)
+                                .collect(Collectors.toSet());
 
-                    Set<String> persistedConnectUrls =
-                            persistedTargets.stream()
-                                    .map(t -> t.connectUrl.toString())
-                                    .collect(Collectors.toSet());
+                Set<String> persistedConnectUrls =
+                        persistedTargets.stream()
+                                .map(t -> t.connectUrl.toString())
+                                .collect(Collectors.toSet());
 
-                    // Find removed targets (in persisted but not in observed)
-                    Set<Target> removedTargets =
-                            persistedTargets.stream()
-                                    .filter(
-                                            t ->
-                                                    !observedConnectUrls.contains(
-                                                            t.connectUrl.toString()))
-                                    .collect(Collectors.toSet());
+                // Find removed targets (in persisted but not in observed)
+                Set<Target> removedTargets =
+                        persistedTargets.stream()
+                                .filter(t -> !observedConnectUrls.contains(t.connectUrl.toString()))
+                                .collect(Collectors.toSet());
 
-                    // Find added targets (in observed but not in persisted)
-                    Set<TargetDTO> addedTargetDtos =
-                            observedTargetDtos.stream()
-                                    .filter(dto -> !persistedConnectUrls.contains(dto.connectUrl()))
-                                    .collect(Collectors.toSet());
+                // Find added targets (in observed but not in persisted)
+                Set<TargetDTO> addedTargetDtos =
+                        observedTargetDtos.stream()
+                                .filter(dto -> !persistedConnectUrls.contains(dto.connectUrl()))
+                                .collect(Collectors.toSet());
 
-                    logger.debugv(
-                            "Namespace {0}: Found {1} persisted targets, {2} observed targets, {3}"
-                                    + " removed targets, {4} added targets",
-                            namespace,
-                            persistedTargets.size(),
-                            observedTargetDtos.size(),
-                            removedTargets.size(),
-                            addedTargetDtos.size());
+                logger.debugv(
+                        "Namespace {0}: Found {1} persisted targets, {2} observed targets, {3}"
+                                + " removed targets, {4} added targets",
+                        namespace,
+                        persistedTargets.size(),
+                        observedTargetDtos.size(),
+                        removedTargets.size(),
+                        addedTargetDtos.size());
 
-                    removedTargets.forEach(
-                            (t) -> {
-                                logger.debugv(
-                                        "Publishing LOST event for target: {0}", t.connectUrl);
-                                notify(
-                                        EndpointDiscoveryEvent.from(
-                                                namespace, t, null, EventKind.LOST));
-                            });
+                removedTargets.forEach(
+                        (t) -> {
+                            logger.debugv("Publishing LOST event for target: {0}", t.connectUrl);
+                            notify(EndpointDiscoveryEvent.from(namespace, t, null, EventKind.LOST));
+                        });
 
-                    addedTargetDtos.forEach(
-                            (targetDto) -> {
-                                DiscoveryNodeDTO hierarchy =
-                                        observedTargetsWithHierarchy.get(targetDto);
-                                logger.debugv(
-                                        "Publishing FOUND event for target: {0}",
-                                        targetDto.connectUrl());
-                                notify(
-                                        EndpointDiscoveryEvent.from(
-                                                namespace,
-                                                null,
-                                                null,
-                                                EventKind.FOUND,
-                                                targetDto,
-                                                hierarchy));
-                            });
-                } catch (Exception e) {
-                    logger.errorv(
-                            e, "Failed to synchronize EndpointSlices in namespace {0}", namespace);
-                }
+                addedTargetDtos.forEach(
+                        (targetDto) -> {
+                            DiscoveryNodeDTO hierarchy =
+                                    observedTargetsWithHierarchy.get(targetDto);
+                            logger.debugv(
+                                    "Publishing FOUND event for target: {0}",
+                                    targetDto.connectUrl());
+                            notify(
+                                    EndpointDiscoveryEvent.from(
+                                            namespace,
+                                            null,
+                                            null,
+                                            EventKind.FOUND,
+                                            targetDto,
+                                            hierarchy));
+                        });
+            } catch (Exception e) {
+                logger.errorv(
+                        e, "Failed to synchronize EndpointSlices in namespace {0}", namespace);
             }
-        } finally {
-            exitDiscoveryEventHandler();
         }
     }
 
     @ConsumeEvent(value = ENDPOINT_SLICE_DISCOVERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRED)
     public void handleEndpointEvent(EndpointDiscoveryEvent evt) {
-<<<<<<< Updated upstream
-        if (!enterDiscoveryEventHandler()) {
-            logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
-            return;
-        }
-        try {
-            String namespace = evt.namespace;
-            DiscoveryNode realm = DiscoveryNode.getRealm(REALM).orElseThrow();
-            realm =
-                    entityManager.find(
-                            DiscoveryNode.class, realm.id, LockModeType.PESSIMISTIC_WRITE);
-            DiscoveryNode lockedRealm = realm;
-            DiscoveryNode nsNode =
-                    DiscoveryNode.getChild(lockedRealm, n -> n.name.equals(namespace))
-                            .orElseGet(
-                                    () -> {
-                                        DiscoveryNode created =
-                                                DiscoveryNode.environment(
-                                                        namespace, KubeDiscoveryNodeType.NAMESPACE);
-                                        created.parent = lockedRealm;
-                                        created.persist();
-                                        return created;
-                                    });
-=======
         if (!withDiscoveryEventHandler(() -> applyEndpointDiscoveryEvent(evt))) {
             logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
         }
@@ -582,32 +522,28 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
                                     created.persist();
                                     return created;
                                 });
->>>>>>> Stashed changes
 
-            if (evt.eventKind == EventKind.FOUND) {
-                if (evt.targetDto != null && evt.hierarchyRoot != null) {
-                    logger.debugv("Persisting target from DTO: {0}", evt.targetDto.connectUrl());
-                    persistOwnerChainFromDTO(nsNode, evt.targetDto, evt.hierarchyRoot);
-                } else {
-                    logger.warnv(
-                            "FOUND event missing DTOs for target: {0}",
-                            evt.target != null ? evt.target.connectUrl : "null");
-                }
+        if (evt.eventKind == EventKind.FOUND) {
+            if (evt.targetDto != null && evt.hierarchyRoot != null) {
+                logger.debugv("Persisting target from DTO: {0}", evt.targetDto.connectUrl());
+                persistOwnerChainFromDTO(nsNode, evt.targetDto, evt.hierarchyRoot);
             } else {
-                pruneOwnerChain(nsNode, evt.target);
+                logger.warnv(
+                        "FOUND event missing DTOs for target: {0}",
+                        evt.target != null ? evt.target.connectUrl : "null");
             }
-
-            if (!nsNode.hasChildren()) {
-                realm.children.remove(nsNode);
-                nsNode.parent = null;
-            } else if (!realm.children.contains(nsNode)) {
-                realm.children.add(nsNode);
-                nsNode.parent = realm;
-            }
-            realm.persist();
-        } finally {
-            exitDiscoveryEventHandler();
+        } else {
+            pruneOwnerChain(nsNode, evt.target);
         }
+
+        if (!nsNode.hasChildren()) {
+            realm.children.remove(nsNode);
+            nsNode.parent = null;
+        } else if (!realm.children.contains(nsNode)) {
+            realm.children.add(nsNode);
+            nsNode.parent = realm;
+        }
+        realm.persist();
     }
 
     private void notify(NamespaceQueryEvent evt) {

--- a/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
+++ b/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -165,6 +166,10 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConfigProperty(name = "cryostat.discovery.kubernetes.force-resync.enabled")
     boolean forceResyncEnabled;
 
+    private final ReentrantReadWriteLock shutdownLock = new ReentrantReadWriteLock();
+
+    private volatile boolean shuttingDown;
+
     private final LazyInitializer<HashMap<String, SharedIndexInformer<EndpointSlice>>> nsInformers =
             new LazyInitializer<HashMap<String, SharedIndexInformer<EndpointSlice>>>() {
                 @Override
@@ -224,6 +229,8 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
             };
 
     void onStart(@Observes StartupEvent evt) {
+        shuttingDown = false;
+
         if (!enabled()) {
             return;
         }
@@ -291,24 +298,32 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     }
 
     void onStop(@Observes ShutdownEvent evt) {
-        if (!(enabled() && available())) {
-            return;
-        }
-        logger.debugv("Shutting down {0} client", REALM);
+        shuttingDown = true;
 
+        var writeLock = shutdownLock.writeLock();
+        writeLock.lock();
         try {
-            scheduler.deleteJob(RESYNC_JOB_KEY);
-        } catch (SchedulerException se) {
-            logger.warn(se);
+            if (!(enabled() && available())) {
+                return;
+            }
+            logger.debugv("Shutting down {0} client", REALM);
+
+            try {
+                scheduler.deleteJob(RESYNC_JOB_KEY);
+            } catch (SchedulerException se) {
+                logger.warn(se);
+            }
+            safeGetInformers()
+                    .forEach(
+                            (ns, informer) -> {
+                                informer.close();
+                                logger.debugv(
+                                        "Closed EndpointSlice SharedInformer for namespace \"{0}\"",
+                                        ns);
+                            });
+        } finally {
+            writeLock.unlock();
         }
-        safeGetInformers()
-                .forEach(
-                        (ns, informer) -> {
-                            informer.close();
-                            logger.debugv(
-                                    "Closed EndpointSlice SharedInformer for namespace \"{0}\"",
-                                    ns);
-                        });
     }
 
     boolean enabled() {
@@ -325,8 +340,34 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         return false;
     }
 
+    void setShuttingDown(boolean shuttingDown) {
+        this.shuttingDown = shuttingDown;
+    }
+
+    boolean enterDiscoveryEventHandler() {
+        if (shuttingDown) {
+            return false;
+        }
+
+        var readLock = shutdownLock.readLock();
+        readLock.lock();
+        if (shuttingDown) {
+            readLock.unlock();
+            return false;
+        }
+        return true;
+    }
+
+    void exitDiscoveryEventHandler() {
+        shutdownLock.readLock().unlock();
+    }
+
     @Override
     public void onAdd(EndpointSlice slice) {
+        if (shuttingDown) {
+            logger.trace("Ignoring EndpointSlice add event during shutdown");
+            return;
+        }
         logger.debugv(
                 "EndpointSlice {0} created in namespace {1}",
                 slice.getMetadata().getName(), slice.getMetadata().getNamespace());
@@ -335,6 +376,10 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
     @Override
     public void onUpdate(EndpointSlice oldSlice, EndpointSlice newSlice) {
+        if (shuttingDown) {
+            logger.trace("Ignoring EndpointSlice update event during shutdown");
+            return;
+        }
         logger.debugv(
                 "EndpointSlice {0} modified in namespace {1}",
                 newSlice.getMetadata().getName(), newSlice.getMetadata().getNamespace());
@@ -343,6 +388,10 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
 
     @Override
     public void onDelete(EndpointSlice endpoints, boolean deletedFinalStateUnknown) {
+        if (shuttingDown) {
+            logger.trace("Ignoring EndpointSlice delete event during shutdown");
+            return;
+        }
         logger.debugv(
                 "EndpointSlice {0} deleted in namespace {1}",
                 endpoints.getMetadata().getName(), endpoints.getMetadata().getNamespace());
@@ -368,122 +417,154 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
     @ConsumeEvent(value = NAMESPACE_QUERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRES_NEW)
     public void handleQueryEvent(NamespaceQueryEvent evt) {
-        for (var namespace : evt.namespaces) {
-            try {
-                Set<Target> persistedTargets = queryPersistedTargets(namespace);
+        if (!enterDiscoveryEventHandler()) {
+            logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
+            return;
+        }
+        try {
+            for (var namespace : evt.namespaces) {
+                try {
+                    Set<Target> persistedTargets = queryPersistedTargets(namespace);
 
-                Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
-                        buildInMemoryTreeForNamespaceDTO(namespace);
+                    Map<TargetDTO, DiscoveryNodeDTO> observedTargetsWithHierarchy =
+                            buildInMemoryTreeForNamespaceDTO(namespace);
 
-                Set<TargetDTO> observedTargetDtos = observedTargetsWithHierarchy.keySet();
+                    Set<TargetDTO> observedTargetDtos = observedTargetsWithHierarchy.keySet();
 
-                Set<String> observedConnectUrls =
-                        observedTargetDtos.stream()
-                                .map(TargetDTO::connectUrl)
-                                .collect(Collectors.toSet());
+                    Set<String> observedConnectUrls =
+                            observedTargetDtos.stream()
+                                    .map(TargetDTO::connectUrl)
+                                    .collect(Collectors.toSet());
 
-                Set<String> persistedConnectUrls =
-                        persistedTargets.stream()
-                                .map(t -> t.connectUrl.toString())
-                                .collect(Collectors.toSet());
+                    Set<String> persistedConnectUrls =
+                            persistedTargets.stream()
+                                    .map(t -> t.connectUrl.toString())
+                                    .collect(Collectors.toSet());
 
-                // Find removed targets (in persisted but not in observed)
-                Set<Target> removedTargets =
-                        persistedTargets.stream()
-                                .filter(t -> !observedConnectUrls.contains(t.connectUrl.toString()))
-                                .collect(Collectors.toSet());
+                    // Find removed targets (in persisted but not in observed)
+                    Set<Target> removedTargets =
+                            persistedTargets.stream()
+                                    .filter(
+                                            t ->
+                                                    !observedConnectUrls.contains(
+                                                            t.connectUrl.toString()))
+                                    .collect(Collectors.toSet());
 
-                // Find added targets (in observed but not in persisted)
-                Set<TargetDTO> addedTargetDtos =
-                        observedTargetDtos.stream()
-                                .filter(dto -> !persistedConnectUrls.contains(dto.connectUrl()))
-                                .collect(Collectors.toSet());
+                    // Find added targets (in observed but not in persisted)
+                    Set<TargetDTO> addedTargetDtos =
+                            observedTargetDtos.stream()
+                                    .filter(dto -> !persistedConnectUrls.contains(dto.connectUrl()))
+                                    .collect(Collectors.toSet());
 
-                logger.debugv(
-                        "Namespace {0}: Found {1} persisted targets, {2} observed targets, {3}"
-                                + " removed targets, {4} added targets",
-                        namespace,
-                        persistedTargets.size(),
-                        observedTargetDtos.size(),
-                        removedTargets.size(),
-                        addedTargetDtos.size());
+                    logger.debugv(
+                            "Namespace {0}: Found {1} persisted targets, {2} observed targets, {3}"
+                                    + " removed targets, {4} added targets",
+                            namespace,
+                            persistedTargets.size(),
+                            observedTargetDtos.size(),
+                            removedTargets.size(),
+                            addedTargetDtos.size());
 
-                removedTargets.forEach(
-                        (t) -> {
-                            logger.debugv("Publishing LOST event for target: {0}", t.connectUrl);
-                            notify(EndpointDiscoveryEvent.from(namespace, t, null, EventKind.LOST));
-                        });
+                    removedTargets.forEach(
+                            (t) -> {
+                                logger.debugv(
+                                        "Publishing LOST event for target: {0}", t.connectUrl);
+                                notify(
+                                        EndpointDiscoveryEvent.from(
+                                                namespace, t, null, EventKind.LOST));
+                            });
 
-                addedTargetDtos.forEach(
-                        (targetDto) -> {
-                            DiscoveryNodeDTO hierarchy =
-                                    observedTargetsWithHierarchy.get(targetDto);
-                            logger.debugv(
-                                    "Publishing FOUND event for target: {0}",
-                                    targetDto.connectUrl());
-                            notify(
-                                    EndpointDiscoveryEvent.from(
-                                            namespace,
-                                            null,
-                                            null,
-                                            EventKind.FOUND,
-                                            targetDto,
-                                            hierarchy));
-                        });
-            } catch (Exception e) {
-                logger.errorv(
-                        e, "Failed to synchronize EndpointSlices in namespace {0}", namespace);
+                    addedTargetDtos.forEach(
+                            (targetDto) -> {
+                                DiscoveryNodeDTO hierarchy =
+                                        observedTargetsWithHierarchy.get(targetDto);
+                                logger.debugv(
+                                        "Publishing FOUND event for target: {0}",
+                                        targetDto.connectUrl());
+                                notify(
+                                        EndpointDiscoveryEvent.from(
+                                                namespace,
+                                                null,
+                                                null,
+                                                EventKind.FOUND,
+                                                targetDto,
+                                                hierarchy));
+                            });
+                } catch (Exception e) {
+                    logger.errorv(
+                            e, "Failed to synchronize EndpointSlices in namespace {0}", namespace);
+                }
             }
+        } finally {
+            exitDiscoveryEventHandler();
         }
     }
 
     @ConsumeEvent(value = ENDPOINT_SLICE_DISCOVERY_ADDR, blocking = true, ordered = true)
     @Transactional(TxType.REQUIRED)
     public void handleEndpointEvent(EndpointDiscoveryEvent evt) {
-        String namespace = evt.namespace;
-        DiscoveryNode realm = DiscoveryNode.getRealm(REALM).orElseThrow();
-        realm = entityManager.find(DiscoveryNode.class, realm.id, LockModeType.PESSIMISTIC_WRITE);
-        DiscoveryNode lockedRealm = realm;
-        DiscoveryNode nsNode =
-                DiscoveryNode.getChild(lockedRealm, n -> n.name.equals(namespace))
-                        .orElseGet(
-                                () -> {
-                                    DiscoveryNode created =
-                                            DiscoveryNode.environment(
-                                                    namespace, KubeDiscoveryNodeType.NAMESPACE);
-                                    created.parent = lockedRealm;
-                                    created.persist();
-                                    return created;
-                                });
+        if (!enterDiscoveryEventHandler()) {
+            logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
+            return;
+        }
+        try {
+            String namespace = evt.namespace;
+            DiscoveryNode realm = DiscoveryNode.getRealm(REALM).orElseThrow();
+            realm =
+                    entityManager.find(
+                            DiscoveryNode.class, realm.id, LockModeType.PESSIMISTIC_WRITE);
+            DiscoveryNode lockedRealm = realm;
+            DiscoveryNode nsNode =
+                    DiscoveryNode.getChild(lockedRealm, n -> n.name.equals(namespace))
+                            .orElseGet(
+                                    () -> {
+                                        DiscoveryNode created =
+                                                DiscoveryNode.environment(
+                                                        namespace, KubeDiscoveryNodeType.NAMESPACE);
+                                        created.parent = lockedRealm;
+                                        created.persist();
+                                        return created;
+                                    });
 
-        if (evt.eventKind == EventKind.FOUND) {
-            if (evt.targetDto != null && evt.hierarchyRoot != null) {
-                logger.debugv("Persisting target from DTO: {0}", evt.targetDto.connectUrl());
-                persistOwnerChainFromDTO(nsNode, evt.targetDto, evt.hierarchyRoot);
+            if (evt.eventKind == EventKind.FOUND) {
+                if (evt.targetDto != null && evt.hierarchyRoot != null) {
+                    logger.debugv("Persisting target from DTO: {0}", evt.targetDto.connectUrl());
+                    persistOwnerChainFromDTO(nsNode, evt.targetDto, evt.hierarchyRoot);
+                } else {
+                    logger.warnv(
+                            "FOUND event missing DTOs for target: {0}",
+                            evt.target != null ? evt.target.connectUrl : "null");
+                }
             } else {
-                logger.warnv(
-                        "FOUND event missing DTOs for target: {0}",
-                        evt.target != null ? evt.target.connectUrl : "null");
+                pruneOwnerChain(nsNode, evt.target);
             }
-        } else {
-            pruneOwnerChain(nsNode, evt.target);
-        }
 
-        if (!nsNode.hasChildren()) {
-            realm.children.remove(nsNode);
-            nsNode.parent = null;
-        } else if (!realm.children.contains(nsNode)) {
-            realm.children.add(nsNode);
-            nsNode.parent = realm;
+            if (!nsNode.hasChildren()) {
+                realm.children.remove(nsNode);
+                nsNode.parent = null;
+            } else if (!realm.children.contains(nsNode)) {
+                realm.children.add(nsNode);
+                nsNode.parent = realm;
+            }
+            realm.persist();
+        } finally {
+            exitDiscoveryEventHandler();
         }
-        realm.persist();
     }
 
     private void notify(NamespaceQueryEvent evt) {
+        if (shuttingDown) {
+            logger.tracev("Ignoring EndpointSlice namespace query event during shutdown: {0}", evt);
+            return;
+        }
         bus.publish(NAMESPACE_QUERY_ADDR, evt);
     }
 
     private void notify(EndpointDiscoveryEvent evt) {
+        if (shuttingDown) {
+            logger.tracev("Ignoring EndpointSlice discovery event during shutdown: {0}", evt);
+            return;
+        }
         bus.publish(ENDPOINT_SLICE_DISCOVERY_ADDR, evt);
     }
 
@@ -1657,7 +1738,7 @@ public class KubeEndpointSlicesDiscovery implements ResourceEventHandler<Endpoin
         }
     }
 
-    private static record EndpointDiscoveryEvent(
+    static record EndpointDiscoveryEvent(
             String namespace,
             Target target,
             ObjectReference objRef,

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -1062,11 +1062,44 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
 
     @Test
     void testShutdownWaitsForActiveDiscoveryEventHandler() throws Exception {
+<<<<<<< Updated upstream
         assertTrue(discovery.enterDiscoveryEventHandler());
 
         CountDownLatch shutdownStarted = new CountDownLatch(1);
         CountDownLatch shutdownFinished = new CountDownLatch(1);
         AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+=======
+        CountDownLatch handlerStarted = new CountDownLatch(1);
+        CountDownLatch releaseHandler = new CountDownLatch(1);
+        CountDownLatch handlerFinished = new CountDownLatch(1);
+        CountDownLatch shutdownStarted = new CountDownLatch(1);
+        CountDownLatch shutdownFinished = new CountDownLatch(1);
+        AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        Thread handlerThread =
+                new Thread(
+                        () -> {
+                            try {
+                                assertTrue(
+                                        discovery.withDiscoveryEventHandler(
+                                                () -> {
+                                                    handlerStarted.countDown();
+                                                    try {
+                                                        assertTrue(
+                                                                releaseHandler.await(
+                                                                        5, TimeUnit.SECONDS));
+                                                    } catch (InterruptedException e) {
+                                                        Thread.currentThread().interrupt();
+                                                        fail(e);
+                                                    }
+                                                }));
+                            } catch (Throwable t) {
+                                handlerFailure.set(t);
+                            } finally {
+                                handlerFinished.countDown();
+                            }
+                        });
+>>>>>>> Stashed changes
         Thread shutdownThread =
                 new Thread(
                         () -> {
@@ -1081,6 +1114,12 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                         });
 
         try {
+<<<<<<< Updated upstream
+=======
+            handlerThread.start();
+            assertTrue(handlerStarted.await(5, TimeUnit.SECONDS));
+
+>>>>>>> Stashed changes
             shutdownThread.start();
 
             assertTrue(shutdownStarted.await(5, TimeUnit.SECONDS));
@@ -1088,10 +1127,21 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                     shutdownFinished.await(250, TimeUnit.MILLISECONDS),
                     "Shutdown should wait for an active discovery event handler");
         } finally {
+<<<<<<< Updated upstream
             discovery.exitDiscoveryEventHandler();
         }
 
         assertTrue(shutdownFinished.await(5, TimeUnit.SECONDS));
+=======
+            releaseHandler.countDown();
+        }
+
+        assertTrue(handlerFinished.await(5, TimeUnit.SECONDS));
+        assertTrue(shutdownFinished.await(5, TimeUnit.SECONDS));
+        if (handlerFailure.get() != null) {
+            fail(handlerFailure.get());
+        }
+>>>>>>> Stashed changes
         if (shutdownFailure.get() != null) {
             fail(shutdownFailure.get());
         }

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.quarkus.arc.ClientProxy;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -61,6 +62,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
 
 @QuarkusTest
 @TestProfile(KubeEndpointSlicesDiscoveryTest.TestProfile.class)
@@ -1094,5 +1096,23 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
             fail(shutdownFailure.get());
         }
         discovery.setShuttingDown(false);
+    }
+
+    @Test
+    void testDeleteResyncJobSkippedWhenSchedulerShutdown() throws Exception {
+        KubeEndpointSlicesDiscovery unwrappedDiscovery = ClientProxy.unwrap(discovery);
+        Scheduler originalScheduler = unwrappedDiscovery.scheduler;
+        Scheduler scheduler = mock(Scheduler.class);
+        unwrappedDiscovery.scheduler = scheduler;
+        when(scheduler.isShutdown()).thenReturn(true);
+
+        try {
+            unwrappedDiscovery.deleteResyncJobIfSchedulerRunning();
+
+            verify(scheduler).isShutdown();
+            verify(scheduler, never()).deleteJob(any());
+        } finally {
+            unwrappedDiscovery.scheduler = originalScheduler;
+        }
     }
 }

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.cryostat.AbstractTransactionalTestBase;
 import io.cryostat.targets.Target;
@@ -966,5 +969,130 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                                 Parameters.with("nodeType", "Pod").and("name", "non-jmx-pod"))
                         .count();
         assertEquals(0, podNodeCount, "No Pod node should exist for non-JMX pod");
+    }
+
+    @Test
+    void testEndpointSliceInformerEventsIgnoredDuringShutdown() {
+        clearInvocations(bus);
+        discovery.setShuttingDown(true);
+
+        try {
+            EndpointSlice slice = mock(EndpointSlice.class);
+
+            discovery.onAdd(slice);
+            discovery.onUpdate(slice, slice);
+            discovery.onDelete(slice, false);
+
+            verifyNoInteractions(bus);
+            verifyNoInteractions(slice);
+        } finally {
+            discovery.setShuttingDown(false);
+        }
+    }
+
+    @Test
+    @Transactional
+    void testHandleQueryEventIgnoredDuringShutdown() {
+        clearInvocations(bus);
+        discovery.setShuttingDown(true);
+
+        try {
+            long nodeCountBefore = DiscoveryNode.count();
+            long targetCountBefore = Target.count();
+
+            discovery.handleQueryEvent(
+                    KubeEndpointSlicesDiscovery.NamespaceQueryEvent.from("test-namespace"));
+
+            entityManager.flush();
+            entityManager.clear();
+
+            assertEquals(
+                    nodeCountBefore,
+                    DiscoveryNode.count(),
+                    "Should not create DiscoveryNodes while shutting down");
+            assertEquals(
+                    targetCountBefore,
+                    Target.count(),
+                    "Should not create Targets while shutting down");
+            verifyNoInteractions(bus);
+        } finally {
+            discovery.setShuttingDown(false);
+        }
+    }
+
+    @Test
+    @Transactional
+    void testHandleEndpointEventIgnoredDuringShutdown() {
+        discovery.setShuttingDown(true);
+
+        try {
+            long nodeCountBefore = DiscoveryNode.count();
+            long targetCountBefore = Target.count();
+
+            Target target = new Target();
+            target.connectUrl =
+                    URI.create("service:jmx:rmi:///jndi/rmi://192.168.1.100:9091/jmxrmi");
+            target.alias = "ignored-target";
+            target.labels = new HashMap<>();
+            target.annotations = new Target.Annotations();
+
+            KubeEndpointSlicesDiscovery.EndpointDiscoveryEvent event =
+                    KubeEndpointSlicesDiscovery.EndpointDiscoveryEvent.from(
+                            "test-namespace", target, null, Target.EventKind.LOST);
+
+            discovery.handleEndpointEvent(event);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            assertEquals(
+                    nodeCountBefore,
+                    DiscoveryNode.count(),
+                    "Should not create DiscoveryNodes while shutting down");
+            assertEquals(
+                    targetCountBefore,
+                    Target.count(),
+                    "Should not create Targets while shutting down");
+        } finally {
+            discovery.setShuttingDown(false);
+        }
+    }
+
+    @Test
+    void testShutdownWaitsForActiveDiscoveryEventHandler() throws Exception {
+        assertTrue(discovery.enterDiscoveryEventHandler());
+
+        CountDownLatch shutdownStarted = new CountDownLatch(1);
+        CountDownLatch shutdownFinished = new CountDownLatch(1);
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        Thread shutdownThread =
+                new Thread(
+                        () -> {
+                            try {
+                                shutdownStarted.countDown();
+                                discovery.onStop(null);
+                            } catch (Throwable t) {
+                                shutdownFailure.set(t);
+                            } finally {
+                                shutdownFinished.countDown();
+                            }
+                        });
+
+        try {
+            shutdownThread.start();
+
+            assertTrue(shutdownStarted.await(5, TimeUnit.SECONDS));
+            assertFalse(
+                    shutdownFinished.await(250, TimeUnit.MILLISECONDS),
+                    "Shutdown should wait for an active discovery event handler");
+        } finally {
+            discovery.exitDiscoveryEventHandler();
+        }
+
+        assertTrue(shutdownFinished.await(5, TimeUnit.SECONDS));
+        if (shutdownFailure.get() != null) {
+            fail(shutdownFailure.get());
+        }
+        discovery.setShuttingDown(false);
     }
 }

--- a/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
+++ b/src/test/java/io/cryostat/discovery/KubeEndpointSlicesDiscoveryTest.java
@@ -1062,13 +1062,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
 
     @Test
     void testShutdownWaitsForActiveDiscoveryEventHandler() throws Exception {
-<<<<<<< Updated upstream
-        assertTrue(discovery.enterDiscoveryEventHandler());
-
-        CountDownLatch shutdownStarted = new CountDownLatch(1);
-        CountDownLatch shutdownFinished = new CountDownLatch(1);
-        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
-=======
         CountDownLatch handlerStarted = new CountDownLatch(1);
         CountDownLatch releaseHandler = new CountDownLatch(1);
         CountDownLatch handlerFinished = new CountDownLatch(1);
@@ -1099,7 +1092,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                                 handlerFinished.countDown();
                             }
                         });
->>>>>>> Stashed changes
         Thread shutdownThread =
                 new Thread(
                         () -> {
@@ -1114,12 +1106,9 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                         });
 
         try {
-<<<<<<< Updated upstream
-=======
             handlerThread.start();
             assertTrue(handlerStarted.await(5, TimeUnit.SECONDS));
 
->>>>>>> Stashed changes
             shutdownThread.start();
 
             assertTrue(shutdownStarted.await(5, TimeUnit.SECONDS));
@@ -1127,12 +1116,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
                     shutdownFinished.await(250, TimeUnit.MILLISECONDS),
                     "Shutdown should wait for an active discovery event handler");
         } finally {
-<<<<<<< Updated upstream
-            discovery.exitDiscoveryEventHandler();
-        }
-
-        assertTrue(shutdownFinished.await(5, TimeUnit.SECONDS));
-=======
             releaseHandler.countDown();
         }
 
@@ -1141,7 +1124,6 @@ class KubeEndpointSlicesDiscoveryTest extends AbstractTransactionalTestBase {
         if (handlerFailure.get() != null) {
             fail(handlerFailure.get());
         }
->>>>>>> Stashed changes
         if (shutdownFailure.get() != null) {
             fail(shutdownFailure.get());
         }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #452

## Description of the change:
* Adds shutdown coordination to Kubernetes EndpointSlice discovery so informer callbacks and queued discovery events stop processing once shutdown begins.
* Ensures shutdown waits for any active discovery event handler to finish before Hibernate/database resources are closed.
* Adds regression coverage for late and in-flight shutdown events.

## Motivation for the change:
* Prevents Kubernetes discovery from persisting or pruning targets during Cryostat shutdown, which can race with Hibernate closing and produce `Session/EntityManager is closed` warnings.

## How to manually test:
1. Start standalone Cryostat with Kubernetes discovery enabled, terminate it while EndpointSlice events are present, and verify shutdown logs do not contain `Endpoint handler exception` or `Session/EntityManager is closed`.
