### PR TITLE
ci(schema): split WebSocket notification schema from OpenAPI+GraphQL schema jobs

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -342,11 +342,12 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
+    - name: Run Quarkus and fetch API schemas
+      continue-on-error: true
+      run: bash /home/runner/work/cryostat/cryostat/schema/update.bash 90 15
     - id: schema-update
-      name: Update API schemas
+      name: Diff API schemas
       run: |
-        bash /home/runner/work/cryostat/cryostat/schema/update.bash 90 15 || true
-
         test -f /home/runner/work/cryostat/cryostat/schema/openapi.yaml
         test -f /home/runner/work/cryostat/cryostat/schema/schema.graphql
 

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -350,11 +350,10 @@ jobs:
         test -f /home/runner/work/cryostat/cryostat/schema/openapi.yaml
         test -f /home/runner/work/cryostat/cryostat/schema/schema.graphql
 
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff
-        echo "openapi_status=$?" >> "$GITHUB_OUTPUT"
-
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff
-        echo "graphql_status=$?" >> "$GITHUB_OUTPUT"
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff; OPENAPI_STATUS=$?
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff; GRAPHQL_STATUS=$?
+        echo "openapi_status=${OPENAPI_STATUS}" >> "$GITHUB_OUTPUT"
+        echo "graphql_status=${GRAPHQL_STATUS}" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
@@ -402,8 +401,8 @@ jobs:
 
         test -f /home/runner/work/cryostat/cryostat/schema/notifications.yaml
 
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/notifications.yaml > /home/runner/work/notifications.diff
-        echo "notifications_status=$?" >> "$GITHUB_OUTPUT"
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/notifications.yaml > /home/runner/work/notifications.diff; NOTIFICATIONS_STATUS=$?
+        echo "notifications_status=${NOTIFICATIONS_STATUS}" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -8,11 +8,6 @@ on:
   issue_comment:
     types:
       - created
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 env:
   TESTCONTAINERS_RYUK_DISABLED: true
@@ -75,17 +70,6 @@ jobs:
             pull_number: context.issue.number
           })
           return { repo: result.data.head.repo.full_name, num: result.data.number, sha: result.data.head.sha, ref: result.data.head.ref }
-
-  checkout-branch-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    outputs:
-      PR_head_ref: ${{ github.event.pull_request.head.ref }}
-      PR_head_sha: ${{ github.event.pull_request.head.sha }}
-      PR_num: ${{ github.event.pull_request.number }}
-      PR_repo: ${{ github.event.pull_request.head.repo.full_name }}
-    steps:
-    - run: 'true'
 
   start-comment:
     runs-on: ubuntu-latest
@@ -322,8 +306,7 @@ jobs:
         status: ${{ steps.run-tests.outcome }}
 
   update-api-schemas:
-    needs: [checkout-branch, checkout-branch-pr]
-    if: ${{ always() && (needs.checkout-branch.result == 'success' || needs.checkout-branch-pr.result == 'success') }}
+    needs: [checkout-branch]
     runs-on: ubuntu-latest
     env:
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -335,8 +318,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        repository: ${{ needs.checkout-branch-pr.outputs.PR_repo || needs.checkout-branch.outputs.PR_repo }}
-        ref: ${{ needs.checkout-branch-pr.outputs.PR_head_ref || needs.checkout-branch.outputs.PR_head_ref }}
+        repository: ${{ needs.checkout-branch.outputs.PR_repo }}
+        ref: ${{ needs.checkout-branch.outputs.PR_head_ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
@@ -348,14 +331,14 @@ jobs:
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: openapi-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - name: Set pending commit status for GraphQL schema
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: graphql-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
@@ -385,8 +368,7 @@ jobs:
         path: /home/runner/work/graphql.diff
 
   update-notifications-schema:
-    needs: [checkout-branch, checkout-branch-pr]
-    if: ${{ always() && (needs.checkout-branch.result == 'success' || needs.checkout-branch-pr.result == 'success') }}
+    needs: [checkout-branch]
     runs-on: ubuntu-latest
     env:
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -397,8 +379,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        repository: ${{ needs.checkout-branch-pr.outputs.PR_repo || needs.checkout-branch.outputs.PR_repo }}
-        ref: ${{ needs.checkout-branch-pr.outputs.PR_head_ref || needs.checkout-branch.outputs.PR_head_ref }}
+        repository: ${{ needs.checkout-branch.outputs.PR_repo }}
+        ref: ${{ needs.checkout-branch.outputs.PR_head_ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
@@ -410,7 +392,7 @@ jobs:
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: notifications-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
@@ -431,8 +413,7 @@ jobs:
         path: /home/runner/work/notifications.diff
 
   compare-schemas:
-    needs: [update-api-schemas, update-notifications-schema, checkout-branch, checkout-branch-pr]
-    if: ${{ always() && (needs.update-api-schemas.result == 'success' || needs.update-api-schemas.result == 'failure') }}
+    needs: [update-api-schemas, update-notifications-schema, checkout-branch]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -459,7 +440,6 @@ jobs:
           const openapiStatus = '${{ needs.update-api-schemas.outputs.OPENAPI_STATUS }}';
           const graphqlStatus = '${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS }}';
           const notificationsStatus = '${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS }}';
-          const prNum = ${{ needs.checkout-branch-pr.outputs.PR_num || needs.checkout-branch.outputs.PR_num }};
           const lines = [];
           lines.push(openapiStatus === '0'
             ? 'No OpenAPI schema changes detected.'
@@ -471,7 +451,7 @@ jobs:
             ? 'No WebSocket notifications schema changes detected.'
             : 'WebSocket notifications schema change detected:\n\n' + diffFmt(fs.readFileSync('diffs/notifications.diff')));
           github.rest.issues.createComment({
-            issue_number: prNum,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: lines.join('\n\n')
@@ -481,7 +461,7 @@ jobs:
       if: always()
       with:
         context: openapi-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
@@ -490,7 +470,7 @@ jobs:
       if: always()
       with:
         context: graphql-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
@@ -499,7 +479,7 @@ jobs:
       if: always()
       with:
         context: notifications-schema-check
-        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'No schema changes' || 'Schema update required' }}

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -305,7 +305,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ steps.run-tests.outcome }}
 
-  update-schemas:
+  update-api-schemas:
     needs: [checkout-branch]
     runs-on: ubuntu-latest
     env:
@@ -313,12 +313,8 @@ jobs:
     permissions:
       statuses: write
     outputs:
-      OPENAPI_STATUS: ${{ fromJSON(steps.schema-update.outputs.outputs).openapi_status }}
-      OPENAPI_DIFF_FILE: ${{ fromJSON(steps.schema-update.outputs.outputs).openapi_diff_file }}
-      GRAPHQL_STATUS: ${{ fromJSON(steps.schema-update.outputs.outputs).graphql_status }}
-      GRAPHQL_DIFF_FILE: ${{ fromJSON(steps.schema-update.outputs.outputs).graphql_diff_file }}
-      NOTIFICATIONS_STATUS: ${{ fromJSON(steps.schema-update.outputs.outputs).notifications_status }}
-      NOTIFICATIONS_DIFF_FILE: ${{ fromJSON(steps.schema-update.outputs.outputs).notifications_diff_file }}
+      OPENAPI_STATUS: ${{ steps.schema-update.outputs.openapi_status }}
+      GRAPHQL_STATUS: ${{ steps.schema-update.outputs.graphql_status }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -345,6 +341,52 @@ jobs:
         sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
+    - run: git submodule init && git submodule update
+    - id: schema-update
+      name: Update API schemas
+      run: |
+        bash /home/runner/work/cryostat/cryostat/schema/update.bash 90 15 || true
+
+        test -f /home/runner/work/cryostat/cryostat/schema/openapi.yaml
+        test -f /home/runner/work/cryostat/cryostat/schema/schema.graphql
+
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff
+        echo "openapi_status=$?" >> "$GITHUB_OUTPUT"
+
+        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff
+        echo "graphql_status=$?" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: openapi-diff
+        path: /home/runner/work/openapi.diff
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: graphql-diff
+        path: /home/runner/work/graphql.diff
+
+  update-notifications-schema:
+    needs: [checkout-branch]
+    runs-on: ubuntu-latest
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
+    permissions:
+      statuses: write
+    outputs:
+      NOTIFICATIONS_STATUS: ${{ steps.notifications-update.outputs.notifications_status }}
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: ${{ needs.checkout-branch.outputs.PR_repo }}
+        ref: ${{ needs.checkout-branch.outputs.PR_head_ref }}
+        submodules: true
+        fetch-depth: 0
+    - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Set pending commit status for Notifications schema
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
@@ -353,45 +395,23 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
-    - id: schema-update
-      name: Update schemas
+    - id: notifications-update
+      name: Update notifications schema
       run: |
-        bash /home/runner/work/cryostat/cryostat/schema/update.bash 90 15 || true
+        bash /home/runner/work/cryostat/cryostat/schema/generate-notifications.bash
 
-        test -f /home/runner/work/cryostat/cryostat/schema/openapi.yaml
-        test -f /home/runner/work/cryostat/cryostat/schema/schema.graphql
         test -f /home/runner/work/cryostat/cryostat/schema/notifications.yaml
 
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff
-        OPENAPI_STATUS=$?
-
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff
-        GRAPHQL_STATUS=$?
-
         git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/notifications.yaml > /home/runner/work/notifications.diff
-        NOTIFICATIONS_STATUS=$?
-
-        echo "openapi_status=${OPENAPI_STATUS}" >> "$GITHUB_OUTPUT"
-        echo "openapi_diff_file=openapi.diff" >> "$GITHUB_OUTPUT"
-        echo "graphql_status=${GRAPHQL_STATUS}" >> "$GITHUB_OUTPUT"
-        echo "graphql_diff_file=graphql.diff" >> "$GITHUB_OUTPUT"
-        echo "notifications_status=${NOTIFICATIONS_STATUS}" >> "$GITHUB_OUTPUT"
-        echo "notifications_diff_file=notifications.diff" >> "$GITHUB_OUTPUT"
+        echo "notifications_status=$?" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: openapi-diff
-        path: /home/runner/work/openapi.diff
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: graphql-diff
-        path: /home/runner/work/graphql.diff
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
       with:
         name: notifications-diff
         path: /home/runner/work/notifications.diff
 
-  compare-openapi-schema:
-    needs: [update-schemas, checkout-branch]
+  compare-schemas:
+    needs: [update-api-schemas, update-notifications-schema, checkout-branch]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -400,100 +420,64 @@ jobs:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: openapi-diff
-    - name: Comment schema check result
+        path: diffs
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: graphql-diff
+        path: diffs
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: notifications-diff
+        path: diffs
+    - name: Comment schema check results
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
-          const diffFmt = s => {
-            return "```diff\n" + s + "\n```";
-          };
-          const commentBody = '${{ needs.update-schemas.outputs.OPENAPI_STATUS }}' == '0'
-            ? `No OpenAPI schema changes detected.`
-            : `OpenAPI schema change detected:\n\n${diffFmt(require('fs').readFileSync('${{ needs.update-schemas.outputs.OPENAPI_DIFF_FILE }}'))}`;
+          const fs = require('fs');
+          const diffFmt = s => "```diff\n" + s + "\n```";
+          const openapiStatus = '${{ needs.update-api-schemas.outputs.OPENAPI_STATUS }}';
+          const graphqlStatus = '${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS }}';
+          const notificationsStatus = '${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS }}';
+          const lines = [];
+          lines.push(openapiStatus === '0'
+            ? 'No OpenAPI schema changes detected.'
+            : 'OpenAPI schema change detected:\n\n' + diffFmt(fs.readFileSync('diffs/openapi.diff')));
+          lines.push(graphqlStatus === '0'
+            ? 'No GraphQL schema changes detected.'
+            : 'GraphQL schema change detected:\n\n' + diffFmt(fs.readFileSync('diffs/graphql.diff')));
+          lines.push(notificationsStatus === '0'
+            ? 'No WebSocket notifications schema changes detected.'
+            : 'WebSocket notifications schema change detected:\n\n' + diffFmt(fs.readFileSync('diffs/notifications.diff')));
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: commentBody
+            body: lines.join('\n\n')
           });
-    - name: Set commit status
+    - name: Set OpenAPI schema commit status
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       if: always()
       with:
         context: openapi-schema-check
         sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ needs.update-schemas.outputs.OPENAPI_STATUS == '0' && 'success' || 'failure' }}
-        description: ${{ needs.update-schemas.outputs.OPENAPI_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
-
-  compare-graphql-schema:
-    needs: [update-schemas, checkout-branch]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      statuses: write
-    steps:
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: graphql-diff
-    - name: Comment schema check result
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-      with:
-        script: |
-          const diffFmt = s => {
-            return "```diff\n" + s + "\n```";
-          };
-          const commentBody = '${{ needs.update-schemas.outputs.GRAPHQL_STATUS }}' == '0'
-            ? `No GraphQL schema changes detected.`
-            : `GraphQL schema change detected:\n\n${diffFmt(require('fs').readFileSync('${{ needs.update-schemas.outputs.GRAPHQL_DIFF_FILE }}'))}`;
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: commentBody
-          });
-    - name: Set commit status
+        status: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'success' || 'failure' }}
+        description: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
+    - name: Set GraphQL schema commit status
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       if: always()
       with:
         context: graphql-schema-check
         sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ needs.update-schemas.outputs.GRAPHQL_STATUS == '0' && 'success' || 'failure' }}
-        description: ${{ needs.update-schemas.outputs.GRAPHQL_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
-
-  compare-notifications-schema:
-    needs: [update-schemas, checkout-branch]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      statuses: write
-    steps:
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: notifications-diff
-    - name: Comment schema check result
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-      with:
-        script: |
-          const diffFmt = s => {
-            return "```diff\n" + s + "\n```";
-          };
-          const commentBody = '${{ needs.update-schemas.outputs.NOTIFICATIONS_STATUS }}' == '0'
-            ? `No WebSocket notifications schema changes detected.`
-            : `WebSocket notifications schema change detected:\n\n${diffFmt(require('fs').readFileSync('${{ needs.update-schemas.outputs.NOTIFICATIONS_DIFF_FILE }}'))}`;
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: commentBody
-          });
-    - name: Set commit status
+        status: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'success' || 'failure' }}
+        description: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
+    - name: Set Notifications schema commit status
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       if: always()
       with:
         context: notifications-schema-check
         sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ needs.update-schemas.outputs.NOTIFICATIONS_STATUS == '0' && 'success' || 'failure' }}
-        description: ${{ needs.update-schemas.outputs.NOTIFICATIONS_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
+        status: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'success' || 'failure' }}
+        description: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'No schema changes' || 'Schema update required' }}

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -8,6 +8,11 @@ on:
   issue_comment:
     types:
       - created
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   TESTCONTAINERS_RYUK_DISABLED: true
@@ -70,6 +75,17 @@ jobs:
             pull_number: context.issue.number
           })
           return { repo: result.data.head.repo.full_name, num: result.data.number, sha: result.data.head.sha, ref: result.data.head.ref }
+
+  checkout-branch-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      PR_head_ref: ${{ github.event.pull_request.head.ref }}
+      PR_head_sha: ${{ github.event.pull_request.head.sha }}
+      PR_num: ${{ github.event.pull_request.number }}
+      PR_repo: ${{ github.event.pull_request.head.repo.full_name }}
+    steps:
+    - run: 'true'
 
   start-comment:
     runs-on: ubuntu-latest
@@ -306,7 +322,8 @@ jobs:
         status: ${{ steps.run-tests.outcome }}
 
   update-api-schemas:
-    needs: [checkout-branch]
+    needs: [checkout-branch, checkout-branch-pr]
+    if: ${{ always() && (needs.checkout-branch.result == 'success' || needs.checkout-branch-pr.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -318,8 +335,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        repository: ${{ needs.checkout-branch.outputs.PR_repo }}
-        ref: ${{ needs.checkout-branch.outputs.PR_head_ref }}
+        repository: ${{ needs.checkout-branch-pr.outputs.PR_repo || needs.checkout-branch.outputs.PR_repo }}
+        ref: ${{ needs.checkout-branch-pr.outputs.PR_head_ref || needs.checkout-branch.outputs.PR_head_ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
@@ -331,14 +348,14 @@ jobs:
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: openapi-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - name: Set pending commit status for GraphQL schema
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: graphql-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
@@ -366,7 +383,8 @@ jobs:
         path: /home/runner/work/graphql.diff
 
   update-notifications-schema:
-    needs: [checkout-branch]
+    needs: [checkout-branch, checkout-branch-pr]
+    if: ${{ always() && (needs.checkout-branch.result == 'success' || needs.checkout-branch-pr.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -377,8 +395,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        repository: ${{ needs.checkout-branch.outputs.PR_repo }}
-        ref: ${{ needs.checkout-branch.outputs.PR_head_ref }}
+        repository: ${{ needs.checkout-branch-pr.outputs.PR_repo || needs.checkout-branch.outputs.PR_repo }}
+        ref: ${{ needs.checkout-branch-pr.outputs.PR_head_ref || needs.checkout-branch.outputs.PR_head_ref }}
         submodules: true
         fetch-depth: 0
     - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
@@ -390,7 +408,7 @@ jobs:
       uses: daltonbr/set-commit-status-action@2a09190f6d04d912bca5ede8094b5d5dce303ebb # v3.0.1
       with:
         context: notifications-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
     - run: git submodule init && git submodule update
@@ -410,7 +428,8 @@ jobs:
         path: /home/runner/work/notifications.diff
 
   compare-schemas:
-    needs: [update-api-schemas, update-notifications-schema, checkout-branch]
+    needs: [update-api-schemas, update-notifications-schema, checkout-branch, checkout-branch-pr]
+    if: ${{ always() && (needs.update-api-schemas.result == 'success' || needs.update-api-schemas.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -437,6 +456,7 @@ jobs:
           const openapiStatus = '${{ needs.update-api-schemas.outputs.OPENAPI_STATUS }}';
           const graphqlStatus = '${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS }}';
           const notificationsStatus = '${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS }}';
+          const prNum = ${{ needs.checkout-branch-pr.outputs.PR_num || needs.checkout-branch.outputs.PR_num }};
           const lines = [];
           lines.push(openapiStatus === '0'
             ? 'No OpenAPI schema changes detected.'
@@ -448,7 +468,7 @@ jobs:
             ? 'No WebSocket notifications schema changes detected.'
             : 'WebSocket notifications schema change detected:\n\n' + diffFmt(fs.readFileSync('diffs/notifications.diff')));
           github.rest.issues.createComment({
-            issue_number: context.issue.number,
+            issue_number: prNum,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: lines.join('\n\n')
@@ -458,7 +478,7 @@ jobs:
       if: always()
       with:
         context: openapi-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-api-schemas.outputs.OPENAPI_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
@@ -467,7 +487,7 @@ jobs:
       if: always()
       with:
         context: graphql-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-api-schemas.outputs.GRAPHQL_STATUS == '0' && 'No schema changes' || 'Schema update required' }}
@@ -476,7 +496,7 @@ jobs:
       if: always()
       with:
         context: notifications-schema-check
-        sha: ${{ needs.checkout-branch.outputs.PR_head_sha }}
+        sha: ${{ needs.checkout-branch-pr.outputs.PR_head_sha || needs.checkout-branch.outputs.PR_head_sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'success' || 'failure' }}
         description: ${{ needs.update-notifications-schema.outputs.NOTIFICATIONS_STATUS == '0' && 'No schema changes' || 'Schema update required' }}

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -367,8 +367,10 @@ jobs:
         test -f /home/runner/work/cryostat/cryostat/schema/openapi.yaml
         test -f /home/runner/work/cryostat/cryostat/schema/schema.graphql
 
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff; OPENAPI_STATUS=$?
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff; GRAPHQL_STATUS=$?
+        git diff -U10 /home/runner/work/cryostat/cryostat/schema/openapi.yaml > /home/runner/work/openapi.diff
+        OPENAPI_STATUS=$([ -s /home/runner/work/openapi.diff ] && echo 1 || echo 0)
+        git diff -U10 /home/runner/work/cryostat/cryostat/schema/schema.graphql > /home/runner/work/graphql.diff
+        GRAPHQL_STATUS=$([ -s /home/runner/work/graphql.diff ] && echo 1 || echo 0)
         echo "openapi_status=${OPENAPI_STATUS}" >> "$GITHUB_OUTPUT"
         echo "graphql_status=${GRAPHQL_STATUS}" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -419,7 +421,8 @@ jobs:
 
         test -f /home/runner/work/cryostat/cryostat/schema/notifications.yaml
 
-        git diff -U10 --exit-code /home/runner/work/cryostat/cryostat/schema/notifications.yaml > /home/runner/work/notifications.diff; NOTIFICATIONS_STATUS=$?
+        git diff -U10 /home/runner/work/cryostat/cryostat/schema/notifications.yaml > /home/runner/work/notifications.diff
+        NOTIFICATIONS_STATUS=$([ -s /home/runner/work/notifications.diff ] && echo 1 || echo 0)
         echo "notifications_status=${NOTIFICATIONS_STATUS}" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,6 +9,7 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
+set +m
 setsid "${DIR}"/../mvnw -B \
     -Dquarkus.quinoa=false \
     -Dquarkus.log.level=warn \

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -10,7 +10,7 @@ if ! command -v http && ! command -v wget; then
 fi
 
 (
-    trap 'exit 0' TERM INT
+    trap 'kill $mvn_pid 2>/dev/null; exit 0' TERM INT
     "${DIR}"/../mvnw -B \
         -Dquarkus.quinoa=false \
         -Dquarkus.log.level=warn \
@@ -19,7 +19,9 @@ fi
         -Dmaven.test.skip \
         -Dspotless.check.skip \
         -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
-        clean quarkus:generate-code compile test-compile quarkus:dev
+        clean quarkus:generate-code compile test-compile quarkus:dev &
+    mvn_pid=$!
+    wait $mvn_pid
 ) &
 
 pid="$!"

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,7 +9,7 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-setsid "${DIR}"/../mvnw -B \
+"${DIR}"/../mvnw -B \
     -Dquarkus.quinoa=false \
     -Dquarkus.log.level=warn \
     -Dquarkus.http.access-log.enabled=false \
@@ -20,13 +20,15 @@ setsid "${DIR}"/../mvnw -B \
     clean quarkus:generate-code compile test-compile quarkus:dev &
 
 pid="$!"
+disown $pid
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill -- -$pid || true
-        wait $pid || true
+        kill $pid || true
+        sleep 5
+        kill -9 $pid || true
         exit 1
     fi
     if command -v http; then
@@ -52,6 +54,7 @@ elif command -v wget; then
     wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
-kill -- -$pid || true
-wait $pid || true
+kill $pid || true
+sleep 5
+kill -9 $pid || true
 exit 0

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -22,9 +22,11 @@ fi
 pid="$!"
 function cleanup() {
     kill $pid || true
+    exit 0
 }
 trap cleanup EXIT
 set +e
+set -o pipefail
 sleep "${1:-30}"
 counter=0
 while true; do

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,29 +9,35 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-(
-    trap 'kill $mvn_pid 2>/dev/null; wait $mvn_pid 2>/dev/null; exit 0' TERM INT
-    "${DIR}"/../mvnw -B \
-        -Dquarkus.quinoa=false \
-        -Dquarkus.log.level=warn \
-        -Dquarkus.http.access-log.enabled=false \
-        -Dquarkus.hibernate-orm.log.sql=false \
-        -Dmaven.test.skip \
-        -Dspotless.check.skip \
-        -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
-        clean quarkus:generate-code compile test-compile quarkus:dev &
-    mvn_pid=$!
-    wait $mvn_pid
-) &
+setsid "${DIR}"/../mvnw -B \
+    -Dquarkus.quinoa=false \
+    -Dquarkus.log.level=warn \
+    -Dquarkus.http.access-log.enabled=false \
+    -Dquarkus.hibernate-orm.log.sql=false \
+    -Dmaven.test.skip \
+    -Dspotless.check.skip \
+    -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
+    clean quarkus:generate-code compile test-compile quarkus:dev &
 
 pid="$!"
+
+kill_mvn() {
+    local pgid
+    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ -n "$pgid" ] && [ "$pgid" != "0" ]; then
+        kill -- "-$pgid" 2>/dev/null || true
+        sleep 5
+        kill -9 -- "-$pgid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill $pid
-        wait $pid
+        kill_mvn
         exit 1
     fi
     if command -v http; then
@@ -58,6 +64,5 @@ elif command -v wget; then
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
 yq -P 'sort_keys(..)' "${DIR}/openapi.yaml.tmp" > "${DIR}/openapi.yaml" || mv "${DIR}/openapi.yaml.tmp" "${DIR}/openapi.yaml"
-kill $pid
-wait $pid
+kill_mvn
 exit 0

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,52 +9,23 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-PIDFILE="$(mktemp)"
-bash -c "
-    setsid \"${DIR}\"/../mvnw -B \
-        -Dquarkus.quinoa=false \
-        -Dquarkus.log.level=warn \
-        -Dquarkus.http.access-log.enabled=false \
-        -Dquarkus.hibernate-orm.log.sql=false \
-        -Dmaven.test.skip \
-        -Dspotless.check.skip \
-        \"-Dquarkus.smallrye-openapi.info-title=Cryostat API\" \
-        clean quarkus:generate-code compile test-compile quarkus:dev &
-    echo \$! > \"${PIDFILE}\"
-    wait
-" &
-wrapper_pid=$!
-sleep 2
-pid=$(cat "${PIDFILE}" 2>/dev/null)
-rm -f "${PIDFILE}"
+"${DIR}"/../mvnw -B \
+    -Dquarkus.quinoa=false \
+    -Dquarkus.log.level=warn \
+    -Dquarkus.http.access-log.enabled=false \
+    -Dquarkus.hibernate-orm.log.sql=false \
+    -Dmaven.test.skip \
+    -Dspotless.check.skip \
+    -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
+    clean quarkus:generate-code compile test-compile quarkus:dev &
 
-kill_mvn() {
-    if [ -n "$pid" ]; then
-        local pgid
-        pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
-        if [ -n "$pgid" ] && [ "$pgid" != "0" ]; then
-            kill -- "-$pgid" 2>/dev/null || true
-            sleep 5
-            kill -9 -- "-$pgid" 2>/dev/null || true
-            local i=0
-            while kill -0 -- "-$pgid" 2>/dev/null; do
-                sleep 1
-                i=$((i + 1))
-                if [ "$i" -gt 10 ]; then
-                    break
-                fi
-            done
-        fi
-    fi
-    wait "$wrapper_pid" 2>/dev/null || true
-}
-
+pid="$!"
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill_mvn
+        kill "$pid"
         exit 1
     fi
     if command -v http; then
@@ -81,5 +52,4 @@ elif command -v wget; then
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
 yq -P 'sort_keys(..)' "${DIR}/openapi.yaml.tmp" > "${DIR}/openapi.yaml" || mv "${DIR}/openapi.yaml.tmp" "${DIR}/openapi.yaml"
-kill_mvn
-exit 0
+kill "$pid"

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,26 +9,27 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-"${DIR}"/../mvnw -B \
-    -Dquarkus.quinoa=false \
-    -Dquarkus.log.level=warn \
-    -Dquarkus.http.access-log.enabled=false \
-    -Dquarkus.hibernate-orm.log.sql=false \
-    -Dmaven.test.skip \
-    -Dspotless.check.skip \
-    -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
-    clean quarkus:generate-code compile test-compile quarkus:dev &
+(
+    trap 'exit 0' TERM INT
+    "${DIR}"/../mvnw -B \
+        -Dquarkus.quinoa=false \
+        -Dquarkus.log.level=warn \
+        -Dquarkus.http.access-log.enabled=false \
+        -Dquarkus.hibernate-orm.log.sql=false \
+        -Dmaven.test.skip \
+        -Dspotless.check.skip \
+        -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
+        clean quarkus:generate-code compile test-compile quarkus:dev
+) &
 
 pid="$!"
-disown $pid
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill $pid || true
-        sleep 5
-        kill -9 $pid || true
+        kill $pid
+        wait $pid
         exit 1
     fi
     if command -v http; then
@@ -55,7 +56,6 @@ elif command -v wget; then
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
 yq -P 'sort_keys(..)' "${DIR}/openapi.yaml.tmp" > "${DIR}/openapi.yaml" || mv "${DIR}/openapi.yaml.tmp" "${DIR}/openapi.yaml"
-kill $pid || true
-sleep 5
-kill -9 $pid || true
+kill $pid
+wait $pid
 exit 0

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -28,6 +28,15 @@ kill_mvn() {
         kill -- "-$pgid" 2>/dev/null || true
         sleep 5
         kill -9 -- "-$pgid" 2>/dev/null || true
+        # Wait until every process in the group is gone
+        local i=0
+        while kill -0 -- "-$pgid" 2>/dev/null; do
+            sleep 1
+            i=$((i + 1))
+            if [ "$i" -gt 10 ]; then
+                break
+            fi
+        done
     fi
     wait "$pid" 2>/dev/null || true
 }

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -54,5 +54,3 @@ elif command -v wget; then
     wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
-
-"${DIR}"/generate-notifications.bash || true

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,7 +9,7 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-"${DIR}"/../mvnw -B \
+setsid "${DIR}"/../mvnw -B \
     -Dquarkus.quinoa=false \
     -Dquarkus.log.level=warn \
     -Dquarkus.http.access-log.enabled=false \
@@ -25,7 +25,8 @@ sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill $pid || true
+        kill -- -$pid || true
+        wait $pid || true
         exit 1
     fi
     if command -v http; then
@@ -51,5 +52,6 @@ elif command -v wget; then
     wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
-kill $pid || true
+kill -- -$pid || true
+wait $pid || true
 exit 0

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -20,12 +20,15 @@ fi
     clean quarkus:generate-code compile test-compile quarkus:dev &
 
 pid="$!"
+function cleanup() {
+    kill $pid || true
+}
+trap cleanup EXIT
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
-        kill "$pid"
         exit 1
     fi
     if command -v http; then
@@ -45,11 +48,11 @@ while true; do
     fi
 done
 if command -v http; then
-    http --pretty=format --body :8181/api > "${DIR}/openapi.yaml.tmp"
+    http --pretty=format --body :8181/api | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     http --pretty=format --body :8181/api/v4/graphql/schema.graphql > "${DIR}/schema.graphql"
 elif command -v wget; then
-    wget http://localhost:8181/api -O "${DIR}/openapi.yaml.tmp"
+    wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
-yq -P 'sort_keys(..)' "${DIR}/openapi.yaml.tmp" > "${DIR}/openapi.yaml" || mv "${DIR}/openapi.yaml.tmp" "${DIR}/openapi.yaml"
-kill "$pid"
+
+"${DIR}"/generate-notifications.bash || true

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -48,12 +48,13 @@ while true; do
     fi
 done
 if command -v http; then
-    http --pretty=format --body :8181/api | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
+    http --pretty=format --body :8181/api > "${DIR}/openapi.yaml.tmp"
     http --pretty=format --body :8181/api/v4/graphql/schema.graphql > "${DIR}/schema.graphql"
 elif command -v wget; then
-    wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
+    wget http://localhost:8181/api -O "${DIR}/openapi.yaml.tmp"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
+yq -P 'sort_keys(..)' "${DIR}/openapi.yaml.tmp" > "${DIR}/openapi.yaml" || mv "${DIR}/openapi.yaml.tmp" "${DIR}/openapi.yaml"
 kill $pid || true
 sleep 5
 kill -9 $pid || true

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -20,16 +20,12 @@ fi
     clean quarkus:generate-code compile test-compile quarkus:dev &
 
 pid="$!"
-function cleanup() {
-    kill $pid || true
-    exit 0
-}
-trap cleanup EXIT
 set +e
 sleep "${1:-30}"
 counter=0
 while true; do
     if [ "${counter}" -gt "${MAX_REPEATS:-60}" ]; then
+        kill $pid || true
         exit 1
     fi
     if command -v http; then
@@ -55,3 +51,5 @@ elif command -v wget; then
     wget http://localhost:8181/api -O - | yq -P 'sort_keys(..)' > "${DIR}/openapi.yaml"
     wget http://localhost:8181/api/v4/graphql/schema.graphql -O "${DIR}/schema.graphql"
 fi
+kill $pid || true
+exit 0

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -9,37 +9,44 @@ if ! command -v http && ! command -v wget; then
     exit 1
 fi
 
-set +m
-setsid "${DIR}"/../mvnw -B \
-    -Dquarkus.quinoa=false \
-    -Dquarkus.log.level=warn \
-    -Dquarkus.http.access-log.enabled=false \
-    -Dquarkus.hibernate-orm.log.sql=false \
-    -Dmaven.test.skip \
-    -Dspotless.check.skip \
-    -Dquarkus.smallrye-openapi.info-title="Cryostat API" \
-    clean quarkus:generate-code compile test-compile quarkus:dev &
-
-pid="$!"
+PIDFILE="$(mktemp)"
+bash -c "
+    setsid \"${DIR}\"/../mvnw -B \
+        -Dquarkus.quinoa=false \
+        -Dquarkus.log.level=warn \
+        -Dquarkus.http.access-log.enabled=false \
+        -Dquarkus.hibernate-orm.log.sql=false \
+        -Dmaven.test.skip \
+        -Dspotless.check.skip \
+        \"-Dquarkus.smallrye-openapi.info-title=Cryostat API\" \
+        clean quarkus:generate-code compile test-compile quarkus:dev &
+    echo \$! > \"${PIDFILE}\"
+    wait
+" &
+wrapper_pid=$!
+sleep 2
+pid=$(cat "${PIDFILE}" 2>/dev/null)
+rm -f "${PIDFILE}"
 
 kill_mvn() {
-    local pgid
-    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
-    if [ -n "$pgid" ] && [ "$pgid" != "0" ]; then
-        kill -- "-$pgid" 2>/dev/null || true
-        sleep 5
-        kill -9 -- "-$pgid" 2>/dev/null || true
-        # Wait until every process in the group is gone
-        local i=0
-        while kill -0 -- "-$pgid" 2>/dev/null; do
-            sleep 1
-            i=$((i + 1))
-            if [ "$i" -gt 10 ]; then
-                break
-            fi
-        done
+    if [ -n "$pid" ]; then
+        local pgid
+        pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+        if [ -n "$pgid" ] && [ "$pgid" != "0" ]; then
+            kill -- "-$pgid" 2>/dev/null || true
+            sleep 5
+            kill -9 -- "-$pgid" 2>/dev/null || true
+            local i=0
+            while kill -0 -- "-$pgid" 2>/dev/null; do
+                sleep 1
+                i=$((i + 1))
+                if [ "$i" -gt 10 ]; then
+                    break
+                fi
+            done
+        fi
     fi
-    wait "$pid" 2>/dev/null || true
+    wait "$wrapper_pid" 2>/dev/null || true
 }
 
 set +e

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -26,7 +26,6 @@ function cleanup() {
 }
 trap cleanup EXIT
 set +e
-set -o pipefail
 sleep "${1:-30}"
 counter=0
 while true; do

--- a/schema/update.bash
+++ b/schema/update.bash
@@ -10,7 +10,7 @@ if ! command -v http && ! command -v wget; then
 fi
 
 (
-    trap 'kill $mvn_pid 2>/dev/null; exit 0' TERM INT
+    trap 'kill $mvn_pid 2>/dev/null; wait $mvn_pid 2>/dev/null; exit 0' TERM INT
     "${DIR}"/../mvnw -B \
         -Dquarkus.quinoa=false \
         -Dquarkus.log.level=warn \


### PR DESCRIPTION
`# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1656

1. `update-schemas` is now two parallel jobs. The single `update-schemas` job is replaced by `update-api-schemas` (runs `update.bash` and diffs OpenAPI & GraphQL) and `update-notifications-schema` (runs `generate-notifications.bash` and diffs notifications)
2. `quarkus:dev` run is a separate step with `continue-on-error: true`, isolated from the diff step. This should fix the recurring issue where the CI step fails with an exit code 1. I believe the root cause is that the way the script kills the running `mvn quarkus:dev` process within `update.bash` causes the CI runner to fail the entire job, so running this separately and explicitly marking the job to continue on this step's failure works around that.
3. `git diff` no longer uses `--exit-code` and instead checks whether the diff file is non-empty. This is also intended to work around the Actions exit status handling
4. Job outputs no longer use fromJSON - `${{ fromJSON(steps.schema-update.outputs.outputs).X }}` pattern is replaced with direct `${{ steps.schema-update.outputs.X }}`
5. Diff artifact uploads use `if: always()` to ensure diffs are uploaded even when the preceding step reports an error, again to work around Actions exit status handling
6. Three `compare-*` jobs merged into one `compare-schemas job`: `compare-openapi-schema`, `compare-graphql-schema`, and `compare-notifications-schema` are consolidated into a single `compare-schemas` job that downloads all three diff artifacts and posts one combined PR comment covering all three schemas.