### PR TITLE
fix(gc): clean up tracking entities after operation completes

### DIFF
--- a/src/main/java/io/cryostat/diagnostic/Diagnostics.java
+++ b/src/main/java/io/cryostat/diagnostic/Diagnostics.java
@@ -298,7 +298,6 @@ public class Diagnostics {
     @Path("targets/{targetId}/gc")
     @RolesAllowed("write")
     @Blocking
-    @Transactional
     @POST
     @Operation(
             summary = "Initiate a garbage collection on the specified target",
@@ -308,14 +307,22 @@ public class Diagnostics {
                     request. This is generally equivalent to a System.gc() call made within the target JVM.
                     """)
     public void gc(@RestPath long targetId) {
-        Target target = Target.getTargetById(targetId);
+        Target target =
+                QuarkusTransaction.requiringNew().call(() -> Target.getTargetById(targetId));
+        GarbageCollection gc =
+                QuarkusTransaction.requiringNew()
+                        .call(
+                                () -> {
+                                    GarbageCollection entity = GarbageCollection.of(target);
+                                    entity.persist();
+                                    return entity;
+                                });
         targetConnectionManager.executeConnectedTask(
                 target,
                 conn ->
                         conn.invokeMBeanOperation(
                                 "java.lang:type=Memory", "gc", null, null, Void.class));
-
-        GarbageCollection.of(target).persist();
+        QuarkusTransaction.requiringNew().run(() -> GarbageCollection.deleteById(gc.id));
     }
 
     @Path("fs/heapdumps")

--- a/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
+++ b/src/main/java/io/cryostat/diagnostic/DiagnosticsHelper.java
@@ -32,18 +32,22 @@ import java.util.UUID;
 import io.cryostat.ConfigProperties;
 import io.cryostat.Producers;
 import io.cryostat.StorageBuckets;
+import io.cryostat.asyncprofiler.AsyncProfilerRecording;
 import io.cryostat.diagnostic.Diagnostics.HeapDump;
 import io.cryostat.diagnostic.Diagnostics.ThreadDump;
 import io.cryostat.diagnostic.HeapDumpsMetadataService.StorageMode;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.recordings.ActiveRecordings.Metadata;
 import io.cryostat.targets.Target;
+import io.cryostat.targets.Target.EventKind;
+import io.cryostat.targets.Target.TargetDiscovery;
 import io.cryostat.targets.TargetConnectionManager;
 import io.cryostat.ws.MessagingServer;
 import io.cryostat.ws.Notification;
 
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -137,6 +141,22 @@ public class DiagnosticsHelper {
         buckets.createIfNecessary(threadDumpBucket);
         log.tracev("Creating heap dump report bucket: {0}", heapDumpReportBucket);
         buckets.createIfNecessary(heapDumpReportBucket);
+    }
+
+    @ConsumeEvent(value = Target.TARGET_JVM_DISCOVERY, blocking = true)
+    void onTargetLost(TargetDiscovery event) {
+        if (!EventKind.LOST.equals(event.kind())) {
+            return;
+        }
+        Target target = event.serviceRef();
+        QuarkusTransaction.requiringNew()
+                .run(
+                        () -> {
+                            AsyncProfilerRecording.delete("target", target);
+                            io.cryostat.diagnostic.HeapDump.delete("target", target);
+                            io.cryostat.diagnostic.ThreadDump.delete("target", target);
+                            io.cryostat.diagnostic.GarbageCollection.delete("target", target);
+                        });
     }
 
     public void dumpHeap(Target target, String requestId) {

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -112,3 +112,52 @@ BEGIN
 
     RAISE NOTICE 'Added plugin-id labels to existing CryostatAgent target nodes';
 END $$;
+
+-- Migrate existing GarbageCollection rows into _AUD as INSERT+DELETE revision pairs,
+-- then truncate the primary table. Going forward, the gc() handler will persist and
+-- immediately delete each entity so only _AUD retains the durable record.
+DO $$
+DECLARE
+    migration_rev   INTEGER;
+    migration_ts    BIGINT;
+    gc              RECORD;
+    insert_rev      INTEGER;
+BEGIN
+    migration_ts := EXTRACT(EPOCH FROM now()) * 1000;
+
+    -- Create one synthetic REVINFO row for this migration event.
+    -- REVINFO.REV has no DEFAULT; use nextval() explicitly (Hibernate manages the sequence).
+    INSERT INTO REVINFO (REV, REVTSTMP, username)
+    VALUES (nextval('REVINFO_SEQ'), migration_ts, 'migration')
+    RETURNING REV INTO migration_rev;
+
+    -- For each existing GarbageCollection row that has a matching INSERT revision in _AUD,
+    -- add a DELETE revision and back-fill REVEND on the INSERT revision.
+    FOR gc IN SELECT id FROM GarbageCollection LOOP
+
+        -- Find the INSERT revision for this entity
+        SELECT REV INTO insert_rev
+        FROM GarbageCollection_AUD
+        WHERE id = gc.id AND REVTYPE = 0
+        ORDER BY REV DESC
+        LIMIT 1;
+
+        IF insert_rev IS NOT NULL THEN
+            -- Back-fill REVEND on the INSERT row (ValidityAuditStrategy requirement)
+            UPDATE GarbageCollection_AUD
+            SET REVEND = migration_rev, REVEND_TSTMP = migration_ts
+            WHERE id = gc.id AND REV = insert_rev;
+
+            -- Insert the DELETE revision row
+            INSERT INTO GarbageCollection_AUD (id, REV, REVTYPE, REVEND, REVEND_TSTMP, target_id, triggeredAt)
+            SELECT gc.id, migration_rev, 2, NULL, NULL, target_id, triggeredAt
+            FROM GarbageCollection
+            WHERE id = gc.id;
+        END IF;
+    END LOOP;
+
+    -- Primary table is now fully mirrored in _AUD; clear it
+    TRUNCATE TABLE GarbageCollection;
+
+    RAISE NOTICE 'GarbageCollection migration complete: primary table truncated, % revision created', migration_rev;
+END $$;

--- a/src/main/resources/db/migration/V4.2.1__cryostat.sql
+++ b/src/main/resources/db/migration/V4.2.1__cryostat.sql
@@ -119,45 +119,51 @@ END $$;
 DO $$
 DECLARE
     migration_rev   INTEGER;
-    migration_ts    BIGINT;
     gc              RECORD;
     insert_rev      INTEGER;
+    gc_count        INTEGER;
 BEGIN
-    migration_ts := EXTRACT(EPOCH FROM now()) * 1000;
+    SELECT COUNT(*) INTO gc_count FROM GarbageCollection;
 
-    -- Create one synthetic REVINFO row for this migration event.
-    -- REVINFO.REV has no DEFAULT; use nextval() explicitly (Hibernate manages the sequence).
-    INSERT INTO REVINFO (REV, REVTSTMP, username)
-    VALUES (nextval('REVINFO_SEQ'), migration_ts, 'migration')
-    RETURNING REV INTO migration_rev;
+    IF gc_count > 0 THEN
+        -- Create one synthetic REVINFO row for this migration event only when there are rows
+        -- to migrate. Using timestamp 0 places this revision in the same "seed" epoch as the
+        -- initial revision, keeping it out of any recent time-range queries.
+        -- REVINFO.REV has no DEFAULT; use nextval() explicitly (Hibernate manages the sequence).
+        INSERT INTO REVINFO (REV, REVTSTMP, username)
+        VALUES (nextval('REVINFO_SEQ'), 0, 'migration')
+        RETURNING REV INTO migration_rev;
 
-    -- For each existing GarbageCollection row that has a matching INSERT revision in _AUD,
-    -- add a DELETE revision and back-fill REVEND on the INSERT revision.
-    FOR gc IN SELECT id FROM GarbageCollection LOOP
+        -- For each existing GarbageCollection row that has a matching INSERT revision in _AUD,
+        -- add a DELETE revision and back-fill REVEND on the INSERT revision.
+        FOR gc IN SELECT id FROM GarbageCollection LOOP
 
-        -- Find the INSERT revision for this entity
-        SELECT REV INTO insert_rev
-        FROM GarbageCollection_AUD
-        WHERE id = gc.id AND REVTYPE = 0
-        ORDER BY REV DESC
-        LIMIT 1;
+            -- Find the INSERT revision for this entity
+            SELECT REV INTO insert_rev
+            FROM GarbageCollection_AUD
+            WHERE id = gc.id AND REVTYPE = 0
+            ORDER BY REV DESC
+            LIMIT 1;
 
-        IF insert_rev IS NOT NULL THEN
-            -- Back-fill REVEND on the INSERT row (ValidityAuditStrategy requirement)
-            UPDATE GarbageCollection_AUD
-            SET REVEND = migration_rev, REVEND_TSTMP = migration_ts
-            WHERE id = gc.id AND REV = insert_rev;
+            IF insert_rev IS NOT NULL THEN
+                -- Back-fill REVEND on the INSERT row (ValidityAuditStrategy requirement)
+                UPDATE GarbageCollection_AUD
+                SET REVEND = migration_rev, REVEND_TSTMP = 0
+                WHERE id = gc.id AND REV = insert_rev;
 
-            -- Insert the DELETE revision row
-            INSERT INTO GarbageCollection_AUD (id, REV, REVTYPE, REVEND, REVEND_TSTMP, target_id, triggeredAt)
-            SELECT gc.id, migration_rev, 2, NULL, NULL, target_id, triggeredAt
-            FROM GarbageCollection
-            WHERE id = gc.id;
-        END IF;
-    END LOOP;
+                -- Insert the DELETE revision row
+                INSERT INTO GarbageCollection_AUD (id, REV, REVTYPE, REVEND, REVEND_TSTMP, target_id, triggeredAt)
+                SELECT gc.id, migration_rev, 2, NULL, NULL, target_id, triggeredAt
+                FROM GarbageCollection
+                WHERE id = gc.id;
+            END IF;
+        END LOOP;
 
-    -- Primary table is now fully mirrored in _AUD; clear it
+        RAISE NOTICE 'GarbageCollection migration complete: primary table truncated, % revision created', migration_rev;
+    ELSE
+        RAISE NOTICE 'GarbageCollection migration: no existing rows, skipping revision creation';
+    END IF;
+
+    -- Primary table is now fully mirrored in _AUD; clear it (no-op if already empty)
     TRUNCATE TABLE GarbageCollection;
-
-    RAISE NOTICE 'GarbageCollection migration complete: primary table truncated, % revision created', migration_rev;
 END $$;

--- a/src/test/java/io/cryostat/diagnostics/GarbageCollectionTest.java
+++ b/src/test/java/io/cryostat/diagnostics/GarbageCollectionTest.java
@@ -17,6 +17,8 @@ package io.cryostat.diagnostics;
 
 import static io.restassured.RestAssured.given;
 
+import java.util.List;
+
 import io.cryostat.audit.AuditTestBase;
 import io.cryostat.diagnostic.Diagnostics;
 import io.cryostat.diagnostic.GarbageCollection;
@@ -55,8 +57,22 @@ public class GarbageCollectionTest extends AuditTestBase {
                 .assertThat()
                 .statusCode(204);
 
-        long count = GarbageCollection.count("target.id = ?1", Long.valueOf(targetId));
-        Assertions.assertEquals(1, count, "Expected one GarbageCollection entity to be created");
+        // Primary table must be empty — the gc() handler deletes the row after persisting.
+        long primaryCount = GarbageCollection.count("target.id = ?1", Long.valueOf(targetId));
+        Assertions.assertEquals(
+                0, primaryCount, "GarbageCollection primary table should be empty after gc()");
+
+        // _AUD table must have exactly 2 revisions (INSERT + DELETE) for the entity.
+        AuditReader auditReader = AuditReaderFactory.get(em);
+        List<?> gcRevisions =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, false, true)
+                        .getResultList();
+        Assertions.assertEquals(
+                2,
+                gcRevisions.size(),
+                "GarbageCollection_AUD should have 2 revisions (INSERT + DELETE)");
     }
 
     @Test
@@ -74,16 +90,24 @@ public class GarbageCollectionTest extends AuditTestBase {
                 .assertThat()
                 .statusCode(204);
 
+        // Primary row is gone; query the AUD table instead.
         AuditReader auditReader = AuditReaderFactory.get(em);
-        var gcEntity =
-                GarbageCollection.<GarbageCollection>find("target.id", Long.valueOf(targetId))
-                        .firstResult();
-        Assertions.assertNotNull(gcEntity, "GarbageCollection entity should exist");
+        List<?> auditResults =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, true, true)
+                        .getResultList();
+        Assertions.assertFalse(auditResults.isEmpty(), "Should have at least one audit revision");
 
-        var revisions = auditReader.getRevisions(GarbageCollection.class, gcEntity.id);
-        Assertions.assertTrue(!revisions.isEmpty(), "Should have at least one audit revision");
+        // Retrieve the entity state from the last known revision (includes deleted entities).
+        List<?> allRevisions =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, false, true)
+                        .getResultList();
         Assertions.assertTrue(
-                revisions.size() >= 1, "Should have at least one audit revision for creation");
+                allRevisions.size() >= 2,
+                "Should have at least 2 audit revisions (INSERT and DELETE)");
     }
 
     @Test
@@ -104,15 +128,22 @@ public class GarbageCollectionTest extends AuditTestBase {
 
         long afterTrigger = System.currentTimeMillis();
 
-        var gcEntity =
-                GarbageCollection.<GarbageCollection>find("target.id", Long.valueOf(targetId))
-                        .firstResult();
-        Assertions.assertNotNull(gcEntity);
+        // Read triggeredAt from the INSERT revision in _AUD (primary row is deleted).
+        AuditReader auditReader = AuditReaderFactory.get(em);
+        List<?> results =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, true, true)
+                        .getResultList();
+        Assertions.assertFalse(results.isEmpty(), "Should have at least one audit revision");
+
+        GarbageCollection audited = (GarbageCollection) results.get(0);
+        Assertions.assertNotNull(audited);
         Assertions.assertTrue(
-                gcEntity.triggeredAt >= beforeTrigger,
+                audited.triggeredAt >= beforeTrigger,
                 "Triggered timestamp should be after or equal to before trigger time");
         Assertions.assertTrue(
-                gcEntity.triggeredAt <= afterTrigger,
+                audited.triggeredAt <= afterTrigger,
                 "Triggered timestamp should be before or equal to after trigger time");
     }
 
@@ -131,12 +162,19 @@ public class GarbageCollectionTest extends AuditTestBase {
                 .assertThat()
                 .statusCode(204);
 
-        var gcEntity =
-                GarbageCollection.<GarbageCollection>find("target.id", Long.valueOf(targetId))
-                        .firstResult();
-        Assertions.assertNotNull(gcEntity);
-        Assertions.assertNotNull(gcEntity.target);
-        Assertions.assertEquals(Long.valueOf(targetId), gcEntity.target.id);
+        // Read target reference from the INSERT revision in _AUD (primary row is deleted).
+        AuditReader auditReader = AuditReaderFactory.get(em);
+        List<?> results =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, true, true)
+                        .getResultList();
+        Assertions.assertFalse(results.isEmpty());
+
+        GarbageCollection audited = (GarbageCollection) results.get(0);
+        Assertions.assertNotNull(audited);
+        Assertions.assertNotNull(audited.target);
+        Assertions.assertEquals(Long.valueOf(targetId), audited.target.id);
     }
 
     @Test
@@ -156,9 +194,24 @@ public class GarbageCollectionTest extends AuditTestBase {
                     .statusCode(204);
         }
 
-        long count = GarbageCollection.count("target.id = ?1", Long.valueOf(targetId));
+        // Primary table must be empty — each gc() call deletes its row.
+        long primaryCount = GarbageCollection.count("target.id = ?1", Long.valueOf(targetId));
         Assertions.assertEquals(
-                3, count, "Expected three GarbageCollection entities to be created");
+                0,
+                primaryCount,
+                "GarbageCollection primary table should be empty after 3 gc() calls");
+
+        // _AUD table must have 6 revisions: 2 (INSERT + DELETE) per trigger.
+        AuditReader auditReader = AuditReaderFactory.get(em);
+        List<?> allRevisions =
+                auditReader
+                        .createQuery()
+                        .forRevisionsOfEntity(GarbageCollection.class, false, true)
+                        .getResultList();
+        Assertions.assertEquals(
+                6,
+                allRevisions.size(),
+                "Should have 6 audit revisions (2 per trigger × 3 triggers)");
     }
 
     @Test
@@ -215,6 +268,8 @@ public class GarbageCollectionTest extends AuditTestBase {
 
         long endTime = System.currentTimeMillis();
 
+        // The DELETE transaction creates its own REVINFO row; query the latest revision
+        // in the time window — it should be the DELETE revision (revtype == 2).
         Integer revisionNumber =
                 given().basePath("/")
                         .log()
@@ -235,6 +290,7 @@ public class GarbageCollectionTest extends AuditTestBase {
 
         Assertions.assertNotNull(revisionNumber, "Should have at least one revision");
 
+        // The most recent revision in the window is the DELETE revision (revtype == 2).
         given().basePath("/")
                 .log()
                 .all()
@@ -251,9 +307,6 @@ public class GarbageCollectionTest extends AuditTestBase {
                 .body(
                         "entities.GarbageCollection",
                         org.hamcrest.Matchers.instanceOf(java.util.List.class))
-                .body(
-                        "entities.GarbageCollection[0].triggeredAt",
-                        org.hamcrest.Matchers.notNullValue())
-                .body("entities.GarbageCollection[0].revtype", org.hamcrest.Matchers.equalTo(0));
+                .body("entities.GarbageCollection[0].revtype", org.hamcrest.Matchers.equalTo(2));
     }
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1708

## Description of the change:
Ensures that the `GarbageCollection` entity is deleted after a `gc` request completes. This entity is only intended to track `gc` invocations for the audit log - the entity doesn't encode any information or even carry any specific metadata than the universal audit log metadata (timestamp, link to target ID, name of requesting client/user). Prior to this change both the primary GarbageCollection table and its GarbageCollection_AUD audit log would gain/retain a new row each time a GC request was serviced. The primary table should generally be empty in this case and only the audit log should retain a historical log.
This also adds an event listener to catch target loss and ensure that no dangling ThreadDump, HeapDump, or AsyncProfilerRecording tracking entities are left behind. These already do normally have a deletion in their lifecycle, but if the associated target is unexpectedly lost while an operation is underway then the tracking entities could be left behind stale forever.
