### PR TITLE
feat(archives): synthetic recording merge by timestamp range

### DIFF
--- a/schema/notifications.yaml
+++ b/schema/notifications.yaml
@@ -48,6 +48,8 @@ channels:
         - $ref: '#/components/messages/ProbeTemplateUploaded'
         - $ref: '#/components/messages/ProbesRemoved'
         - $ref: '#/components/messages/RecordingMetadataUpdated'
+        - $ref: '#/components/messages/RecordingSynthesisComplete'
+        - $ref: '#/components/messages/RecordingSynthesisFailure'
         - $ref: '#/components/messages/ReportFailure'
         - $ref: '#/components/messages/ReportSuccess'
         - $ref: '#/components/messages/RuleCreated'
@@ -838,6 +840,81 @@ components:
                         type: object
                         additionalProperties: true
               jvmId:
+                type: string
+        required:
+        - meta
+        - message
+    RecordingSynthesisComplete:
+      name: RecordingSynthesisComplete
+      title: Recording Synthesis Complete
+      summary: 'Notification: RecordingSynthesisComplete'
+      description: WebSocket notification for Recording Synthesis Complete events
+      payload:
+        type: object
+        description: WebSocket notification message wrapper
+        properties:
+          meta:
+            type: object
+            description: Notification metadata
+            properties:
+              category:
+                type: string
+                const: RecordingSynthesisComplete
+                description: Notification category identifier
+            required:
+            - category
+          message:
+            type: object
+            properties:
+              jobId:
+                type: string
+              recording:
+                type: object
+                properties:
+                  jvmId:
+                    type: string
+                  name:
+                    type: string
+                  downloadUrl:
+                    type: string
+                  reportUrl:
+                    type: string
+                  metadata:
+                    type: object
+                    properties:
+                      labels:
+                        type: object
+                        additionalProperties: true
+                  size:
+                    type: integer
+                  archivedTime:
+                    type: integer
+        required:
+        - meta
+        - message
+    RecordingSynthesisFailure:
+      name: RecordingSynthesisFailure
+      title: Recording Synthesis Failure
+      summary: 'Notification: RecordingSynthesisFailure'
+      description: WebSocket notification for Recording Synthesis Failure events
+      payload:
+        type: object
+        description: WebSocket notification message wrapper
+        properties:
+          meta:
+            type: object
+            description: Notification metadata
+            properties:
+              category:
+                type: string
+                const: RecordingSynthesisFailure
+                description: Notification category identifier
+            required:
+            - category
+          message:
+            type: object
+            properties:
+              jobId:
                 type: string
         required:
         - meta

--- a/schema/notifications.yaml
+++ b/schema/notifications.yaml
@@ -1165,6 +1165,8 @@ components:
                   serviceRef:
                     type: object
                     properties:
+                      id:
+                        type: integer
                       connectUrl:
                         type: object
                         description: Payload of type URI
@@ -1184,6 +1186,8 @@ components:
                           cryostat:
                             type: object
                             additionalProperties: true
+                      agent:
+                        type: boolean
                   jvmId:
                     type: string
         required:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1704,6 +1704,45 @@ paths:
       summary: Execute Query
       tags:
         - Jfr Analytics
+  /api/beta/recording_synthesis/{jvmId}:
+    post:
+      parameters:
+        - in: path
+          name: jvmId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: fromTimestamp
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: toTimestamp
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: {}
+          description: OK
+        "400":
+          description: Bad Request
+      summary: Synthesize
+      tags:
+        - Recordings Synthesis
   /api/beta/recordings/{connectUrl}/{filename}:
     delete:
       parameters:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2036,6 +2036,7 @@ paths:
             type: string
         - in: query
           name: fromTimestamp
+          required: true
           schema:
             format: int64
             type: integer
@@ -2045,6 +2046,7 @@ paths:
             type: string
         - in: query
           name: toTimestamp
+          required: true
           schema:
             format: int64
             type: integer

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -1714,6 +1714,7 @@ paths:
             type: string
         - in: query
           name: fromTimestamp
+          required: true
           schema:
             format: int64
             type: integer
@@ -1723,6 +1724,7 @@ paths:
             type: string
         - in: query
           name: toTimestamp
+          required: true
           schema:
             format: int64
             type: integer

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2026,6 +2026,45 @@ paths:
       summary: Execute Query
       tags:
         - Jfr Analytics
+  /api/beta/recording_synthesis/{jvmId}:
+    post:
+      parameters:
+        - in: path
+          name: jvmId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: fromTimestamp
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: toTimestamp
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpServerResponse'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: {}
+          description: OK
+        "400":
+          description: Bad Request
+      summary: Synthesize
+      tags:
+        - Recordings Synthesis
   /api/beta/recordings/{connectUrl}/{filename}:
     delete:
       parameters:

--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -37,6 +37,7 @@ import io.cryostat.recordings.LongRunningRequestGenerator.ThreadDumpRequest;
 import io.cryostat.targets.Target;
 import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.util.HttpMimeType;
+import io.cryostat.util.ResponseDispatch;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.narayana.jta.QuarkusTransaction;
@@ -153,8 +154,9 @@ public class Diagnostics {
         io.cryostat.diagnostic.ThreadDump.requested(target, jobId, format).persist();
 
         ThreadDumpRequest request = new ThreadDumpRequest(jobId, targetId, format);
-        response.endHandler(
-                (e) -> bus.publish(LongRunningRequestGenerator.THREAD_DUMP_ADDRESS, request));
+        ResponseDispatch.onComplete(
+                response,
+                () -> bus.publish(LongRunningRequestGenerator.THREAD_DUMP_ADDRESS, request));
         return request.id();
     }
 
@@ -189,8 +191,9 @@ public class Diagnostics {
         log.trace("Cache miss. Creating heap dump reports request");
         var jobId = UUID.randomUUID().toString();
         HeapDumpAnalysisRequest request = new HeapDumpAnalysisRequest(jobId, jvmId, heapDumpId);
-        response.endHandler(
-                (e) ->
+        ResponseDispatch.onComplete(
+                response,
+                () ->
                         bus.publish(
                                 LongRunningRequestGenerator.HEAP_DUMP_ANALYSIS_REQUEST_ADDRESS,
                                 request));
@@ -382,8 +385,9 @@ public class Diagnostics {
         io.cryostat.diagnostic.HeapDump.requested(target, jobId).persist();
 
         HeapDumpRequest request = new HeapDumpRequest(jobId, targetId);
-        response.endHandler(
-                (e) -> bus.publish(LongRunningRequestGenerator.HEAP_DUMP_REQUEST_ADDRESS, request));
+        ResponseDispatch.onComplete(
+                response,
+                () -> bus.publish(LongRunningRequestGenerator.HEAP_DUMP_REQUEST_ADDRESS, request));
         return request.id();
     }
 

--- a/src/main/java/io/cryostat/recordings/ActiveRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ActiveRecordings.java
@@ -34,6 +34,7 @@ import io.cryostat.recordings.LongRunningRequestGenerator.GrafanaActiveUploadReq
 import io.cryostat.recordings.RecordingHelper.RecordingOptions;
 import io.cryostat.recordings.RecordingHelper.RecordingReplace;
 import io.cryostat.targets.Target;
+import io.cryostat.util.ResponseDispatch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -159,8 +160,9 @@ public class ActiveRecordings {
                         new ArchiveRequest(UUID.randomUUID().toString(), activeRecording);
                 logger.tracev(
                         "Request created: ({0}, {1})", request.id(), request.recording().name);
-                response.endHandler(
-                        (e) ->
+                ResponseDispatch.onComplete(
+                        response,
+                        () ->
                                 bus.publish(
                                         LongRunningRequestGenerator.ARCHIVE_REQUEST_ADDRESS,
                                         request));
@@ -295,8 +297,9 @@ public class ActiveRecordings {
                         + request.id()
                         + request.remoteId()
                         + request.targetId());
-        response.endHandler(
-                (e) ->
+        ResponseDispatch.onComplete(
+                response,
+                () ->
                         bus.publish(
                                 LongRunningRequestGenerator.GRAFANA_ACTIVE_REQUEST_ADDRESS,
                                 request));

--- a/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
+++ b/src/main/java/io/cryostat/recordings/ArchivedRecordings.java
@@ -37,6 +37,7 @@ import io.cryostat.recordings.ActiveRecordings.Metadata;
 import io.cryostat.recordings.LongRunningRequestGenerator.GrafanaArchiveUploadRequest;
 import io.cryostat.targets.Target;
 import io.cryostat.util.HttpMimeType;
+import io.cryostat.util.ResponseDispatch;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.quarkus.narayana.jta.QuarkusTransaction;
@@ -450,8 +451,9 @@ public class ArchivedRecordings {
         GrafanaArchiveUploadRequest request =
                 new GrafanaArchiveUploadRequest(UUID.randomUUID().toString(), pair);
         logger.tracev("Request created: ({0}, {1})", request.id(), request.pair());
-        response.endHandler(
-                (e) ->
+        ResponseDispatch.onComplete(
+                response,
+                () ->
                         bus.publish(
                                 LongRunningRequestGenerator.GRAFANA_ARCHIVE_REQUEST_ADDRESS,
                                 request));

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -15,9 +15,22 @@
  */
 package io.cryostat.recordings;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import io.cryostat.ConfigProperties;
@@ -39,6 +52,7 @@ import io.cryostat.ws.notifications.NotificationPayloads.HeapDumpAnalysisSuccess
 import io.cryostat.ws.notifications.NotificationPayloads.HeapDumpSuccessPayload;
 import io.cryostat.ws.notifications.NotificationPayloads.JobIdPayload;
 import io.cryostat.ws.notifications.NotificationPayloads.ReportSuccessPayload;
+import io.cryostat.ws.notifications.NotificationPayloads.SynthesisCompletePayload;
 import io.cryostat.ws.notifications.NotificationPayloads.ThreadDumpFailurePayload;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -84,6 +98,8 @@ public class LongRunningRequestGenerator {
             "io.cryostat.recordings.LongRunningRequestGenerator.HeapDumpRequest";
     public static final String THREAD_DUMP_ADDRESS =
             "io.cryostat.recordings.LongRunningRequestGenerator.ThreadDump";
+    public static final String SYNTHESIS_REQUEST_ADDRESS =
+            "io.cryostat.recordings.LongRunningRequestGenerator.SynthesisRequest";
 
     private static final String ARCHIVE_RECORDING_SUCCESS = "ArchiveRecordingSuccess";
     private static final String ARCHIVE_RECORDING_FAIL = "ArchiveRecordingFailure";
@@ -96,6 +112,8 @@ public class LongRunningRequestGenerator {
     private static final String HEAP_DUMP_ANALYSIS_SUCCESS = "HeapDumpAnalysisSuccess";
     private static final String HEAP_DUMP_ANALYSIS_FAILURE = "HeapDumpAnalysisFailure";
     private static final String THREAD_DUMP_FAILURE = "ThreadDumpFailure";
+    private static final String SYNTHESIS_SUCCESS = "RecordingSynthesisComplete";
+    private static final String SYNTHESIS_FAILURE = "RecordingSynthesisFailure";
 
     @Inject Logger logger;
     @Inject private EventBus bus;
@@ -416,6 +434,141 @@ public class LongRunningRequestGenerator {
         }
     }
 
+    @ConsumeEvent(value = SYNTHESIS_REQUEST_ADDRESS, blocking = true)
+    @Transactional
+    public void onMessage(SynthesisRequest request) {
+        logger.tracev("Synthesis job ID: {0} submitted.", request.id());
+        long fromMs = request.fromTimestamp() * 1000L;
+        long toMs = request.toTimestamp() * 1000L;
+
+        List<ArchivedRecording> current = recordingHelper.listArchivedRecordings(request.jvmId());
+        Optional<ArchivedRecording> existing =
+                current.stream()
+                        .filter(RecordingsSynthesis.completeFilter(fromMs, toMs))
+                        .max(Comparator.comparingDouble(RecordingsSynthesis::density));
+        if (existing.isPresent()) {
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            SYNTHESIS_SUCCESS,
+                            new SynthesisCompletePayload(request.id(), existing.get())));
+            return;
+        }
+
+        List<ArchivedRecording> candidates = request.candidates();
+        long minStart = Long.MAX_VALUE;
+        long maxEnd = Long.MIN_VALUE;
+        for (ArchivedRecording r : candidates) {
+            long st = Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
+            long dur = Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
+            if (st < minStart) minStart = st;
+            if (st + dur > maxEnd) maxEnd = st + dur;
+        }
+        long syntheticDuration = maxEnd - minStart;
+
+        String isoStart =
+                Instant.ofEpochMilli(minStart).toString().replace(':', '-').replace('.', '-');
+        String humanDur = formatDuration(Duration.ofMillis(syntheticDuration));
+        String filename = request.tag() + "_" + isoStart + "_" + humanDur + ".jfr";
+
+        long totalSize = candidates.stream().mapToLong(ArchivedRecording::size).sum();
+        long[] offsets = new long[candidates.size()];
+        offsets[0] = 0;
+        for (int i = 1; i < candidates.size(); i++) {
+            offsets[i] = offsets[i - 1] + candidates.get(i - 1).size();
+        }
+
+        Path tempFile = null;
+        FileChannel channel = null;
+        try {
+            tempFile = Files.createTempFile("synthesis-", ".jfr");
+            channel = FileChannel.open(tempFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            // allocate tempFile large enough to hold concatenated contents of all candidate
+            // recordings, and fail fast if the required space is not available
+            try {
+                channel.write(ByteBuffer.allocate(1), totalSize - 1);
+            } catch (IOException e) {
+                throw e;
+            }
+
+            final FileChannel fc = channel;
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (int i = 0; i < candidates.size(); i++) {
+                final String name = candidates.get(i).name();
+                final long offset = offsets[i];
+                futures.add(
+                        CompletableFuture.runAsync(
+                                () -> {
+                                    try (var in =
+                                            recordingHelper.getArchivedRecordingStream(
+                                                    request.jvmId(), name)) {
+                                        byte[] buf = new byte[8192];
+                                        int read;
+                                        long pos = offset;
+                                        while ((read = in.read(buf)) != -1) {
+                                            fc.write(ByteBuffer.wrap(buf, 0, read), pos);
+                                            pos += read;
+                                        }
+                                    } catch (Exception ex) {
+                                        throw new CompletionException(ex);
+                                    }
+                                },
+                                recordingHelper.partUploader));
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            channel.close();
+            channel = null;
+
+            Map<String, String> labelsMap = new HashMap<>();
+            labelsMap.put("jvmId", request.jvmId());
+            labelsMap.put(RecordingHelper.START_TIME_LABEL, String.valueOf(minStart));
+            labelsMap.put(RecordingHelper.DURATION_LABEL, String.valueOf(syntheticDuration));
+            labelsMap.put(AnalysisReportAggregator.AUTOANALYZE_LABEL, "true");
+            labelsMap.put("synthetic", "true");
+            ActiveRecordings.Metadata metadata = new ActiveRecordings.Metadata(labelsMap);
+
+            ArchivedRecording result =
+                    recordingHelper.uploadSynthesizedRecording(
+                            request.jvmId(), tempFile, filename, metadata);
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(
+                            SYNTHESIS_SUCCESS, new SynthesisCompletePayload(request.id(), result)));
+        } catch (Exception e) {
+            logger.warnv("Synthesis job {0} failed: {1}", request.id(), e.getMessage());
+            bus.publish(
+                    MessagingServer.class.getName(),
+                    new Notification(SYNTHESIS_FAILURE, new JobIdPayload(request.id())));
+            throw new CompletionException(e);
+        } finally {
+            if (channel != null) {
+                try {
+                    channel.close();
+                } catch (Exception ignored) {
+                }
+            }
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private static String formatDuration(Duration d) {
+        long seconds = d.getSeconds();
+        long hours = seconds / 3600;
+        long minutes = (seconds % 3600) / 60;
+        long secs = seconds % 60;
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) sb.append(hours).append('h');
+        if (minutes > 0) sb.append(minutes).append('m');
+        if (secs > 0 || sb.length() == 0) sb.append(secs).append('s');
+        return sb.toString();
+    }
+
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public record ArchiveRequest(String id, ActiveRecording recording, boolean deleteOnCompletion) {
         public ArchiveRequest {
@@ -507,6 +660,21 @@ public class LongRunningRequestGenerator {
             Objects.requireNonNull(id);
             Objects.requireNonNull(jvmId);
             Objects.requireNonNull(heapDumpId);
+        }
+    }
+
+    public record SynthesisRequest(
+            String id,
+            String jvmId,
+            long fromTimestamp,
+            long toTimestamp,
+            String tag,
+            List<ArchivedRecording> candidates) {
+        public SynthesisRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(jvmId);
+            Objects.requireNonNull(tag);
+            Objects.requireNonNull(candidates);
         }
     }
 }

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -570,7 +570,7 @@ public class LongRunningRequestGenerator {
                     MessagingServer.class.getName(),
                     new Notification(
                             SYNTHESIS_SUCCESS, new SynthesisCompletePayload(request.id(), result)));
-        } catch (IOException | CompletionException e) {
+        } catch (Exception e) {
             logger.warnv("Synthesis job {0} failed: {1}", request.id(), e.getMessage());
             bus.publish(
                     MessagingServer.class.getName(),

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.regex.Pattern;
 
 import io.cryostat.ConfigProperties;
 import io.cryostat.core.diagnostic.HeapDumpAnalysis;
@@ -468,7 +469,7 @@ public class LongRunningRequestGenerator {
         String isoStart =
                 Instant.ofEpochMilli(minStart).toString().replace(':', '-').replace('.', '-');
         String humanDur = formatDuration(Duration.ofMillis(syntheticDuration));
-        String filename = request.tag() + "_" + isoStart + "_" + humanDur + ".jfr";
+        String filename = sanitizeTag(request.tag()) + "_" + isoStart + "_" + humanDur + ".jfr";
 
         long totalSize = candidates.stream().mapToLong(ArchivedRecording::size).sum();
         long[] offsets = new long[candidates.size()];
@@ -581,6 +582,12 @@ public class LongRunningRequestGenerator {
             }
         }
     }
+
+    static String sanitizeTag(String tag) {
+        return UNSAFE_TAG_CHARS.matcher(tag).replaceAll("_");
+    }
+
+    private static final Pattern UNSAFE_TAG_CHARS = Pattern.compile("[^\\p{L}\\p{N}\\-_]");
 
     private static String formatDuration(Duration d) {
         long seconds = d.getSeconds();

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -513,8 +513,17 @@ public class LongRunningRequestGenerator {
                                         int read;
                                         long pos = offset;
                                         while ((read = in.read(buf)) != -1) {
-                                            fc.write(ByteBuffer.wrap(buf, 0, read), pos);
-                                            pos += read;
+                                            ByteBuffer bb = ByteBuffer.wrap(buf, 0, read);
+                                            while (bb.hasRemaining()) {
+                                                int n = fc.write(bb, pos);
+                                                if (n <= 0) {
+                                                    throw new IOException(
+                                                            "Failed to write segment '"
+                                                                    + name
+                                                                    + "'");
+                                                }
+                                                pos += n;
+                                            }
                                         }
                                         long written = pos - offset;
                                         if (written != expectedSize) {

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -437,6 +437,11 @@ public class LongRunningRequestGenerator {
 
     @ConsumeEvent(value = SYNTHESIS_REQUEST_ADDRESS, blocking = true)
     @Transactional
+    @SuppressFBWarnings(
+            value = "REC_CATCH_EXCEPTION",
+            justification =
+                    "Catch broad Exception intentionally to ensure any unexpected exception,"
+                            + " including RuntimeExceptions, are handled")
     public void onMessage(SynthesisRequest request) {
         logger.tracev("Synthesis job ID: {0} submitted.", request.id());
         long fromMs = request.fromMs();

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -16,6 +16,7 @@
 package io.cryostat.recordings;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -32,6 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.regex.Pattern;
 
 import io.cryostat.ConfigProperties;
@@ -502,6 +504,8 @@ public class LongRunningRequestGenerator {
 
             final FileChannel fc = channel;
             final long[] actualWritten = new long[candidates.size()];
+            final AtomicReferenceArray<InputStream> openStreams =
+                    new AtomicReferenceArray<>(candidates.size());
             List<CompletableFuture<Void>> futures = new ArrayList<>();
             for (int i = 0; i < candidates.size(); i++) {
                 final String name = candidates.get(i).name();
@@ -511,9 +515,11 @@ public class LongRunningRequestGenerator {
                 futures.add(
                         CompletableFuture.runAsync(
                                 () -> {
-                                    try (var in =
+                                    InputStream in =
                                             recordingHelper.getArchivedRecordingStream(
-                                                    request.jvmId(), name)) {
+                                                    request.jvmId(), name);
+                                    openStreams.set(idx, in);
+                                    try {
                                         byte[] buf = new byte[8192];
                                         int read;
                                         long pos = offset;
@@ -543,6 +549,11 @@ public class LongRunningRequestGenerator {
                                         actualWritten[idx] = written;
                                     } catch (IOException ex) {
                                         throw new CompletionException(ex);
+                                    } finally {
+                                        try {
+                                            in.close();
+                                        } catch (IOException ignored) {
+                                        }
                                     }
                                 },
                                 recordingHelper.partUploader));
@@ -553,7 +564,25 @@ public class LongRunningRequestGenerator {
             try {
                 allFutures.join();
             } catch (CompletionException e) {
+                // Close all open sibling streams so blocked reads unblock immediately.
+                for (int i = 0; i < openStreams.length(); i++) {
+                    InputStream s = openStreams.get(i);
+                    if (s != null) {
+                        try {
+                            s.close();
+                        } catch (IOException ignored) {
+                        }
+                    }
+                }
+                // Cancel tasks after streams are closed so the executor threads can finish.
                 futures.forEach(f -> f.cancel(true));
+                // Await termination of all sibling tasks before allowing cleanup to proceed.
+                for (CompletableFuture<Void> f : futures) {
+                    try {
+                        f.join();
+                    } catch (Exception ignored) {
+                    }
+                }
                 throw e;
             }
 

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -462,36 +462,41 @@ public class LongRunningRequestGenerator {
         }
 
         List<ArchivedRecording> candidates = request.candidates();
-        long minStart = Long.MAX_VALUE;
-        long maxEnd = Long.MIN_VALUE;
-        for (ArchivedRecording r : candidates) {
-            long st = Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
-            long dur = Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
-            if (st < minStart) minStart = st;
-            if (st + dur > maxEnd) maxEnd = st + dur;
-        }
-        long syntheticDuration = maxEnd - minStart;
-
-        String isoStart =
-                Instant.ofEpochMilli(minStart).toString().replace(':', '-').replace('.', '-');
-        String humanDur = formatDuration(Duration.ofMillis(syntheticDuration));
-        String filename = sanitizeTag(request.tag()) + "_" + isoStart + "_" + humanDur + ".jfr";
-
-        long totalSize = candidates.stream().mapToLong(ArchivedRecording::size).sum();
-        long[] offsets = new long[candidates.size()];
-        offsets[0] = 0;
-        for (int i = 1; i < candidates.size(); i++) {
-            offsets[i] = offsets[i - 1] + candidates.get(i - 1).size();
-        }
-
-        if (totalSize <= 0) {
-            throw new IllegalStateException(
-                    "Cannot synthesise recordings: total candidate size is zero");
-        }
 
         Path tempFile = null;
         FileChannel channel = null;
         try {
+            long minStart = Long.MAX_VALUE;
+            long maxEnd = Long.MIN_VALUE;
+            for (ArchivedRecording r : candidates) {
+                long st =
+                        Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
+                long dur =
+                        Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
+                if (st < minStart) minStart = st;
+                if (st + dur > maxEnd) maxEnd = st + dur;
+            }
+            long syntheticDuration = maxEnd - minStart;
+
+            String isoStart =
+                    Instant.ofEpochMilli(minStart).toString().replace(':', '-').replace('.', '-');
+            String humanDur = formatDuration(Duration.ofMillis(syntheticDuration));
+            String filename = sanitizeTag(request.tag()) + "_" + isoStart + "_" + humanDur + ".jfr";
+
+            long totalSize = candidates.stream().mapToLong(ArchivedRecording::size).sum();
+            if (totalSize <= 0) {
+                throw new IllegalStateException(
+                        "Cannot synthesise recordings: total candidate size is zero");
+            }
+
+            long[] offsets = new long[candidates.size()];
+            if (!candidates.isEmpty()) {
+                offsets[0] = 0;
+                for (int i = 1; i < candidates.size(); i++) {
+                    offsets[i] = offsets[i - 1] + candidates.get(i - 1).size();
+                }
+            }
+
             tempFile = Files.createTempFile("synthesis-", ".jfr");
             channel = FileChannel.open(tempFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
 

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -438,7 +438,6 @@ public class LongRunningRequestGenerator {
     }
 
     @ConsumeEvent(value = SYNTHESIS_REQUEST_ADDRESS, blocking = true)
-    @Transactional
     @SuppressFBWarnings(
             value = "REC_CATCH_EXCEPTION",
             justification =

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -439,8 +439,8 @@ public class LongRunningRequestGenerator {
     @Transactional
     public void onMessage(SynthesisRequest request) {
         logger.tracev("Synthesis job ID: {0} submitted.", request.id());
-        long fromMs = request.fromTimestamp() * 1000L;
-        long toMs = request.toTimestamp() * 1000L;
+        long fromMs = request.fromMs();
+        long toMs = request.toMs();
 
         Optional<ArchivedRecording> existing =
                 request.candidates().stream()
@@ -707,14 +707,17 @@ public class LongRunningRequestGenerator {
     public record SynthesisRequest(
             String id,
             String jvmId,
-            long fromTimestamp,
-            long toTimestamp,
+            long fromMs,
+            long toMs,
             String tag,
             List<ArchivedRecording> candidates) {
         public SynthesisRequest {
             Objects.requireNonNull(id);
             Objects.requireNonNull(jvmId);
             Objects.requireNonNull(tag);
+            if (fromMs <= 0 || toMs <= 0 || fromMs >= toMs) {
+                throw new IllegalArgumentException("Invalid millisecond timestamps");
+            }
             candidates = List.copyOf(candidates);
         }
     }

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -441,10 +441,9 @@ public class LongRunningRequestGenerator {
         long fromMs = request.fromTimestamp() * 1000L;
         long toMs = request.toTimestamp() * 1000L;
 
-        List<ArchivedRecording> current = recordingHelper.listArchivedRecordings(request.jvmId());
         Optional<ArchivedRecording> existing =
-                current.stream()
-                        .filter(RecordingsSynthesis.completeFilter(fromMs, toMs))
+                request.candidates().stream()
+                        .filter(r -> RecordingsSynthesis.isComplete(r, fromMs, toMs))
                         .max(Comparator.comparingDouble(RecordingsSynthesis::density));
         if (existing.isPresent()) {
             bus.publish(
@@ -535,7 +534,7 @@ public class LongRunningRequestGenerator {
                     MessagingServer.class.getName(),
                     new Notification(
                             SYNTHESIS_SUCCESS, new SynthesisCompletePayload(request.id(), result)));
-        } catch (Exception e) {
+        } catch (IOException | CompletionException e) {
             logger.warnv("Synthesis job {0} failed: {1}", request.id(), e.getMessage());
             bus.publish(
                     MessagingServer.class.getName(),
@@ -674,7 +673,7 @@ public class LongRunningRequestGenerator {
             Objects.requireNonNull(id);
             Objects.requireNonNull(jvmId);
             Objects.requireNonNull(tag);
-            Objects.requireNonNull(candidates);
+            candidates = List.copyOf(candidates);
         }
     }
 }

--- a/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
+++ b/src/main/java/io/cryostat/recordings/LongRunningRequestGenerator.java
@@ -477,24 +477,31 @@ public class LongRunningRequestGenerator {
             offsets[i] = offsets[i - 1] + candidates.get(i - 1).size();
         }
 
+        if (totalSize <= 0) {
+            throw new IllegalStateException(
+                    "Cannot synthesise recordings: total candidate size is zero");
+        }
+
         Path tempFile = null;
         FileChannel channel = null;
         try {
             tempFile = Files.createTempFile("synthesis-", ".jfr");
             channel = FileChannel.open(tempFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
-            // allocate tempFile large enough to hold concatenated contents of all candidate
-            // recordings, and fail fast if the required space is not available
-            try {
-                channel.write(ByteBuffer.allocate(1), totalSize - 1);
-            } catch (IOException e) {
-                throw e;
-            }
+
+            // Best-effort space probe: writing one byte at the last expected offset forces the
+            // filesystem to report ENOSPC immediately if it cannot accommodate totalSize bytes,
+            // before any downloads begin.
+            channel.write(ByteBuffer.allocate(1), totalSize - 1);
+            channel.truncate(0);
 
             final FileChannel fc = channel;
+            final long[] actualWritten = new long[candidates.size()];
             List<CompletableFuture<Void>> futures = new ArrayList<>();
             for (int i = 0; i < candidates.size(); i++) {
                 final String name = candidates.get(i).name();
+                final long expectedSize = candidates.get(i).size();
                 final long offset = offsets[i];
+                final int idx = i;
                 futures.add(
                         CompletableFuture.runAsync(
                                 () -> {
@@ -508,13 +515,32 @@ public class LongRunningRequestGenerator {
                                             fc.write(ByteBuffer.wrap(buf, 0, read), pos);
                                             pos += read;
                                         }
-                                    } catch (Exception ex) {
+                                        long written = pos - offset;
+                                        if (written != expectedSize) {
+                                            throw new IOException(
+                                                    "Size mismatch for '"
+                                                            + name
+                                                            + "': expected "
+                                                            + expectedSize
+                                                            + " bytes but transferred "
+                                                            + written);
+                                        }
+                                        actualWritten[idx] = written;
+                                    } catch (IOException ex) {
                                         throw new CompletionException(ex);
                                     }
                                 },
                                 recordingHelper.partUploader));
             }
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            CompletableFuture<Void> allFutures =
+                    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            try {
+                allFutures.join();
+            } catch (CompletionException e) {
+                futures.forEach(f -> f.cancel(true));
+                throw e;
+            }
 
             channel.close();
             channel = null;

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -1456,6 +1457,66 @@ public class RecordingHelper {
         } catch (IOException ioe) {
             logger.warn(ioe);
         }
+        return archivedRecording;
+    }
+
+    public ArchivedRecording uploadSynthesizedRecording(
+            String jvmId, Path source, String filename, Metadata metadata) throws IOException {
+        Map<String, String> labels = new HashMap<>(metadata.labels());
+        labels.put("jvmId", jvmId);
+        Metadata resolvedMetadata = new Metadata(labels);
+        String key = archivedRecordingKey(jvmId, filename);
+        Builder requestBuilder =
+                PutObjectRequest.builder()
+                        .bucket(archiveBucket)
+                        .key(key)
+                        .contentType(HttpMimeType.JFR.mime())
+                        .contentDisposition(String.format("attachment; filename=\"%s\"", filename));
+        switch (storageMode()) {
+            case TAGGING:
+                requestBuilder = requestBuilder.tagging(createMetadataTagging(resolvedMetadata));
+                break;
+            case METADATA:
+                requestBuilder = requestBuilder.metadata(labels);
+                break;
+            case BUCKET:
+                metadataService.get().create(jvmId, filename, resolvedMetadata);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        transferManager
+                .uploadFile(
+                        UploadFileRequest.builder()
+                                .putObjectRequest(requestBuilder.build())
+                                .source(source)
+                                .build())
+                .completionFuture()
+                .join();
+
+        QuarkusTransaction.joiningExisting()
+                .run(() -> ArchivedRecordingInfo.of(jvmId, filename, null).persist());
+
+        long size = Files.size(source);
+        var target = Target.getTargetByJvmId(jvmId);
+        ArchivedRecording archivedRecording =
+                new ArchivedRecording(
+                        jvmId,
+                        filename,
+                        downloadUrl(jvmId, filename),
+                        reportUrl(jvmId, filename),
+                        resolvedMetadata,
+                        size,
+                        clock.now().getEpochSecond());
+        var event =
+                new ArchivedRecordingNotification(
+                        ActiveRecordings.RecordingEventCategory.ARCHIVED_CREATED,
+                        ArchivedRecordingNotification.Payload.of(
+                                target.map(t -> t.connectUrl).orElse(null), archivedRecording));
+        bus.publish(event.category().category(), event.payload().recording());
+        bus.publish(
+                MessagingServer.class.getName(),
+                new Notification(event.category().category(), event.payload()));
         return archivedRecording;
     }
 

--- a/src/main/java/io/cryostat/recordings/RecordingHelper.java
+++ b/src/main/java/io/cryostat/recordings/RecordingHelper.java
@@ -1480,7 +1480,6 @@ public class RecordingHelper {
                 requestBuilder = requestBuilder.metadata(labels);
                 break;
             case BUCKET:
-                metadataService.get().create(jvmId, filename, resolvedMetadata);
                 break;
             default:
                 throw new IllegalStateException();
@@ -1493,6 +1492,9 @@ public class RecordingHelper {
                                 .build())
                 .completionFuture()
                 .join();
+        if (storageMode() == ArchivedRecordingMetadataService.StorageMode.BUCKET) {
+            metadataService.get().create(jvmId, filename, resolvedMetadata);
+        }
 
         QuarkusTransaction.joiningExisting()
                 .run(() -> ArchivedRecordingInfo.of(jvmId, filename, null).persist());

--- a/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import io.cryostat.recordings.ArchivedRecordings.ArchivedRecording;
+import io.cryostat.recordings.LongRunningRequestGenerator.SynthesisRequest;
+import io.cryostat.targets.Target;
+
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.query.AuditEntity;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestPath;
+
+@ApplicationScoped
+@Path("")
+public class RecordingsSynthesis {
+
+    @Inject RecordingHelper recordingHelper;
+    @Inject EventBus bus;
+    @Inject EntityManager em;
+    @Inject Logger logger;
+
+    @POST
+    @Blocking
+    @Transactional
+    @RolesAllowed("write")
+    @Path("/api/beta/recording_synthesis/{jvmId}")
+    public Response synthesize(
+            HttpServerResponse response,
+            @RestPath String jvmId,
+            @QueryParam("fromTimestamp") long fromTimestamp,
+            @QueryParam("toTimestamp") long toTimestamp,
+            @QueryParam("tag") String tag) {
+
+        if (fromTimestamp >= toTimestamp) {
+            throw new BadRequestException();
+        }
+
+        long fromMs = fromTimestamp * 1000L;
+        long toMs = toTimestamp * 1000L;
+
+        List<ArchivedRecording> completeCandidates = new ArrayList<>();
+        List<ArchivedRecording> incompleteCandidates = new ArrayList<>();
+        recordingHelper.listArchivedRecordings(jvmId).stream()
+                .filter(r -> !isExcluded(r, fromMs, toMs))
+                .forEach(
+                        r -> {
+                            if (isComplete(r, fromMs, toMs)) {
+                                completeCandidates.add(r);
+                            } else {
+                                incompleteCandidates.add(r);
+                            }
+                        });
+
+        if (completeCandidates.isEmpty() && incompleteCandidates.isEmpty()) {
+            throw new BadRequestException();
+        }
+
+        if (!completeCandidates.isEmpty()) {
+            ArchivedRecording densest =
+                    completeCandidates.stream()
+                            .max(Comparator.comparingDouble(RecordingsSynthesis::density))
+                            .orElseThrow();
+            return Response.ok(densest).build();
+        }
+
+        if (incompleteCandidates.size() == 1) {
+            return Response.ok(incompleteCandidates.get(0)).build();
+        }
+
+        String resolvedTag = resolveTag(jvmId, tag);
+        String jobId = UUID.randomUUID().toString();
+        incompleteCandidates.sort(Comparator.comparingLong(r -> startTimeMs(r)));
+        SynthesisRequest request =
+                new SynthesisRequest(
+                        jobId,
+                        jvmId,
+                        fromTimestamp,
+                        toTimestamp,
+                        resolvedTag,
+                        incompleteCandidates);
+        response.endHandler(
+                (e) -> bus.publish(LongRunningRequestGenerator.SYNTHESIS_REQUEST_ADDRESS, request));
+        return Response.accepted(jobId).type(MediaType.TEXT_PLAIN).build();
+    }
+
+    private String resolveTag(String jvmId, String tagParam) {
+        if (StringUtils.isNotBlank(tagParam)) {
+            return tagParam;
+        }
+        var fromTarget = Target.getTargetByJvmId(jvmId).map(t -> t.alias);
+        if (fromTarget.isPresent() && StringUtils.isNotBlank(fromTarget.get())) {
+            return fromTarget.get();
+        }
+        try {
+            var ar = AuditReaderFactory.get(em);
+            @SuppressWarnings("unchecked")
+            var q =
+                    ar.createQuery()
+                            .forRevisionsOfEntity(Target.class, false, true)
+                            .add(AuditEntity.property("jvmId").eq(jvmId))
+                            .add(
+                                    AuditEntity.revisionType()
+                                            .ne(org.hibernate.envers.RevisionType.DEL))
+                            .addOrder(AuditEntity.revisionNumber().desc())
+                            .setMaxResults(1)
+                            .getResultList();
+            if (!q.isEmpty()) {
+                Object[] result = (Object[]) q.get(0);
+                Target t = (Target) result[0];
+                if (t != null && StringUtils.isNotBlank(t.alias)) {
+                    return t.alias;
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to look up target alias from audit for jvmId: " + jvmId, e);
+        }
+        return jvmId;
+    }
+
+    static boolean isExcluded(ArchivedRecording r, long fromMs, long toMs) {
+        try {
+            long startTime =
+                    Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
+            long duration =
+                    Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
+            return (startTime + duration) <= fromMs || startTime >= toMs;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    static boolean isComplete(ArchivedRecording r, long fromMs, long toMs) {
+        try {
+            long startTime =
+                    Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
+            long duration =
+                    Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
+            return startTime <= fromMs && (startTime + duration) >= toMs;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Predicate<ArchivedRecording> completeFilter(long fromMs, long toMs) {
+        return r -> isComplete(r, fromMs, toMs);
+    }
+
+    static double density(ArchivedRecording r) {
+        try {
+            long duration =
+                    Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
+            if (duration == 0) return 0.0;
+            return (double) r.size() / duration;
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+
+    static long startTimeMs(ArchivedRecording r) {
+        try {
+            return Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Predicate;
 
 import io.cryostat.recordings.ArchivedRecordings.ArchivedRecording;
 import io.cryostat.recordings.LongRunningRequestGenerator.SynthesisRequest;
@@ -32,7 +31,6 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -40,6 +38,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.query.AuditEntity;
 import org.jboss.logging.Logger;
@@ -56,14 +55,13 @@ public class RecordingsSynthesis {
 
     @POST
     @Blocking
-    @Transactional
     @RolesAllowed("write")
     @Path("/api/beta/recording_synthesis/{jvmId}")
     public Response synthesize(
             HttpServerResponse response,
             @RestPath String jvmId,
-            @QueryParam("fromTimestamp") long fromTimestamp,
-            @QueryParam("toTimestamp") long toTimestamp,
+            @Parameter(required = true) @QueryParam("fromTimestamp") long fromTimestamp,
+            @Parameter(required = true) @QueryParam("toTimestamp") long toTimestamp,
             @QueryParam("tag") String tag) {
 
         if (fromTimestamp >= toTimestamp) {
@@ -131,11 +129,8 @@ public class RecordingsSynthesis {
             @SuppressWarnings("unchecked")
             var q =
                     ar.createQuery()
-                            .forRevisionsOfEntity(Target.class, false, true)
+                            .forRevisionsOfEntity(Target.class, false, false)
                             .add(AuditEntity.property("jvmId").eq(jvmId))
-                            .add(
-                                    AuditEntity.revisionType()
-                                            .ne(org.hibernate.envers.RevisionType.DEL))
                             .addOrder(AuditEntity.revisionNumber().desc())
                             .setMaxResults(1)
                             .getResultList();
@@ -147,7 +142,7 @@ public class RecordingsSynthesis {
                 }
             }
         } catch (Exception e) {
-            logger.debug("Failed to look up target alias from audit for jvmId: " + jvmId, e);
+            logger.debugv("Failed to look up target alias from audit for jvmId: {0}", jvmId, e);
         }
         return jvmId;
     }
@@ -174,10 +169,6 @@ public class RecordingsSynthesis {
         } catch (Exception e) {
             return false;
         }
-    }
-
-    static Predicate<ArchivedRecording> completeFilter(long fromMs, long toMs) {
-        return r -> isComplete(r, fromMs, toMs);
     }
 
     static double density(ArchivedRecording r) {

--- a/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.recordings;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -64,12 +65,20 @@ public class RecordingsSynthesis {
             @Parameter(required = true) @QueryParam("toTimestamp") long toTimestamp,
             @QueryParam("tag") String tag) {
 
+        // Reject values that are clearly not epoch-seconds (negative, zero, or above year 2106).
+        long MAX_EPOCH_SECONDS = BigInteger.TWO.pow(32).longValueExact();
+        if (fromTimestamp <= 0
+                || toTimestamp <= 0
+                || fromTimestamp > MAX_EPOCH_SECONDS
+                || toTimestamp > MAX_EPOCH_SECONDS) {
+            throw new BadRequestException("Timestamp out of valid epoch-seconds range");
+        }
         if (fromTimestamp >= toTimestamp) {
             throw new BadRequestException();
         }
 
-        long fromMs = fromTimestamp * 1000L;
-        long toMs = toTimestamp * 1000L;
+        long fromMs = Math.multiplyExact(fromTimestamp, 1000L);
+        long toMs = Math.multiplyExact(toTimestamp, 1000L);
 
         List<ArchivedRecording> completeCandidates = new ArrayList<>();
         List<ArchivedRecording> incompleteCandidates = new ArrayList<>();
@@ -104,13 +113,7 @@ public class RecordingsSynthesis {
         String jobId = UUID.randomUUID().toString();
         incompleteCandidates.sort(Comparator.comparingLong(r -> startTimeMs(r)));
         SynthesisRequest request =
-                new SynthesisRequest(
-                        jobId,
-                        jvmId,
-                        fromTimestamp,
-                        toTimestamp,
-                        resolvedTag,
-                        incompleteCandidates);
+                new SynthesisRequest(jobId, jvmId, fromMs, toMs, resolvedTag, incompleteCandidates);
         response.endHandler(
                 (e) -> bus.publish(LongRunningRequestGenerator.SYNTHESIS_REQUEST_ADDRESS, request));
         return Response.accepted(jobId).type(MediaType.TEXT_PLAIN).build();

--- a/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
@@ -158,7 +158,9 @@ public class RecordingsSynthesis {
                     Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
             long duration =
                     Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
-            return (startTime + duration) <= fromMs || startTime >= toMs;
+            if (startTime < 0 || duration <= 0) return true;
+            long endTime = Math.addExact(startTime, duration);
+            return endTime <= fromMs || startTime >= toMs;
         } catch (Exception e) {
             return true;
         }
@@ -170,7 +172,9 @@ public class RecordingsSynthesis {
                     Long.parseLong(r.metadata().labels().get(RecordingHelper.START_TIME_LABEL));
             long duration =
                     Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
-            return startTime <= fromMs && (startTime + duration) >= toMs;
+            if (startTime < 0 || duration <= 0) return false;
+            long endTime = Math.addExact(startTime, duration);
+            return startTime <= fromMs && endTime >= toMs;
         } catch (Exception e) {
             return false;
         }
@@ -180,7 +184,7 @@ public class RecordingsSynthesis {
         try {
             long duration =
                     Long.parseLong(r.metadata().labels().get(RecordingHelper.DURATION_LABEL));
-            if (duration == 0) return 0.0;
+            if (duration <= 0) return 0.0;
             return (double) r.size() / duration;
         } catch (Exception e) {
             return 0.0;

--- a/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
+++ b/src/main/java/io/cryostat/recordings/RecordingsSynthesis.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import io.cryostat.recordings.ArchivedRecordings.ArchivedRecording;
 import io.cryostat.recordings.LongRunningRequestGenerator.SynthesisRequest;
 import io.cryostat.targets.Target;
+import io.cryostat.util.ResponseDispatch;
 
 import io.smallrye.common.annotation.Blocking;
 import io.vertx.core.http.HttpServerResponse;
@@ -114,8 +115,9 @@ public class RecordingsSynthesis {
         incompleteCandidates.sort(Comparator.comparingLong(r -> startTimeMs(r)));
         SynthesisRequest request =
                 new SynthesisRequest(jobId, jvmId, fromMs, toMs, resolvedTag, incompleteCandidates);
-        response.endHandler(
-                (e) -> bus.publish(LongRunningRequestGenerator.SYNTHESIS_REQUEST_ADDRESS, request));
+        ResponseDispatch.onComplete(
+                response,
+                () -> bus.publish(LongRunningRequestGenerator.SYNTHESIS_REQUEST_ADDRESS, request));
         return Response.accepted(jobId).type(MediaType.TEXT_PLAIN).build();
     }
 

--- a/src/main/java/io/cryostat/util/ResponseDispatch.java
+++ b/src/main/java/io/cryostat/util/ResponseDispatch.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.vertx.core.http.HttpServerResponse;
+
+public final class ResponseDispatch {
+
+    /**
+     * Registers handlers on {@code response} so that {@code action} is called exactly once when the
+     * response finishes writing ({@code endHandler}) <em>or</em> when the underlying connection
+     * closes before the response is fully sent ({@code closeHandler}). The {@link AtomicBoolean}
+     * guard ensures only one of the two handlers executes the action.
+     */
+    public static void onComplete(HttpServerResponse response, Runnable action) {
+        AtomicBoolean fired = new AtomicBoolean(false);
+        Runnable once =
+                () -> {
+                    if (fired.compareAndSet(false, true)) {
+                        action.run();
+                    }
+                };
+        response.endHandler((e) -> once.run());
+        response.closeHandler((e) -> once.run());
+    }
+}

--- a/src/main/java/io/cryostat/ws/notifications/NotificationPayloads.java
+++ b/src/main/java/io/cryostat/ws/notifications/NotificationPayloads.java
@@ -18,6 +18,7 @@ package io.cryostat.ws.notifications;
 import java.util.Objects;
 
 import io.cryostat.core.diagnostic.HeapDumpAnalysis;
+import io.cryostat.recordings.ArchivedRecordings.ArchivedRecording;
 
 /**
  * Notification payload record types for WebSocket notifications. These records represent the
@@ -115,6 +116,13 @@ public final class NotificationPayloads {
         public ProbeTemplateUploadedPayload {
             Objects.requireNonNull(probeTemplate);
             Objects.requireNonNull(templateContent);
+        }
+    }
+
+    public record SynthesisCompletePayload(String jobId, ArchivedRecording recording) {
+        public SynthesisCompletePayload {
+            Objects.requireNonNull(jobId);
+            Objects.requireNonNull(recording);
         }
     }
 }

--- a/src/test/java/io/cryostat/recordings/LongRunningRequestGeneratorTest.java
+++ b/src/test/java/io/cryostat/recordings/LongRunningRequestGeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class LongRunningRequestGeneratorTest {
+
+    @Test
+    void sanitizeTagPassesThroughAsciiAlphanumericHyphenUnderscore() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("my-app_v1"), is("my-app_v1"));
+    }
+
+    @Test
+    void sanitizeTagReplacesForwardSlashWithUnderscore() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("a/b"), is("a_b"));
+    }
+
+    @Test
+    void sanitizeTagReplacesBackslashWithUnderscore() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("a\\b"), is("a_b"));
+    }
+
+    @Test
+    void sanitizeTagReplacesDotsAndColonsWithUnderscore() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("app.host:8080"), is("app_host_8080"));
+    }
+
+    @Test
+    void sanitizeTagReplacesPathTraversalSequence() {
+        assertThat(
+                LongRunningRequestGenerator.sanitizeTag("../../etc/passwd"),
+                is("______etc_passwd"));
+    }
+
+    @Test
+    void sanitizeTagPreservesNonEnglishLetters() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("héros_αβγ"), is("héros_αβγ"));
+    }
+
+    @Test
+    void sanitizeTagPreservesNonAsciiDigits() {
+        assertThat(LongRunningRequestGenerator.sanitizeTag("tag123"), is("tag123"));
+    }
+}

--- a/src/test/java/io/cryostat/recordings/RecordingsSynthesisTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingsSynthesisTest.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+
+import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.resources.S3StorageResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = S3StorageResource.class, restrictToAnnotatedClass = true)
+public class RecordingsSynthesisTest extends AbstractTransactionalTestBase {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @AfterEach
+    void deleteAllArchivedRecordingsForJvmId() throws IOException {
+        if (selfJvmId == null || selfJvmId.isBlank()) {
+            return;
+        }
+        for (var obj : recordingHelper.listArchivedRecordingObjects(selfJvmId)) {
+            String[] parts = obj.key().strip().split("/");
+            if (parts.length == 2) {
+                try {
+                    recordingHelper.deleteArchivedRecording(parts[0], parts[1]);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid timestamp range
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFromTimestampEqualToToTimestampReturns400() {
+        defineSelfCustomTarget();
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 1000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    @Test
+    void testFromTimestampAfterToTimestampReturns400() {
+        defineSelfCustomTarget();
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 2000L)
+                .queryParam("toTimestamp", 1000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    // -------------------------------------------------------------------------
+    // No candidates at all → 400
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNoArchivesForJvmIdReturns400() {
+        defineSelfCustomTarget();
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    @Test
+    void testRecordingEndingBeforeRangeStartIsExcludedReturns400() throws Exception {
+        defineSelfCustomTarget();
+
+        // Recording ends at 600s — entirely before [1000s, 2000s)
+        Path file = Files.createTempFile("synthesis-before-range", ".jfr");
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("before-range.jfr", file),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(500_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(100_000L))));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    @Test
+    void testRecordingStartingAfterRangeEndIsExcludedReturns400() throws Exception {
+        defineSelfCustomTarget();
+
+        // Recording starts at 2500s — entirely after [1000s, 2000s)
+        Path file = Files.createTempFile("synthesis-after-range", ".jfr");
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("after-range.jfr", file),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(2_500_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(500_000L))));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    // -------------------------------------------------------------------------
+    // Complete candidate fast-path — immediate 200
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSingleCompleteCandidateReturns200() throws Exception {
+        defineSelfCustomTarget();
+
+        // [900s, 2100s) fully spans [1000s, 2000s)
+        Path file = Files.createTempFile("synthesis-complete", ".jfr");
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("complete.jfr", file),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(900_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(1_200_000L))));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is("complete.jfr"))
+                .body("jvmId", is(selfJvmId));
+    }
+
+    @Test
+    void testPreviouslySynthesisedCompleteCandidateReturns200Idempotent() throws Exception {
+        defineSelfCustomTarget();
+
+        // A prior synthetic recording that fully covers [1000s, 2000s)
+        Path file = Files.createTempFile("synthesis-synthetic-complete", ".jfr");
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("synthetic-complete.jfr", file),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL,
+                                    String.valueOf(900_000L),
+                                    RecordingHelper.DURATION_LABEL,
+                                    String.valueOf(1_200_000L),
+                                    "synthetic",
+                                    "true")));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is("synthetic-complete.jfr"))
+                .body("metadata.labels.find { it.key == 'synthetic' }.value", is("true"))
+                .body("jvmId", is(selfJvmId));
+    }
+
+    @Test
+    void testDensestCompleteCandidateSelectedWhenMultipleExist() throws Exception {
+        defineSelfCustomTarget();
+
+        // Two complete candidates covering [1000s, 2000s):
+        //   sparse.jfr:  900s start, 1200s duration, 4 bytes  → density ≈ 0.0033 bytes/ms
+        //   dense.jfr:   950s start, 1100s duration, 100 bytes → density ≈ 0.091 bytes/ms
+        Path sparse = Files.createTempFile("synthesis-sparse", ".jfr");
+        Path dense = Files.createTempFile("synthesis-dense", ".jfr");
+        Files.write(sparse, new byte[] {1, 2, 3, 4});
+        byte[] denseBytes = new byte[100];
+        for (int i = 0; i < 100; i++) denseBytes[i] = (byte) i;
+        Files.write(dense, denseBytes);
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("sparse.jfr", sparse),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(900_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(1_200_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("dense.jfr", dense),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(950_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(1_100_000L))));
+        } finally {
+            Files.deleteIfExists(sparse);
+            Files.deleteIfExists(dense);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is("dense.jfr"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Single incomplete candidate fast-path — immediate 200
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSingleIncompleteCandidateReturns200Directly() throws Exception {
+        defineSelfCustomTarget();
+
+        // Overlaps [1000s, 2000s) but doesn't fully span it: starts after fromTimestamp
+        Path file = Files.createTempFile("synthesis-incomplete", ".jfr");
+        Files.write(file, new byte[] {1, 2, 3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("incomplete.jfr", file),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(1_200_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(900_000L))));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is("incomplete.jfr"))
+                .body("jvmId", is(selfJvmId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiple incomplete candidates — 202 async job dispatched
+    // Gapless coverage is NOT required; any two overlapping recordings qualify
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testMultipleIncompleteCandidatesReturns202() throws Exception {
+        defineSelfCustomTarget();
+
+        // Two overlapping recordings, neither fully covers [1000s, 2000s):
+        // [800s, 1300s) and [1500s, 2100s) — there is a gap, but that is acceptable
+        Path file1 = Files.createTempFile("synthesis-multi-a", ".jfr");
+        Path file2 = Files.createTempFile("synthesis-multi-b", ".jfr");
+        Files.write(file1, new byte[] {1, 2, 3, 4});
+        Files.write(file2, new byte[] {5, 6, 7, 8});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("multi-a.jfr", file1),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(800_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(500_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("multi-b.jfr", file2),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(1_500_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(600_000L))));
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(202)
+                .contentType(ContentType.TEXT)
+                .body(notNullValue());
+
+        webSocketClient.expectNotification("RecordingSynthesisComplete", Duration.ofSeconds(30));
+    }
+
+    @Test
+    void testCompleteCandidateWinsOverMultipleIncompleteCandidates() throws Exception {
+        defineSelfCustomTarget();
+
+        // One complete candidate alongside two incomplete ones —
+        // should return the complete candidate as 200, not dispatch a 202 job
+        Path complete = Files.createTempFile("synthesis-wins-complete", ".jfr");
+        Path inc1 = Files.createTempFile("synthesis-wins-inc1", ".jfr");
+        Path inc2 = Files.createTempFile("synthesis-wins-inc2", ".jfr");
+        byte[] largeBytes = new byte[200];
+        Files.write(complete, largeBytes);
+        Files.write(inc1, new byte[] {1, 2});
+        Files.write(inc2, new byte[] {3, 4});
+        try {
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("wins-complete.jfr", complete),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(900_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(1_200_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("wins-inc1.jfr", inc1),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(800_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(500_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("wins-inc2.jfr", inc2),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(1_500_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(600_000L))));
+        } finally {
+            Files.deleteIfExists(complete);
+            Files.deleteIfExists(inc1);
+            Files.deleteIfExists(inc2);
+        }
+
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is("wins-complete.jfr"));
+    }
+}

--- a/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.recordings;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.resources.S3StorageResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(value = S3StorageResource.class, restrictToAnnotatedClass = true)
+public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBase {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @AfterEach
+    void deleteAllArchivedRecordingsForJvmId() throws IOException {
+        if (selfJvmId == null || selfJvmId.isBlank()) {
+            return;
+        }
+        for (var obj : recordingHelper.listArchivedRecordingObjects(selfJvmId)) {
+            String[] parts = obj.key().strip().split("/");
+            if (parts.length == 2) {
+                try {
+                    recordingHelper.deleteArchivedRecording(parts[0], parts[1]);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full async workflow: 202 → RecordingSynthesisComplete notification
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSynthesisJobCompletesAndEmitsNotification() throws Exception {
+        defineSelfCustomTarget();
+
+        Path file1 = Files.createTempFile("synthesis-workflow-a", ".jfr");
+        Path file2 = Files.createTempFile("synthesis-workflow-b", ".jfr");
+        // Write minimal valid-ish JFR-shaped bytes (content doesn't matter for concat test)
+        Files.write(file1, new byte[] {1, 2, 3, 4});
+        Files.write(file2, new byte[] {5, 6, 7, 8});
+        try {
+            // [800s, 1300s) and [1200s, 2100s) together span [1000s, 2000s) without gap
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("workflow-a.jfr", file1),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(800_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(500_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("workflow-b.jfr", file2),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(1_200_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(900_000L))));
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+        }
+
+        final String[] jobId = new String[1];
+
+        Executors.newSingleThreadScheduledExecutor()
+                .schedule(
+                        () -> {
+                            var body =
+                                    given().basePath("/")
+                                            .log()
+                                            .all()
+                                            .queryParam("fromTimestamp", 1000L)
+                                            .queryParam("toTimestamp", 2000L)
+                                            .when()
+                                            .post(
+                                                    "/api/beta/recording_synthesis/{jvmId}",
+                                                    selfJvmId)
+                                            .then()
+                                            .log()
+                                            .all()
+                                            .assertThat()
+                                            .statusCode(202)
+                                            .contentType(ContentType.TEXT)
+                                            .extract()
+                                            .body()
+                                            .asString();
+                            jobId[0] = body.strip();
+                        },
+                        1,
+                        TimeUnit.SECONDS);
+
+        var notification =
+                webSocketClient.expectNotification(
+                        "RecordingSynthesisComplete",
+                        json ->
+                                Objects.equals(
+                                        json.getJsonObject("message").getString("jobId"),
+                                        jobId[0]));
+
+        var message = notification.getJsonObject("message");
+        assertThat(message.containsKey("recording"), is(true));
+        var recording = message.getJsonObject("recording");
+        assertThat(recording.getString("jvmId"), is(selfJvmId));
+        var labels = recording.getJsonObject("metadata").getJsonArray("labels");
+        String syntheticValue =
+                labels.stream()
+                        .map(o -> (io.vertx.core.json.JsonObject) o)
+                        .filter(e -> "synthetic".equals(e.getString("key")))
+                        .map(e -> e.getString("value"))
+                        .findFirst()
+                        .orElse(null);
+        assertThat(syntheticValue, is("true"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Idempotency at consumer level: a race-winning fully-covering recording
+    // emits RecordingSynthesisComplete with the existing recording, no re-upload
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void
+            testSynthesisJobIdempotentWhenFullyCoveringRecordingAlreadyExistsBeforeConsumerRuns()
+                    throws Exception {
+        defineSelfCustomTarget();
+
+        Path file1 = Files.createTempFile("synthesis-idem-a", ".jfr");
+        Path file2 = Files.createTempFile("synthesis-idem-b", ".jfr");
+        Path fileCover = Files.createTempFile("synthesis-idem-cover", ".jfr");
+        Files.write(file1, new byte[] {1, 2});
+        Files.write(file2, new byte[] {3, 4});
+        Files.write(fileCover, new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        try {
+            // Two partial recordings to trigger the 202 path
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("idem-a.jfr", file1),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(800_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(500_000L))));
+            recordingHelper.uploadArchivedRecording(
+                    selfJvmId,
+                    new TestFileUpload("idem-b.jfr", file2),
+                    new ActiveRecordings.Metadata(
+                            Map.of(
+                                    RecordingHelper.START_TIME_LABEL, String.valueOf(1_200_000L),
+                                    RecordingHelper.DURATION_LABEL, String.valueOf(900_000L))));
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+        }
+
+        final String[] jobId = new String[1];
+
+        // Issue first synthesis request to get a 202 job
+        Executors.newSingleThreadScheduledExecutor()
+                .schedule(
+                        () -> {
+                            var body =
+                                    given().basePath("/")
+                                            .queryParam("fromTimestamp", 1000L)
+                                            .queryParam("toTimestamp", 2000L)
+                                            .when()
+                                            .post(
+                                                    "/api/beta/recording_synthesis/{jvmId}",
+                                                    selfJvmId)
+                                            .then()
+                                            .assertThat()
+                                            .statusCode(202)
+                                            .extract()
+                                            .body()
+                                            .asString();
+                            jobId[0] = body.strip();
+                        },
+                        1,
+                        TimeUnit.SECONDS);
+
+        // Wait for the synthesis to complete (success notification)
+        var notification =
+                webSocketClient.expectNotification(
+                        "RecordingSynthesisComplete",
+                        json ->
+                                Objects.equals(
+                                        json.getJsonObject("message").getString("jobId"),
+                                        jobId[0]));
+
+        // Extract the synthesised recording name
+        var syntheticName =
+                notification.getJsonObject("message").getJsonObject("recording").getString("name");
+
+        // Issue a second request with the same range. Must be served as an immediate 200
+        // because the synthetic recording now fully covers the range
+        given().basePath("/")
+                .log()
+                .all()
+                .queryParam("fromTimestamp", 1000L)
+                .queryParam("toTimestamp", 2000L)
+                .when()
+                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", is(syntheticName))
+                .body("jvmId", is(selfJvmId));
+
+        try {
+            Files.deleteIfExists(fileCover);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
@@ -95,54 +95,56 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
 
         final String[] jobId = new String[1];
 
-        Executors.newSingleThreadScheduledExecutor()
-                .schedule(
-                        () -> {
-                            var body =
-                                    given().basePath("/")
-                                            .log()
-                                            .all()
-                                            .queryParam("fromTimestamp", 1000L)
-                                            .queryParam("toTimestamp", 2000L)
-                                            .when()
-                                            .post(
-                                                    "/api/beta/recording_synthesis/{jvmId}",
-                                                    selfJvmId)
-                                            .then()
-                                            .log()
-                                            .all()
-                                            .assertThat()
-                                            .statusCode(202)
-                                            .contentType(ContentType.TEXT)
-                                            .extract()
-                                            .body()
-                                            .asString();
-                            jobId[0] = body.strip();
-                        },
-                        1,
-                        TimeUnit.SECONDS);
+        var executor1 = Executors.newSingleThreadScheduledExecutor();
+        try {
+            executor1.schedule(
+                    () -> {
+                        var body =
+                                given().basePath("/")
+                                        .log()
+                                        .all()
+                                        .queryParam("fromTimestamp", 1000L)
+                                        .queryParam("toTimestamp", 2000L)
+                                        .when()
+                                        .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                                        .then()
+                                        .log()
+                                        .all()
+                                        .assertThat()
+                                        .statusCode(202)
+                                        .contentType(ContentType.TEXT)
+                                        .extract()
+                                        .body()
+                                        .asString();
+                        jobId[0] = body.strip();
+                    },
+                    1,
+                    TimeUnit.SECONDS);
 
-        var notification =
-                webSocketClient.expectNotification(
-                        "RecordingSynthesisComplete",
-                        json ->
-                                Objects.equals(
-                                        json.getJsonObject("message").getString("jobId"),
-                                        jobId[0]));
+            var notification =
+                    webSocketClient.expectNotification(
+                            "RecordingSynthesisComplete",
+                            json ->
+                                    Objects.equals(
+                                            json.getJsonObject("message").getString("jobId"),
+                                            jobId[0]));
 
-        var message = notification.getJsonObject("message");
-        assertThat(message.containsKey("recording"), is(true));
-        var recording = message.getJsonObject("recording");
-        assertThat(recording.getString("jvmId"), is(selfJvmId));
-        var labels = recording.getJsonObject("metadata").getJsonArray("labels");
-        String syntheticValue =
-                labels.stream()
-                        .map(o -> (io.vertx.core.json.JsonObject) o)
-                        .filter(e -> "synthetic".equals(e.getString("key")))
-                        .map(e -> e.getString("value"))
-                        .findFirst()
-                        .orElse(null);
-        assertThat(syntheticValue, is("true"));
+            var message = notification.getJsonObject("message");
+            assertThat(message.containsKey("recording"), is(true));
+            var recording = message.getJsonObject("recording");
+            assertThat(recording.getString("jvmId"), is(selfJvmId));
+            var labels = recording.getJsonObject("metadata").getJsonArray("labels");
+            String syntheticValue =
+                    labels.stream()
+                            .map(o -> (io.vertx.core.json.JsonObject) o)
+                            .filter(e -> "synthetic".equals(e.getString("key")))
+                            .map(e -> e.getString("value"))
+                            .findFirst()
+                            .orElse(null);
+            assertThat(syntheticValue, is("true"));
+        } finally {
+            executor1.shutdown();
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -158,10 +160,8 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
 
         Path file1 = Files.createTempFile("synthesis-idem-a", ".jfr");
         Path file2 = Files.createTempFile("synthesis-idem-b", ".jfr");
-        Path fileCover = Files.createTempFile("synthesis-idem-cover", ".jfr");
         Files.write(file1, new byte[] {1, 2});
         Files.write(file2, new byte[] {3, 4});
-        Files.write(fileCover, new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         try {
             // Two partial recordings to trigger the 202 path
             recordingHelper.uploadArchivedRecording(
@@ -186,62 +186,62 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
         final String[] jobId = new String[1];
 
         // Issue first synthesis request to get a 202 job
-        Executors.newSingleThreadScheduledExecutor()
-                .schedule(
-                        () -> {
-                            var body =
-                                    given().basePath("/")
-                                            .queryParam("fromTimestamp", 1000L)
-                                            .queryParam("toTimestamp", 2000L)
-                                            .when()
-                                            .post(
-                                                    "/api/beta/recording_synthesis/{jvmId}",
-                                                    selfJvmId)
-                                            .then()
-                                            .assertThat()
-                                            .statusCode(202)
-                                            .extract()
-                                            .body()
-                                            .asString();
-                            jobId[0] = body.strip();
-                        },
-                        1,
-                        TimeUnit.SECONDS);
-
-        // Wait for the synthesis to complete (success notification)
-        var notification =
-                webSocketClient.expectNotification(
-                        "RecordingSynthesisComplete",
-                        json ->
-                                Objects.equals(
-                                        json.getJsonObject("message").getString("jobId"),
-                                        jobId[0]));
-
-        // Extract the synthesised recording name
-        var syntheticName =
-                notification.getJsonObject("message").getJsonObject("recording").getString("name");
-
-        // Issue a second request with the same range. Must be served as an immediate 200
-        // because the synthetic recording now fully covers the range
-        given().basePath("/")
-                .log()
-                .all()
-                .queryParam("fromTimestamp", 1000L)
-                .queryParam("toTimestamp", 2000L)
-                .when()
-                .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
-                .then()
-                .log()
-                .all()
-                .assertThat()
-                .statusCode(200)
-                .contentType(ContentType.JSON)
-                .body("name", is(syntheticName))
-                .body("jvmId", is(selfJvmId));
-
+        var executor2 = Executors.newSingleThreadScheduledExecutor();
         try {
-            Files.deleteIfExists(fileCover);
-        } catch (Exception ignored) {
+            executor2.schedule(
+                    () -> {
+                        var body =
+                                given().basePath("/")
+                                        .queryParam("fromTimestamp", 1000L)
+                                        .queryParam("toTimestamp", 2000L)
+                                        .when()
+                                        .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                                        .then()
+                                        .assertThat()
+                                        .statusCode(202)
+                                        .extract()
+                                        .body()
+                                        .asString();
+                        jobId[0] = body.strip();
+                    },
+                    1,
+                    TimeUnit.SECONDS);
+
+            // Wait for the synthesis to complete (success notification)
+            var notification =
+                    webSocketClient.expectNotification(
+                            "RecordingSynthesisComplete",
+                            json ->
+                                    Objects.equals(
+                                            json.getJsonObject("message").getString("jobId"),
+                                            jobId[0]));
+
+            // Extract the synthesised recording name
+            var syntheticName =
+                    notification
+                            .getJsonObject("message")
+                            .getJsonObject("recording")
+                            .getString("name");
+
+            // Issue a second request with the same range. Must be served as an immediate 200
+            // because the synthetic recording now fully covers the range
+            given().basePath("/")
+                    .log()
+                    .all()
+                    .queryParam("fromTimestamp", 1000L)
+                    .queryParam("toTimestamp", 2000L)
+                    .when()
+                    .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
+                    .then()
+                    .log()
+                    .all()
+                    .assertThat()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("name", is(syntheticName))
+                    .body("jvmId", is(selfJvmId));
+        } finally {
+            executor2.shutdown();
         }
     }
 }

--- a/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
@@ -101,26 +101,30 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
             var future1 =
                     executor1.schedule(
                             () -> {
-                                var body =
-                                        given().basePath("/")
-                                                .log()
-                                                .all()
-                                                .queryParam("fromTimestamp", 1000L)
-                                                .queryParam("toTimestamp", 2000L)
-                                                .when()
-                                                .post(
-                                                        "/api/beta/recording_synthesis/{jvmId}",
-                                                        selfJvmId)
-                                                .then()
-                                                .log()
-                                                .all()
-                                                .assertThat()
-                                                .statusCode(202)
-                                                .contentType(ContentType.TEXT)
-                                                .extract()
-                                                .body()
-                                                .asString();
-                                jobId1.complete(body.strip());
+                                try {
+                                    var body =
+                                            given().basePath("/")
+                                                    .log()
+                                                    .all()
+                                                    .queryParam("fromTimestamp", 1000L)
+                                                    .queryParam("toTimestamp", 2000L)
+                                                    .when()
+                                                    .post(
+                                                            "/api/beta/recording_synthesis/{jvmId}",
+                                                            selfJvmId)
+                                                    .then()
+                                                    .log()
+                                                    .all()
+                                                    .assertThat()
+                                                    .statusCode(202)
+                                                    .contentType(ContentType.TEXT)
+                                                    .extract()
+                                                    .body()
+                                                    .asString();
+                                    jobId1.complete(body.strip());
+                                } catch (Exception ex) {
+                                    jobId1.completeExceptionally(ex);
+                                }
                             },
                             1,
                             TimeUnit.SECONDS);
@@ -196,21 +200,25 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
             var future2 =
                     executor2.schedule(
                             () -> {
-                                var body =
-                                        given().basePath("/")
-                                                .queryParam("fromTimestamp", 1000L)
-                                                .queryParam("toTimestamp", 2000L)
-                                                .when()
-                                                .post(
-                                                        "/api/beta/recording_synthesis/{jvmId}",
-                                                        selfJvmId)
-                                                .then()
-                                                .assertThat()
-                                                .statusCode(202)
-                                                .extract()
-                                                .body()
-                                                .asString();
-                                jobId2.complete(body.strip());
+                                try {
+                                    var body =
+                                            given().basePath("/")
+                                                    .queryParam("fromTimestamp", 1000L)
+                                                    .queryParam("toTimestamp", 2000L)
+                                                    .when()
+                                                    .post(
+                                                            "/api/beta/recording_synthesis/{jvmId}",
+                                                            selfJvmId)
+                                                    .then()
+                                                    .assertThat()
+                                                    .statusCode(202)
+                                                    .extract()
+                                                    .body()
+                                                    .asString();
+                                    jobId2.complete(body.strip());
+                                } catch (Exception ex) {
+                                    jobId2.completeExceptionally(ex);
+                                }
                             },
                             1,
                             TimeUnit.SECONDS);

--- a/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingsSynthesisWorkflowTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -93,33 +94,36 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
             Files.deleteIfExists(file2);
         }
 
-        final String[] jobId = new String[1];
+        CompletableFuture<String> jobId1 = new CompletableFuture<>();
 
         var executor1 = Executors.newSingleThreadScheduledExecutor();
         try {
-            executor1.schedule(
-                    () -> {
-                        var body =
-                                given().basePath("/")
-                                        .log()
-                                        .all()
-                                        .queryParam("fromTimestamp", 1000L)
-                                        .queryParam("toTimestamp", 2000L)
-                                        .when()
-                                        .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
-                                        .then()
-                                        .log()
-                                        .all()
-                                        .assertThat()
-                                        .statusCode(202)
-                                        .contentType(ContentType.TEXT)
-                                        .extract()
-                                        .body()
-                                        .asString();
-                        jobId[0] = body.strip();
-                    },
-                    1,
-                    TimeUnit.SECONDS);
+            var future1 =
+                    executor1.schedule(
+                            () -> {
+                                var body =
+                                        given().basePath("/")
+                                                .log()
+                                                .all()
+                                                .queryParam("fromTimestamp", 1000L)
+                                                .queryParam("toTimestamp", 2000L)
+                                                .when()
+                                                .post(
+                                                        "/api/beta/recording_synthesis/{jvmId}",
+                                                        selfJvmId)
+                                                .then()
+                                                .log()
+                                                .all()
+                                                .assertThat()
+                                                .statusCode(202)
+                                                .contentType(ContentType.TEXT)
+                                                .extract()
+                                                .body()
+                                                .asString();
+                                jobId1.complete(body.strip());
+                            },
+                            1,
+                            TimeUnit.SECONDS);
 
             var notification =
                     webSocketClient.expectNotification(
@@ -127,7 +131,8 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
                             json ->
                                     Objects.equals(
                                             json.getJsonObject("message").getString("jobId"),
-                                            jobId[0]));
+                                            jobId1.join()));
+            future1.get();
 
             var message = notification.getJsonObject("message");
             assertThat(message.containsKey("recording"), is(true));
@@ -183,29 +188,32 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
             Files.deleteIfExists(file2);
         }
 
-        final String[] jobId = new String[1];
+        CompletableFuture<String> jobId2 = new CompletableFuture<>();
 
         // Issue first synthesis request to get a 202 job
         var executor2 = Executors.newSingleThreadScheduledExecutor();
         try {
-            executor2.schedule(
-                    () -> {
-                        var body =
-                                given().basePath("/")
-                                        .queryParam("fromTimestamp", 1000L)
-                                        .queryParam("toTimestamp", 2000L)
-                                        .when()
-                                        .post("/api/beta/recording_synthesis/{jvmId}", selfJvmId)
-                                        .then()
-                                        .assertThat()
-                                        .statusCode(202)
-                                        .extract()
-                                        .body()
-                                        .asString();
-                        jobId[0] = body.strip();
-                    },
-                    1,
-                    TimeUnit.SECONDS);
+            var future2 =
+                    executor2.schedule(
+                            () -> {
+                                var body =
+                                        given().basePath("/")
+                                                .queryParam("fromTimestamp", 1000L)
+                                                .queryParam("toTimestamp", 2000L)
+                                                .when()
+                                                .post(
+                                                        "/api/beta/recording_synthesis/{jvmId}",
+                                                        selfJvmId)
+                                                .then()
+                                                .assertThat()
+                                                .statusCode(202)
+                                                .extract()
+                                                .body()
+                                                .asString();
+                                jobId2.complete(body.strip());
+                            },
+                            1,
+                            TimeUnit.SECONDS);
 
             // Wait for the synthesis to complete (success notification)
             var notification =
@@ -214,7 +222,8 @@ public class RecordingsSynthesisWorkflowTest extends AbstractTransactionalTestBa
                             json ->
                                     Objects.equals(
                                             json.getJsonObject("message").getString("jobId"),
-                                            jobId[0]));
+                                            jobId2.join()));
+            future2.get();
 
             // Extract the synthesised recording name
             var syntheticName =


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1605
See https://github.com/cryostatio/cryostat-mcp/issues/26
See https://github.com/cryostatio/cryostat-mcp/issues/83

## Description of the change:
Adds an endpoint allowing clients to specify a target, a start timestamp, and an end timestamp. From this information Cryostat looks at the archived recordings taken from the target, gathers the recordings which are within the timestamp bounds (including overlapping the endpoints, so the dataset may include events older than the start or younger than the end), and creates a new archived recording from the concatenation of these recordings. This merged recording can then be used as any other archived recording: it can be visualized in Grafana, or Automated Analysis can be performed on it, or it can be interrogated with `jfr-analytics`, or it can be downloaded for offline analysis, etc.

## Motivation for the change:
Users who are using Automated Rules or the Agent Harvester are likely to have a series of relatively small archived flight recordings available at any given time. A single recording may indicate a problem with the target application but may not contain the full picture on its own. Or, a potential issue may be slowly growing (ex. a slow resource leak) such that it's not obvious from the individual recordings' short timespans but may become obvious over a longer period.

## How to manually test:
1. Check out and build PR
2. Run `./smoketest.bash -O -t quarkus-cryostat-agent`
3. Wait some time for the Quarkus sample application's Harvester to push some files
4. Use an HTTP client like `curl` to send requests to create merged files
