### PR TITLE
feat(recordings): add active recording sync endpoint

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2523,6 +2523,23 @@ paths:
       summary: Register and publish a Cryostat Agent
       tags:
         - Discovery
+  /api/v4.3/targets/{targetId}/recordings_sync:
+    post:
+      description: Reconcile Cryostat's active recording model with the recordings
+        present on the target.
+      parameters:
+        - in: path
+          name: targetId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "204":
+          description: Active recordings synchronized
+      summary: Resynchronize active recordings on the specified target
+      tags:
+        - Recording Sync
   /api/v4/activedownload/{id}:
     get:
       description: |

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2525,8 +2525,7 @@ paths:
         - Discovery
   /api/v4.3/targets/{targetId}/recordings_sync:
     post:
-      description: Reconcile Cryostat's active recording model with the recordings
-        present on the target.
+      description: Reconcile Cryostat's active recording model with the recordings present on the target.
       parameters:
         - in: path
           name: targetId

--- a/src/main/java/io/cryostat/recordings/RecordingSync.java
+++ b/src/main/java/io/cryostat/recordings/RecordingSync.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cryostat.recordings;
+
+import io.cryostat.targets.Target;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.resteasy.reactive.RestPath;
+
+@Path("/api/v4.3/targets/{targetId}/recordings_sync")
+public class RecordingSync {
+
+    @Inject RecordingHelper recordingHelper;
+
+    @POST
+    @Blocking
+    @Transactional
+    @RolesAllowed("write")
+    @Operation(
+            summary = "Resynchronize active recordings on the specified target",
+            description =
+                    "Reconcile Cryostat's active recording model with the recordings present on the"
+                            + " target.")
+    @APIResponse(responseCode = "204", description = "Active recordings synchronized")
+    public void sync(@RestPath long targetId) {
+        recordingHelper.syncActiveRecordings(Target.getTargetById(targetId));
+    }
+}

--- a/src/main/java/io/cryostat/recordings/RecordingSync.java
+++ b/src/main/java/io/cryostat/recordings/RecordingSync.java
@@ -33,6 +33,11 @@ public class RecordingSync {
 
     @Inject RecordingHelper recordingHelper;
 
+    /**
+     * Synchronizes Cryostat's active recording model with the specified target.
+     *
+     * @param targetId the database identifier of the target to synchronize
+     */
     @POST
     @Blocking
     @Transactional

--- a/src/test/java/io/cryostat/recordings/RecordingSyncTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingSyncTest.java
@@ -42,12 +42,18 @@ public class RecordingSyncTest extends AbstractTransactionalTestBase {
 
     @InjectMock RecordingHelper recordingHelper;
 
+    /**
+     * Pauses background jobs and supplies an empty recording list for test cleanup.
+     *
+     * @throws SchedulerException if the scheduler cannot be paused or cleared
+     */
     @BeforeEach
     void setup() throws SchedulerException {
         shutdownScheduler();
         when(recordingHelper.listActiveRecordings(any(Target.class))).thenReturn(List.of());
     }
 
+    /** Verifies that a missing target returns 404 without invoking synchronization. */
     @Test
     void testSyncOnMissingTarget() {
         given().pathParam("targetId", Integer.MAX_VALUE).when().post().then().statusCode(404);
@@ -56,6 +62,7 @@ public class RecordingSyncTest extends AbstractTransactionalTestBase {
                 .syncActiveRecordings(any(Target.class));
     }
 
+    /** Verifies that a successful request returns 204 and synchronizes the requested target. */
     @Test
     void testSync() {
         int targetId = defineSelfCustomTarget();

--- a/src/test/java/io/cryostat/recordings/RecordingSyncTest.java
+++ b/src/test/java/io/cryostat/recordings/RecordingSyncTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cryostat.recordings;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import io.cryostat.AbstractTransactionalTestBase;
+import io.cryostat.targets.Target;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.quartz.SchedulerException;
+
+@QuarkusTest
+@TestHTTPEndpoint(RecordingSync.class)
+public class RecordingSyncTest extends AbstractTransactionalTestBase {
+
+    @InjectMock RecordingHelper recordingHelper;
+
+    @BeforeEach
+    void setup() throws SchedulerException {
+        shutdownScheduler();
+        when(recordingHelper.listActiveRecordings(any(Target.class))).thenReturn(List.of());
+    }
+
+    @Test
+    void testSyncOnMissingTarget() {
+        given().pathParam("targetId", Integer.MAX_VALUE).when().post().then().statusCode(404);
+
+        verify(recordingHelper, org.mockito.Mockito.never())
+                .syncActiveRecordings(any(Target.class));
+    }
+
+    @Test
+    void testSync() {
+        int targetId = defineSelfCustomTarget();
+        clearInvocations(recordingHelper);
+
+        given().pathParam("targetId", targetId).when().post().then().statusCode(204);
+
+        ArgumentCaptor<Target> targetCaptor = ArgumentCaptor.forClass(Target.class);
+        verify(recordingHelper).syncActiveRecordings(targetCaptor.capture());
+        assertEquals((long) targetId, targetCaptor.getValue().id.longValue());
+    }
+}


### PR DESCRIPTION
Fixes #1740

## Description of the change

Adds POST /api/v4.3/targets/{targetId}/recordings_sync to invoke RecordingHelper.syncActiveRecordings for the specified target.

The endpoint requires the write role and returns 204 on success. Includes OpenAPI documentation and tests covering successful invocation and a missing target.

## Motivation for the change

Allows clients to request a refresh of Cryostat's active recording model from the target JVM. This PR covers the backend endpoint; a frontend button can follow separately.

## Testing

- RecordingSyncTest: both tests passed after rebasing.
- Backend compilation, formatting and license checks passed.
- Local Windows Maven builds used -Dquarkus.quinoa=false and
  -Dexec.skip=true; the exec-plugin helper scripts were skipped.
- Full test suite and schema-update script were not run.